### PR TITLE
[CI] cancel running workflows for the PR except the latest one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,12 @@ jobs:
         nextcloudVersion: [ v23.0.0, master ]
     runs-on: ubuntu-latest
     steps:
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          all_but_latest: true
+          access_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Checkout
         uses: actions/checkout@v2
 


### PR DESCRIPTION
### Description
Sometimes we may push more frequently so that there may be a running workflow for previous pushes in a PR. These in-progress runs will be canceled leaving only the latest run.

GH Action Used: https://github.com/styfle/cancel-workflow-action#advanced-all-but-latest


Signed-off-by: Parajuli Kiran <kiranparajuli589@gmail.com>