### PR TITLE
[#40968] fix getOpenProjectAvatar error handling

### DIFF
--- a/lib/Controller/OpenProjectAPIController.php
+++ b/lib/Controller/OpenProjectAPIController.php
@@ -99,14 +99,10 @@ class OpenProjectAPIController extends Controller {
 			$this->openprojectUrl, $this->accessToken, $this->tokenType, $this->refreshToken,
 			$this->clientID, $this->clientSecret, $userId, $userName
 		);
-		// TODO this will never happen, because `getOpenProjectAvatar` does not return ever an error result
-		// @phpstan-ignore-next-line
-		if (isset($result['error'])) {
-			$response = new DataDisplayResponse($result['error'], 404);
-		} else {
-			$response = new DataDownloadResponse($result['avatar'], 'avatar', $result['type'] ?? '');
-			$response->cacheFor(60 * 60 * 24);
-		}
+		$response = new DataDownloadResponse(
+			$result['avatar'], 'avatar', $result['type'] ?? ''
+		);
+		$response->cacheFor(60 * 60 * 24);
 		return $response;
 	}
 

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -295,7 +295,7 @@ class OpenProjectAPIService {
 	 * @param string $clientSecret
 	 * @param string $userId
 	 * @param string $userName
-	 * @return array{avatar: mixed, type?: string}
+	 * @return array{avatar: string, type?: string}
 	 * @throws \OCP\Files\NotFoundException
 	 * @throws \OCP\Files\NotPermittedException
 	 * @throws \OCP\Lock\LockedException

--- a/tests/lib/Controller/OpenProjectAPIControllerTest.php
+++ b/tests/lib/Controller/OpenProjectAPIControllerTest.php
@@ -105,4 +105,73 @@ class OpenProjectAPIControllerTest extends TestCase {
 		$this->assertSame(401, $response->getStatus());
 		$this->assertSame(['error' => 'something went wrong'], $response->getData());
 	}
+
+	/**
+	 * @return void
+	 */
+	public function testGetOpenProjectAvatar() {
+		$this->getUserValueMock();
+		$service = $this->getMockBuilder(OpenProjectAPIService::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$service->expects($this->once())
+			->method('getOpenProjectAvatar')
+			->with($this->anything(),
+				$this->anything(),
+				$this->anything(),
+				$this->anything(),
+				$this->anything(),
+				$this->anything(),
+				'id', 'name'
+			)
+			->willReturn(['avatar' => 'some image data', 'type' => 'image/png']);
+		$controller = new OpenProjectAPIController(
+			'integration_openproject',
+			$this->requestMock,
+			$this->configMock,
+			$service,
+			'test'
+		);
+		$response = $controller->getOpenProjectAvatar('id', 'name');
+		$this->assertSame('some image data', $response->render());
+		$this->assertSame(
+			"attachment; filename=\"avatar\"",
+			$response->getHeaders()["Content-Disposition"]
+		);
+		$this->assertSame(
+			"image/png",
+			$response->getHeaders()["Content-Type"]
+		);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testGetOpenProjectAvatarNoType() {
+		$this->getUserValueMock();
+		$service = $this->getMockBuilder(OpenProjectAPIService::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$service->expects($this->once())
+			->method('getOpenProjectAvatar')
+			->with($this->anything(),
+				$this->anything(),
+				$this->anything(),
+				$this->anything(),
+				$this->anything(),
+				$this->anything(),
+				'id', 'name'
+			)
+			->willReturn(['avatar' => 'some image data']);
+		$controller = new OpenProjectAPIController(
+			'integration_openproject', $this->requestMock, $this->configMock, $service, 'test'
+		);
+		$response = $controller->getOpenProjectAvatar('id', 'name');
+		$this->assertSame('some image data', $response->render());
+		$this->assertSame(
+			"attachment; filename=\"avatar\"",
+			$response->getHeaders()["Content-Disposition"]
+		);
+		$this->assertEmpty($response->getHeaders()["Content-Type"]);
+	}
 }


### PR DESCRIPTION
the codepath in the fist part of the if statement could not be reached because `getOpenProjectAvatar` never returns an array with `error` as key
so I've deleted that code and covered the codepath with some basic unit tests

