### PR TITLE
[#40969] show correct error message in files tab

### DIFF
--- a/lib/Controller/OpenProjectAPIController.php
+++ b/lib/Controller/OpenProjectAPIController.php
@@ -129,20 +129,36 @@ class OpenProjectAPIController extends Controller {
 	 * @NoAdminRequired
 	 *
 	 * @param ?string $searchQuery
+	 * @param ?int $fileId
 	 *
 	 * @return DataResponse
 	 */
-	public function getSearchedWorkPackages(?string $searchQuery = null): DataResponse {
+	public function getSearchedWorkPackages(?string $searchQuery = null, ?int $fileId = null): DataResponse {
 		if ($this->accessToken === '' || !OpenProjectAPIService::validateOpenProjectURL($this->openprojectUrl)) {
-			return new DataResponse('', Http::STATUS_BAD_REQUEST);
+			return new DataResponse(
+				'invalid open project configuration', Http::STATUS_UNAUTHORIZED
+			);
 		}
 		$result = $this->openprojectAPIService->searchWorkPackage(
-			$this->openprojectUrl, $this->accessToken, $this->refreshToken, $this->clientID, $this->clientSecret, $this->userId, $searchQuery
+			$this->openprojectUrl,
+			$this->accessToken,
+			$this->refreshToken,
+			$this->clientID,
+			$this->clientSecret,
+			$this->userId,
+			$searchQuery,
+			$fileId
 		);
+
 		if (!isset($result['error'])) {
 			$response = new DataResponse($result);
 		} else {
-			$response = new DataResponse($result, Http::STATUS_UNAUTHORIZED);
+			if (isset($result['statusCode'])) {
+				$statusCode = $result['statusCode'];
+			} else {
+				$statusCode = Http::STATUS_BAD_REQUEST;
+			}
+			$response = new DataResponse($result, $statusCode);
 		}
 		return $response;
 	}

--- a/src/components/tab/EmptyContent.vue
+++ b/src/components/tab/EmptyContent.vue
@@ -33,6 +33,10 @@ export default {
 			type: String,
 			required: true,
 		},
+		errorMessage: {
+			type: String,
+			default: '',
+		},
 	},
 	data() {
 		return {
@@ -49,8 +53,12 @@ export default {
 		emptyContentMessage() {
 			if (this.state === 'no-token') {
 				return t('integration_openproject', 'No OpenProject account connected')
-			} else if (this.state === 'error') {
+			} else if (this.state === 'connection-error') {
 				return t('integration_openproject', 'Error connecting to OpenProject')
+			} else if (this.state === 'failed-fetching-workpackages') {
+				return t('integration_openproject', 'Could not fetch work packages from OpenProject')
+			} else if (this.state === 'error') {
+				return t('integration_openproject', 'Unexpected Error')
 			} else if (this.state === 'ok') {
 				return t('integration_openproject', 'No workspaces linked yet, search for work package to add!')
 			}

--- a/src/views/ProjectsTab.vue
+++ b/src/views/ProjectsTab.vue
@@ -77,19 +77,23 @@ export default {
 
 		async fetchWorkpackages(fileId) {
 			const req = {}
-			const url = generateUrl('/apps/integration_openproject/workpackages/' + fileId)
+			const url = generateUrl('/apps/integration_openproject/work_packages?fileId=' + fileId)
 			try {
 				const response = await axios.get(url, req)
 				if (!Array.isArray(response.data)) {
-					this.state = 'error'
+					this.state = 'failed-fetching-workpackages'
 				} else {
 					this.state = 'ok'
 				}
 			} catch (error) {
 				if (error.response && error.response.status === 401) {
 					this.state = 'no-token'
-				} else {
+				} else if (error.response.status === 404) {
+					this.state = 'connection-error'
+				} else if (error.response.status === 500) {
 					this.state = 'error'
+				} else {
+					this.state = 'failed-fetching-workpackages'
 				}
 			}
 		},

--- a/tests/jest/components/tab/EmptyContent.spec.js
+++ b/tests/jest/components/tab/EmptyContent.spec.js
@@ -3,6 +3,15 @@ import { shallowMount, createLocalVue } from '@vue/test-utils'
 import EmptyContent from '../../../../src/components/tab/EmptyContent'
 const localVue = createLocalVue()
 
+function getWrapper(propsData = {}) {
+	return shallowMount(EmptyContent, {
+		localVue,
+		mocks: {
+			t: (msg) => msg,
+		},
+		propsData,
+	})
+}
 describe('EmptyContent.vue Test', () => {
 	let wrapper
 	const emptyContentMessageSelector = '.title'
@@ -28,6 +37,7 @@ describe('EmptyContent.vue Test', () => {
 				requestUrl: 'http://openproject/oauth/',
 			},
 		})
+		wrapper = getWrapper({ state: cases.state })
 		expect(wrapper.find(connectButtonSelector).exists()).toBe(cases.viewed)
 	})
 	it.each([{
@@ -35,7 +45,13 @@ describe('EmptyContent.vue Test', () => {
 		message: 'No OpenProject account connected',
 	}, {
 		state: 'error',
+		message: 'Unexpected Error',
+	}, {
+		state: 'connection-error',
 		message: 'Error connecting to OpenProject',
+	}, {
+		state: 'failed-fetching-workpackages',
+		message: 'Could not fetch work packages from OpenProject',
 	}, {
 		state: 'ok',
 		message: 'No workspaces linked yet',
@@ -53,6 +69,7 @@ describe('EmptyContent.vue Test', () => {
 				requestUrl: 'http://openproject/oauth/',
 			},
 		})
+		wrapper = getWrapper({ state: cases.state })
 		expect(wrapper.find(emptyContentMessageSelector).exists()).toBeTruthy()
 		expect(wrapper.find(emptyContentMessageSelector).text()).toMatch(cases.message)
 	})

--- a/tests/jest/views/ProjectsTab.spec.js
+++ b/tests/jest/views/ProjectsTab.spec.js
@@ -45,23 +45,10 @@ describe('ProjectsTab.vue Test', () => {
 	})
 	describe('fetchWorkpackages', () => {
 		it.each([
-			{ responseData: [], AppState: 'ok' },
-			{ responseData: 'string', AppState: 'error' },
-			{ responseData: null, AppState: 'error' },
-			{ responseData: undefined, AppState: 'error' },
-		])('sets states according to response content in case of success', async (cases) => {
-			axios.get.mockImplementationOnce(() =>
-				Promise.resolve({
-					data: cases.responseData,
-				}),
-			)
-			await wrapper.vm.update({ id: 123 })
-			expect(wrapper.vm.state).toBe(cases.AppState)
-		})
-		it.each([
-			{ HTTPStatus: 400, AppState: 'error' },
+			{ HTTPStatus: 400, AppState: 'failed-fetching-workpackages' },
 			{ HTTPStatus: 401, AppState: 'no-token' },
-			{ HTTPStatus: 404, AppState: 'error' },
+			{ HTTPStatus: 402, AppState: 'failed-fetching-workpackages' },
+			{ HTTPStatus: 404, AppState: 'connection-error' },
 			{ HTTPStatus: 500, AppState: 'error' },
 		])('sets states according to HTTP error codes', async (cases) => {
 			const err = new Error()


### PR DESCRIPTION
This turned into a bit of refactoring for passing around error messages.
Now we have these options that can happen:

When OpenProject server is not reachable
![grafik](https://user-images.githubusercontent.com/2425577/155307899-7040f51a-1475-4b1b-878e-2f073e14f2be.png)

OpenProject does not support the filter (what is currently always the case, because its not implemented yet)
![grafik](https://user-images.githubusercontent.com/2425577/155307830-5b2ab626-a5ce-4a98-b420-6ecbbec5c203.png)

No OAuth connection to OpenProject, because the connection was not established yet
![grafik](https://user-images.githubusercontent.com/2425577/154620336-d24825a9-5f8e-4334-9a2a-823720c6f818.png)


