### PR TITLE
Used pseudo elements for dashboard widget app icons

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -3,6 +3,24 @@
 	filter: contrast(0) brightness(0);
 }
 
-body.theme--dark .icon-openproject {
-	filter: none
+.icon-open-project {
+	position: relative;
+}
+
+.panel--header .icon-open-project::after {
+	left: 20px; top: 22%;
+}
+
+.icon-open-project::after {
+	content: '';
+	position: absolute;
+	top: 10%; left: 40%;
+	height: 30px; width: 30px;
+	background-size: 30px 30px;
+	filter: contrast(0) brightness(0);
+	background-image: url(./../img/app.svg);
+}
+
+body.theme--dark .icon-openproject, body.theme--dark .icon-open-project::after {
+	filter: none;
 }

--- a/lib/Dashboard/OpenProjectWidget.php
+++ b/lib/Dashboard/OpenProjectWidget.php
@@ -70,7 +70,7 @@ class OpenProjectWidget implements IWidget {
 	 * @inheritDoc
 	 */
 	public function getIconClass(): string {
-		return 'icon-openproject';
+		return 'icon-open-project';
 	}
 
 	/**


### PR DESCRIPTION
### Description
The filter was causing the whole `label` background to be black.
With this PR pseudo-elements are used to show OP icons in the dashboard.
A separate CSS selector is introduced for the dashboard widget icon.

### Related
- Fixes OP#40947

### Screenshots
![Screenshot from 2022-02-04 17-56-13](https://user-images.githubusercontent.com/39373750/152526954-4ee925d8-e2cf-442c-ba0d-04f200392d32.png)
nshots
![Screenshot from 2022-02-04 17-56-02](https://user-images.githubusercontent.com/39373750/152526965-7e30211c-898b-4f97-8a1c-ec2517b5f264.png)
![Screenshot from 2022-02-04 17-55-45](https://user-images.githubusercontent.com/39373750/152526980-e684305f-ebf1-4392-b624-f69b552bf260.png)
![Screenshot from 2022-02-04 17-55-24](https://user-images.githubusercontent.com/39373750/152526993-68d492d6-7475-4b8e-9fb2-c1dd3ff751c7.png)
![Screenshot from 2022-02-04 17-51-06](https://user-images.githubusercontent.com/39373750/152527010-be43c822-261f-463c-bf65-cb0959
![Screenshot from 2022-02-04 17-50-30](https://user-images.githubusercontent.com/39373750/152527022-7ff3054f-4c40-4dce-be0d-c4f0ef1bb
![Screenshot from 2022-02-04 17-50-09](https://user-images.githubusercontent.com/39373750/152527030-0bee197a-d94f-4712-a8ee-81bfa635ca63.png)
190.png)
bf3dc4.p
![Screenshot from 2022-02-04 17-49-53](https://user-images.githubusercontent.com/39373750/152527039-1aa223b0-427d-4ad3-9b54-96c993e3a486.png)
ng)

