### PR TITLE
Small style adjustments

### DIFF
--- a/css/tab.css
+++ b/css/tab.css
@@ -9,12 +9,6 @@ body.theme--dark span.icon-open-project {
 	background: url('../img/tab-logo-white.svg') no-repeat center;
 }
 
-#tab-open-project, .fill-height {
+#tab-open-project {
 	height: 100%;
-}
-
-.center-content {
-	display: flex;
-	align-content: center;
-	justify-content: center;
 }

--- a/src/components/tab/EmptyContent.vue
+++ b/src/components/tab/EmptyContent.vue
@@ -83,4 +83,8 @@ export default {
 		padding: 8px 0;
 	}
 }
+
+.fill-height {
+	height: 100%;
+}
 </style>


### PR DESCRIPTION
`.fill-height` is only present in `<EmptyContent>` so it might be cleaner to define its style there.

`.center-content` style is already set in `<ProjectsTab>` and this affects the child components. No need to define it in `tab.css`.

In general I would say it's best to define the style in the components and only use `tab.css` when it's the only way.
What do you think?