### PR TITLE
Added coverage to git ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ js/
 .vscode-upload.json
 .*.sw*
 node_modules
+coverage/


### PR DESCRIPTION
### Description
Every time we run `vue` unit tests, coverage is generated.
this coverage is not necessary for vcs tracking

this pr adds the `coverage` folder to the ignore list  so that we do not commit is even accidentally


