### PR TITLE
set background image size to fit into the element background

### DIFF
--- a/css/tab.css
+++ b/css/tab.css
@@ -4,6 +4,7 @@ span.icon-openproject {
 	padding: 0 !important;
 	min-width: 44px !important;
 	min-height: 16px !important;
+	background-size: 16px 16px;
 }
 
 #tab-open-project {


### PR DESCRIPTION
### Description
with NC server version: 23, the sidebar tab icon was completely grey.
this pr fixes the issue

### Related
OP#41083