### PR TITLE
show 'no connection' message in files tab OP#4068

### DIFF
--- a/src/components/tab/EmptyContent.vue
+++ b/src/components/tab/EmptyContent.vue
@@ -4,17 +4,51 @@
 			<img :src="flowSvg" alt="flow">
 		</div>
 		<div class="title text-center">
-			{{ t('integration_openproject', "No OpenProject links yet") }}
+			{{ emptyContentMessage }}
+		</div>
+		<br>
+		<div v-if="showConnectButton" class="connect-button">
+			<a class="button" :href="settingsUrl">
+				{{ t('integration_openproject', 'Connect to OpenProject') }}
+			</a>
 		</div>
 	</div>
 </template>
 
 <script>
+import { generateUrl } from '@nextcloud/router'
+import { translate as t } from '@nextcloud/l10n'
+
 export default {
 	name: 'EmptyContent',
+	props: {
+		state: {
+			type: String,
+			required: true,
+			default: 'ok',
+		},
+	},
+	data() {
+		return {
+			settingsUrl: generateUrl('/settings/user/connected-accounts'),
+		}
+	},
 	computed: {
 		flowSvg() {
 			return require('../../../img/flow.svg')
+		},
+		showConnectButton() {
+			return ['error', 'no-token'].includes(this.state)
+		},
+		emptyContentMessage() {
+			if (this.state === 'no-token') {
+				return t('integration_openproject', 'No OpenProject account connected')
+			} else if (this.state === 'error') {
+				return t('integration_openproject', 'Error connecting to OpenProject')
+			} else if (this.state === 'ok') {
+				return t('integration_openproject', 'No workspaces linked yet')
+			}
+			return 'invalid state'
 		},
 	},
 }

--- a/tests/jest/__mocks__/@nextcloud/router.js
+++ b/tests/jest/__mocks__/@nextcloud/router.js
@@ -1,8 +1,8 @@
 /* jshint esversion: 8 */
 const router = jest.createMockFromModule('@nextcloud/router')
 
-router.generateUrl = jest.fn(function() {
-	return '/'
+router.generateUrl = jest.fn(function(url) {
+	return 'http://localhost' + url
 })
 
 module.exports = router

--- a/tests/jest/components/tab/EmptyContent.spec.js
+++ b/tests/jest/components/tab/EmptyContent.spec.js
@@ -1,0 +1,62 @@
+/* jshint esversion: 8 */
+import { shallowMount, createLocalVue } from '@vue/test-utils'
+import EmptyContent from '../../../../src/components/tab/EmptyContent'
+
+jest.mock('@nextcloud/l10n', () => ({
+	translate: jest.fn((app, msg) => msg),
+}))
+
+const localVue = createLocalVue()
+
+describe('EmptyContent.vue Test', () => {
+	let wrapper
+	const emptyContentMessageSelector = '.title'
+	const connectButtonSelector = 'a.button'
+
+	it.each([{
+		state: 'ok',
+		viewed: false,
+	}, {
+		state: 'no-token',
+		viewed: true,
+	}, {
+		state: 'error',
+		viewed: true,
+	}])('shows or hides the connect button depending on the state', (cases) => {
+		wrapper = shallowMount(EmptyContent, {
+			localVue,
+			mocks: {
+				t: (msg) => msg,
+			},
+			propsData: {
+				state: cases.state,
+			},
+		})
+		expect(wrapper.find(connectButtonSelector).exists()).toBe(cases.viewed)
+	})
+	it.each([{
+		state: 'no-token',
+		message: 'No OpenProject account connected',
+	}, {
+		state: 'error',
+		message: 'Error connecting to OpenProject',
+	}, {
+		state: 'ok',
+		message: 'No workspaces linked yet',
+	}, {
+		state: 'something else',
+		message: 'invalid state',
+	}])('shows the correct empty message depending on states', async (cases) => {
+		wrapper = shallowMount(EmptyContent, {
+			localVue,
+			mocks: {
+				t: (msg) => msg,
+			},
+			propsData: {
+				state: cases.state,
+			},
+		})
+		expect(wrapper.find(emptyContentMessageSelector).exists()).toBeTruthy()
+		expect(wrapper.find(emptyContentMessageSelector).text()).toMatch(cases.message)
+	})
+})

--- a/tests/jest/views/ProjectsTab.spec.js
+++ b/tests/jest/views/ProjectsTab.spec.js
@@ -1,0 +1,71 @@
+/* jshint esversion: 8 */
+
+import { shallowMount, createLocalVue } from '@vue/test-utils'
+import ProjectsTab from '../../../src/views/ProjectsTab'
+import axios from '@nextcloud/axios'
+jest.mock('@nextcloud/axios')
+const localVue = createLocalVue()
+
+describe('ProjectsTab.vue Test', () => {
+	let wrapper
+	const loadingIndicatorSelector = '.icon-loading'
+	const emptyContentSelector = '#openproject-empty-content'
+	beforeEach(() => {
+		wrapper = shallowMount(ProjectsTab, { localVue })
+	})
+	describe('loading icon', () => {
+		it('shows the loading icon during "loading" state', async () => {
+			wrapper.setData({ state: 'loading' })
+			await localVue.nextTick()
+			expect(wrapper.find(loadingIndicatorSelector).exists()).toBeTruthy()
+		})
+		it('does not show the empty content message during "loading" state', async () => {
+			wrapper.setData({ state: 'loading' })
+			await localVue.nextTick()
+			expect(wrapper.find(emptyContentSelector).exists()).toBeFalsy()
+		})
+		it.each(['ok', 'error'])('shows the loading icon disappears on state change', async (state) => {
+			wrapper.setData({ state: 'loading' })
+			await localVue.nextTick()
+			expect(wrapper.find(loadingIndicatorSelector).exists()).toBeTruthy()
+			wrapper.setData({ state })
+			await localVue.nextTick()
+			expect(wrapper.find(loadingIndicatorSelector).exists()).toBeFalsy()
+		})
+	})
+	describe('empty message', () => {
+		it.each(['no-token', 'ok', 'error'])('shows the empty message when state is other than loading', async (state) => {
+			wrapper.setData({ state })
+			await localVue.nextTick()
+			expect(wrapper.find(emptyContentSelector).exists()).toBeTruthy()
+		})
+	})
+	describe('fetchWorkpackages', () => {
+		it.each([
+			{ responseData: [], AppState: 'ok' },
+			{ responseData: 'string', AppState: 'error' },
+			{ responseData: null, AppState: 'error' },
+			{ responseData: undefined, AppState: 'error' },
+		])('sets states according to response content in case of success', async (cases) => {
+			axios.get.mockImplementationOnce(() =>
+				Promise.resolve({
+					data: cases.responseData,
+				}),
+			)
+			await wrapper.vm.update({ id: 123 })
+			expect(wrapper.vm.state).toBe(cases.AppState)
+		})
+		it.each([
+			{ HTTPStatus: 400, AppState: 'error' },
+			{ HTTPStatus: 401, AppState: 'no-token' },
+			{ HTTPStatus: 404, AppState: 'error' },
+			{ HTTPStatus: 500, AppState: 'error' },
+		])('sets states according to HTTP error codes', async (cases) => {
+			const err = new Error()
+			err.response = { status: cases.HTTPStatus }
+			axios.get.mockRejectedValueOnce(err)
+			await wrapper.vm.update({ id: 123 })
+			expect(wrapper.vm.state).toBe(cases.AppState)
+		})
+	})
+})


### PR DESCRIPTION
In case there is no connection to OpenProject or workpackages could not be fetched, the user should see that information in the files tab and be able to navigate to the connection settings from there.

Currently this will always show "Error" as fetching workpackages is not implemented yet

