### PR TITLE
Added test caches, vendor, example and log files to the gitignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,9 @@ js/
 .vscode-upload.json
 .*.sw*
 node_modules
+.phpunit.result.cache
 coverage/
+example/
+log/
+vendor/
+


### PR DESCRIPTION
### Description
**Resources:**
- PHPUnit caches
- `example` dir
- `log` dir
- `vendor` dir

These are the resources generated or modified during development. Sometimes these can get accidentally added to git and instantly we may get `3000+` changes in a PR. So, all of the mentioned resources are added to the `gitignore` list.







Signed-off-by: Kiran Parajuli <kiranparajuli589@gmail.com>