### PR TITLE
refactor route name 'work_packages' to 'work-packages'

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -17,7 +17,7 @@ return [
 		['name' => 'openProjectAPI#getNotifications', 'url' => '/notifications', 'verb' => 'GET'],
 		['name' => 'openProjectAPI#getOpenProjectUrl', 'url' => '/url', 'verb' => 'GET'],
 		['name' => 'openProjectAPI#getOpenProjectAvatar', 'url' => '/avatar', 'verb' => 'GET'],
-		['name' => 'openProjectAPI#getSearchedWorkPackages', 'url' => '/work_packages', 'verb' => 'GET'],
+		['name' => 'openProjectAPI#getSearchedWorkPackages', 'url' => '/work-packages', 'verb' => 'GET'],
 		['name' => 'openProjectAPI#getOpenProjectWorkPackageStatus', 'url' => '/statuses/{id}', 'verb' => 'GET'],
 		['name' => 'openProjectAPI#getOpenProjectWorkPackageType', 'url' => '/types/{id}', 'verb' => 'GET'],
 	]

--- a/src/components/tab/SearchInput.vue
+++ b/src/components/tab/SearchInput.vue
@@ -111,7 +111,7 @@ export default {
 				this.searchResults = []
 				return
 			}
-			const url = generateUrl('/apps/integration_openproject/work_packages')
+			const url = generateUrl('/apps/integration_openproject/work-packages')
 			if (this.search.length > 3) {
 				const req = {}
 				req.params = {


### PR DESCRIPTION
### Description
Refactor route name `work_packages` to `work-packages`

### Related
OP#41125
https://community.openproject.org/projects/nextcloud-integration/work_packages/41125

Signed-off-by: Parajuli Kiran <kiranparajuli589@gmail.com>