### PR TITLE
Do not show the connect button if admin config is not ok

### DIFF
--- a/lib/Dashboard/OpenProjectWidget.php
+++ b/lib/Dashboard/OpenProjectWidget.php
@@ -105,7 +105,11 @@ class OpenProjectWidget implements IWidget {
 	public function load(): void {
 		Util::addScript(Application::APP_ID, Application::APP_ID . '-dashboard');
 		Util::addStyle(Application::APP_ID, 'dashboard');
+
 		$requestUrl = OpenProjectAPIService::getOpenProjectOauthURL($this->config, $this->url);
+		$isAdminConfigOk = OpenProjectAPIService::isAdminConfigOk($this->config);
+
 		$this->initialStateService->provideInitialState('request-url', $requestUrl);
+		$this->initialStateService->provideInitialState('admin-config-status', $isAdminConfigOk);
 	}
 }

--- a/lib/Listener/LoadSidebarScript.php
+++ b/lib/Listener/LoadSidebarScript.php
@@ -74,7 +74,11 @@ class LoadSidebarScript implements IEventListener {
 			Util::addScript(Application::APP_ID, 'integration_openproject-projectTab');
 		}
 		Util::addStyle(Application::APP_ID, 'tab');
+
 		$requestUrl = OpenProjectAPIService::getOpenProjectOauthURL($this->config, $this->url);
+		$isAdminConfigOk = OpenProjectAPIService::isAdminConfigOk($this->config);
+
 		$this->initialStateService->provideInitialState('request-url', $requestUrl);
+		$this->initialStateService->provideInitialState('admin-config-status', $isAdminConfigOk);
 	}
 }

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -685,14 +685,21 @@ class OpenProjectAPIService {
 	}
 
 	/**
-	 * checks for every admin config variables if they are set
+	 * checks if every admin config variables are set
+	 * checks if the oauth instance url is valid
 	 *
 	 * @param IConfig $config
 	 * @return bool
 	 */
 	public static function isAdminConfigOk(IConfig $config):bool {
-		return !!($config->getAppValue(Application::APP_ID, 'client_id'))
-			&& !!($config->getAppValue(Application::APP_ID, 'client_secret'))
-			&& !!($config->getAppValue(Application::APP_ID, 'oauth_instance_url'));
+		$clientId = $config->getAppValue(Application::APP_ID, 'client_id');
+		$clientSecret = $config->getAppValue(Application::APP_ID, 'client_secret');
+		$oauthInstanceUrl = $config->getAppValue(Application::APP_ID, 'oauth_instance_url');
+		$checkIfConfigIsSet = !!($clientId) && !!($clientSecret) && !!($oauthInstanceUrl);
+		if (!$checkIfConfigIsSet) {
+			return false;
+		} else {
+			return self::validateOpenProjectURL($oauthInstanceUrl);
+		}
 	}
 }

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -575,7 +575,7 @@ class OpenProjectAPIService {
 		return $result;
 	}
 
-	/*
+	/**
 	 * @param IConfig $config
 	 * @param IURLGenerator $urlGenerator
 	 * @return string
@@ -685,9 +685,10 @@ class OpenProjectAPIService {
 	}
 
 	/**
+	 * checks for every admin config variables if they are set
+	 *
 	 * @param IConfig $config
 	 * @return bool
-	 * checks for every admin config variables if they are set
 	 */
 	public static function isAdminConfigOk(IConfig $config):bool {
 		return !!($config->getAppValue(Application::APP_ID, 'client_id'))

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -683,4 +683,15 @@ class OpenProjectAPIService {
 		}
 		return $result['_embedded']['elements'][0]['id'];
 	}
+
+	/**
+	 * @param IConfig $config
+	 * @return bool
+	 * checks for every admin config variables if they are set
+	 */
+	public static function isAdminConfigOk(IConfig $config):bool {
+		return !!($config->getAppValue(Application::APP_ID, 'client_id'))
+			&& !!($config->getAppValue(Application::APP_ID, 'client_secret'))
+			&& !!($config->getAppValue(Application::APP_ID, 'oauth_instance_url'));
+	}
 }

--- a/lib/Settings/Personal.php
+++ b/lib/Settings/Personal.php
@@ -51,6 +51,8 @@ class Personal implements ISettings {
 		$notificationEnabled = $this->config->getUserValue($this->userId, Application::APP_ID, 'notification_enabled', '0');
 		$navigationEnabled = $this->config->getUserValue($this->userId, Application::APP_ID, 'navigation_enabled', '0');
 
+		$isAdminConfigOk = OpenProjectAPIService::isAdminConfigOk($this->config);
+
 		// for OAuth
 		$requestUrl = OpenProjectAPIService::getOpenProjectOauthURL($this->config, $this->url);
 
@@ -63,6 +65,7 @@ class Personal implements ISettings {
 			'request_url' => $requestUrl,
 		];
 		$this->initialStateService->provideInitialState('user-config', $userConfig);
+		$this->initialStateService->provideInitialState('admin-config-status', $isAdminConfigOk);
 		return new TemplateResponse(Application::APP_ID, 'personalSettings');
 	}
 

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -68,10 +68,6 @@ export default {
 			redirect_uri: window.location.protocol + '//' + window.location.host + generateUrl('/apps/integration_openproject/oauth-redirect'),
 		}
 	},
-	created() {
-		// eslint-disable-next-line no-console
-		console.log(this.state)
-	},
 	methods: {
 		onInput() {
 			const that = this

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -68,7 +68,10 @@ export default {
 			redirect_uri: window.location.protocol + '//' + window.location.host + generateUrl('/apps/integration_openproject/oauth-redirect'),
 		}
 	},
-
+	created() {
+		// eslint-disable-next-line no-console
+		console.log(this.state)
+	},
 	methods: {
 		onInput() {
 			const that = this

--- a/src/components/OAuthConnectButton.vue
+++ b/src/components/OAuthConnectButton.vue
@@ -1,10 +1,14 @@
 <template>
 	<button
-		class="openproject-oauth"
+		v-if="adminConfigStatus"
+		class="oauth-connect--button"
 		@click="onOAuthClick">
 		<span class="icon icon-external" />
 		{{ t('integration_openproject', 'Connect to OpenProject') }}
 	</button>
+	<div v-else-if="!adminConfigStatus" class="oauth-connect--message">
+		{{ adminConfigNotOkMessage }}
+	</div>
 </template>
 <script>
 import axios from '@nextcloud/axios'
@@ -20,7 +24,18 @@ export default {
 			type: String,
 			required: true,
 		},
+		adminConfigStatus: {
+			type: Boolean,
+			default: false,
+		},
 	},
+
+	computed: {
+		adminConfigNotOkMessage() {
+			return t('integration_openproject', 'Failed to establish connection. Please contact your administrator.')
+		},
+	},
+
 	methods: {
 		generateRandomString(length) {
 			let text = ''
@@ -70,3 +85,12 @@ export default {
 	},
 }
 </script>
+<style lang="scss" scoped>
+.oauth-connect {
+  &--message {
+    font-size: .875rem;
+    text-align: center;
+    font-weight: 500;
+  }
+}
+</style>

--- a/src/components/OAuthConnectButton.vue
+++ b/src/components/OAuthConnectButton.vue
@@ -32,7 +32,7 @@ export default {
 
 	computed: {
 		adminConfigNotOkMessage() {
-			return t('integration_openproject', 'Failed to establish connection. Please contact your administrator.')
+			return t('integration_openproject', 'Settings of the OpenProject integration app are not complete. Please contact your NextCloud administrator.')
 		},
 	},
 

--- a/src/components/OAuthConnectButton.vue
+++ b/src/components/OAuthConnectButton.vue
@@ -6,7 +6,7 @@
 		<span class="icon icon-external" />
 		{{ t('integration_openproject', 'Connect to OpenProject') }}
 	</button>
-	<div v-else-if="!adminConfigStatus" class="oauth-connect--message">
+	<div v-else class="oauth-connect--message">
 		{{ adminConfigNotOkMessage }}
 	</div>
 </template>

--- a/src/components/PersonalSettings.vue
+++ b/src/components/PersonalSettings.vue
@@ -43,7 +43,7 @@
 					@input="onNotificationChange">
 				<label for="notification-openproject">{{ t('integration_openproject', 'Enable notifications for activity in my work packages') }}</label>
 			</div>
-			<OAuthConnectButton v-else-if="adminConfigStatus" :request-url="requestUrl" />
+			<OAuthConnectButton v-else :request-url="requestUrl" :admin-config-status="adminConfigStatus" />
 		</div>
 	</div>
 </template>
@@ -77,6 +77,7 @@ export default {
 
 	computed: {
 		connected() {
+			if (!this.adminConfigStatus) return false
 			return this.state.token && this.state.token !== ''
 				&& this.state.user_name && this.state.user_name !== ''
 		},
@@ -183,5 +184,9 @@ export default {
 
 #openproject-search-block .icon {
 	width: 22px;
+}
+
+#openproject-content .oauth-connect--message {
+  text-align: left !important;
 }
 </style>

--- a/src/components/PersonalSettings.vue
+++ b/src/components/PersonalSettings.vue
@@ -43,7 +43,7 @@
 					@input="onNotificationChange">
 				<label for="notification-openproject">{{ t('integration_openproject', 'Enable notifications for activity in my work packages') }}</label>
 			</div>
-			<OAuthConnectButton v-else :request-url="requestUrl" />
+			<OAuthConnectButton v-else-if="adminConfigStatus" :request-url="requestUrl" />
 		</div>
 	</div>
 </template>
@@ -68,9 +68,10 @@ export default {
 
 	data() {
 		return {
+			loading: false,
 			state: loadState('integration_openproject', 'user-config'),
 			requestUrl: loadState('integration_openproject', 'user-config').request_url,
-			loading: false,
+			adminConfigStatus: loadState('integration_openproject', 'admin-config-status'),
 		}
 	},
 

--- a/src/components/tab/EmptyContent.vue
+++ b/src/components/tab/EmptyContent.vue
@@ -7,7 +7,8 @@
 			<div class="empty-content--title">
 				{{ emptyContentMessage }}
 			</div>
-			<div v-if="showConnectButton" class="empty-content--connect-button">
+			<br>
+			<div v-if="showOauth && showConnectButton" class="connect-button">
 				<OAuthConnectButton :request-url="requestUrl" />
 			</div>
 		</div>
@@ -18,6 +19,7 @@
 import { generateUrl } from '@nextcloud/router'
 import { translate as t } from '@nextcloud/l10n'
 import OAuthConnectButton from '../OAuthConnectButton'
+import { loadState } from '@nextcloud/initial-state'
 
 export default {
 	name: 'EmptyContent',
@@ -35,6 +37,10 @@ export default {
 		errorMessage: {
 			type: String,
 			default: '',
+		},
+		showOauth: {
+			type: Boolean,
+			required: true,
 		},
 	},
 	data() {
@@ -62,6 +68,9 @@ export default {
 				return t('integration_openproject', 'No workspaces linked yet, search for work package to add!')
 			}
 			return 'invalid state'
+		},
+		adminConfig() {
+			return loadState('integration_openproject', 'admin-config')
 		},
 	},
 }

--- a/src/components/tab/EmptyContent.vue
+++ b/src/components/tab/EmptyContent.vue
@@ -8,7 +8,7 @@
 				{{ emptyContentMessage }}
 			</div>
 			<br>
-			<div v-if="showOauth && showConnectButton" class="connect-button">
+			<div v-if="showConnect && showConnectButton" class="connect-button">
 				<OAuthConnectButton :request-url="requestUrl" />
 			</div>
 		</div>
@@ -19,7 +19,6 @@
 import { generateUrl } from '@nextcloud/router'
 import { translate as t } from '@nextcloud/l10n'
 import OAuthConnectButton from '../OAuthConnectButton'
-import { loadState } from '@nextcloud/initial-state'
 
 export default {
 	name: 'EmptyContent',
@@ -38,7 +37,7 @@ export default {
 			type: String,
 			default: '',
 		},
-		showOauth: {
+		showConnect: {
 			type: Boolean,
 			required: true,
 		},
@@ -68,9 +67,6 @@ export default {
 				return t('integration_openproject', 'No workspaces linked yet, search for work package to add!')
 			}
 			return 'invalid state'
-		},
-		adminConfig() {
-			return loadState('integration_openproject', 'admin-config')
 		},
 	},
 }

--- a/src/components/tab/EmptyContent.vue
+++ b/src/components/tab/EmptyContent.vue
@@ -4,12 +4,11 @@
 			<div class="empty-content--icon">
 				<img :src="flowSvg" alt="flow">
 			</div>
-			<div class="empty-content--title">
+			<div v-if="adminConfigStatus" class="empty-content--title">
 				{{ emptyContentMessage }}
 			</div>
-			<br>
-			<div v-if="showConnect && showConnectButton" class="connect-button">
-				<OAuthConnectButton :request-url="requestUrl" />
+			<div v-if="showConnectButton" class="empty-content--connect-button">
+				<OAuthConnectButton :request-url="requestUrl" :admin-config-status="adminConfigStatus" />
 			</div>
 		</div>
 	</div>
@@ -37,7 +36,7 @@ export default {
 			type: String,
 			default: '',
 		},
-		showConnect: {
+		adminConfigStatus: {
 			type: Boolean,
 			required: true,
 		},

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -9,7 +9,7 @@
 				:icon="emptyContentIcon">
 				<template #desc>
 					{{ emptyContentMessage }}
-					<div v-if="state === 'no-token' || state === 'error'" class="connect-button">
+					<div v-if="showOauthConnect" class="connect-button">
 						<OAuthConnectButton :request-url="requestUrl" />
 					</div>
 				</template>
@@ -50,6 +50,7 @@ export default {
 			loop: null,
 			state: 'loading',
 			requestUrl: loadState('integration_openproject', 'request-url'),
+			adminConfigStatus: loadState('integration_openproject', 'admin-config-status'),
 			settingsUrl: generateUrl('/settings/user/connected-accounts'),
 			themingColor: OCA.Theming ? OCA.Theming.color.replace('#', '') : '0082C9',
 			windowVisibility: true,
@@ -99,6 +100,10 @@ export default {
 				return 'icon-checkmark'
 			}
 			return 'icon-checkmark'
+		},
+		showOauthConnect() {
+			if (!this.adminConfigStatus) return false
+			return ['no-token', 'error'].includes(this.state)
 		},
 	},
 	watch: {

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -8,9 +8,11 @@
 				v-if="emptyContentMessage"
 				:icon="emptyContentIcon">
 				<template #desc>
-					{{ emptyContentMessage }}
+					<div v-if="adminConfigStatus">
+						{{ emptyContentMessage }}
+					</div>
 					<div v-if="showOauthConnect" class="connect-button">
-						<OAuthConnectButton :request-url="requestUrl" />
+						<OAuthConnectButton :request-url="requestUrl" :admin-config-status="adminConfigStatus" />
 					</div>
 				</template>
 			</EmptyContent>
@@ -102,7 +104,6 @@ export default {
 			return 'icon-checkmark'
 		},
 		showOauthConnect() {
-			if (!this.adminConfigStatus) return false
 			return ['no-token', 'error'].includes(this.state)
 		},
 	},

--- a/src/views/ProjectsTab.vue
+++ b/src/views/ProjectsTab.vue
@@ -38,7 +38,8 @@
 		<EmptyContent v-else
 			id="openproject-empty-content"
 			:state="state"
-			:request-url="requestUrl" />
+			:request-url="requestUrl"
+			:show-oauth="adminConfigStatus" />
 	</div>
 </template>
 
@@ -63,13 +64,12 @@ export default {
 		state: 'loading',
 		workpackages: [],
 		requestUrl: loadState('integration_openproject', 'request-url'),
+		adminConfigStatus: loadState('integration_openproject', 'admin-config-status'),
 	}),
 	computed: {
 		isLoading() {
 			return this.state === 'loading'
 		},
-	},
-	created() {
 	},
 	methods: {
 		/**

--- a/src/views/ProjectsTab.vue
+++ b/src/views/ProjectsTab.vue
@@ -39,7 +39,7 @@
 			id="openproject-empty-content"
 			:state="state"
 			:request-url="requestUrl"
-			:show-connect="adminConfigStatus" />
+			:admin-config-status="adminConfigStatus" />
 	</div>
 </template>
 

--- a/src/views/ProjectsTab.vue
+++ b/src/views/ProjectsTab.vue
@@ -39,7 +39,7 @@
 			id="openproject-empty-content"
 			:state="state"
 			:request-url="requestUrl"
-			:show-oauth="adminConfigStatus" />
+			:show-connect="adminConfigStatus" />
 	</div>
 </template>
 

--- a/tests/jest/components/OAuthConnectButton.spec.js
+++ b/tests/jest/components/OAuthConnectButton.spec.js
@@ -21,7 +21,6 @@ describe('OAuthConnectButton.vue Test', () => {
 	describe('when admin config status is not ok', () => {
 		it('should show message', async () => {
 			wrapper = getWrapper({ adminConfigStatus: false })
-			await wrapper.setProps({ adminConfigStatus: false })
 			expect(wrapper).toMatchSnapshot()
 		})
 	})

--- a/tests/jest/components/OAuthConnectButton.spec.js
+++ b/tests/jest/components/OAuthConnectButton.spec.js
@@ -14,83 +14,98 @@ const localVue = createLocalVue()
 describe('OAuthConnectButton.vue Test', () => {
 	let wrapper
 	let generateCodeChallengeSpy
-	beforeEach(() => {
-		delete window.location
-		window.location = { replace: jest.fn() }
-		OAuthConnectButton.methods.digest = jest.fn(
-			() => Promise.resolve(new ArrayBuffer(8))
-		)
-		generateCodeChallengeSpy = jest.spyOn(
-			OAuthConnectButton.methods, 'generateCodeChallenge'
-		)
-		wrapper = shallowMount(OAuthConnectButton, {
-			localVue,
-			mocks: {
-				t: (app, msg) => msg,
-			},
-			propsData: {
-				requestUrl: 'http://openproject/oauth/',
-			},
-		})
-	})
 	afterEach(() => {
 		window.location = location
 		jest.clearAllMocks()
 	})
-	describe('on successful saving of the state & challenge', () => {
-		beforeEach(() => {
-			axios.put.mockImplementationOnce(() =>
-				Promise.resolve({}),
-			)
+	describe('when admin config status is not ok', () => {
+		it('should show message', async () => {
+			wrapper = getWrapper({ adminConfigStatus: false })
+			await wrapper.setProps({ adminConfigStatus: false })
+			expect(wrapper).toMatchSnapshot()
 		})
-		it('saves the state to user config', async () => {
-			wrapper.find('button').trigger('click')
-			await localVue.nextTick()
-			expect(axios.put).toHaveBeenCalledWith(
-				'http://localhost/apps/integration_openproject/config',
-				{
-					values: {
-						oauth_state: expect.stringMatching(/[A-Za-z0-9\-._~]{10}/),
-						code_verifier: expect.stringMatching(/[A-Za-z0-9\-._~]{128}/),
+	})
+	describe('when admin config status is ok', () => {
+		beforeEach(() => {
+			delete window.location
+			window.location = { replace: jest.fn() }
+			OAuthConnectButton.methods.digest = jest.fn(
+				() => Promise.resolve(new ArrayBuffer(8))
+			)
+			generateCodeChallengeSpy = jest.spyOn(
+				OAuthConnectButton.methods, 'generateCodeChallenge'
+			)
+			wrapper = getWrapper({ adminConfigStatus: true })
+		})
+		describe('on successful saving of the state & challenge', () => {
+			beforeEach(() => {
+				axios.put.mockImplementationOnce(() =>
+					Promise.resolve({}),
+				)
+			})
+			it('saves the state to user config', async () => {
+				wrapper.find('button').trigger('click')
+				await localVue.nextTick()
+				expect(axios.put).toHaveBeenCalledWith(
+					'http://localhost/apps/integration_openproject/config',
+					{
+						values: {
+							oauth_state: expect.stringMatching(/[A-Za-z0-9\-._~]{10}/),
+							code_verifier: expect.stringMatching(/[A-Za-z0-9\-._~]{128}/),
+						},
 					},
-				},
-			)
+				)
+			})
+			it('redirects to the openproject oauth uri', async () => {
+				wrapper.find('button').trigger('click')
+				await localVue.nextTick()
+				expect(generateCodeChallengeSpy).toHaveBeenCalledTimes(1)
+				await localVue.nextTick()
+				expect(window.location.replace).toHaveBeenCalledWith(
+					expect.stringMatching(
+						/http:\/\/openproject\/oauth\/&state=[A-Za-z0-9\-._~]{10}&code_challenge=A{11}&code_challenge_method=S256/
+					),
+				)
+			})
 		})
-		it('redirects to the openproject oauth uri', async () => {
-			wrapper.find('button').trigger('click')
-			await localVue.nextTick()
-			expect(generateCodeChallengeSpy).toHaveBeenCalledTimes(1)
-			await localVue.nextTick()
-			expect(window.location.replace).toHaveBeenCalledWith(
-				expect.stringMatching(
-					/http:\/\/openproject\/oauth\/&state=[A-Za-z0-9\-._~]{10}&code_challenge=A{11}&code_challenge_method=S256/
-				),
-			)
+		describe('on unsuccessful saving of the state', () => {
+			beforeEach(() => {
+				const err = new Error()
+				err.message = 'some issue'
+				axios.put.mockRejectedValueOnce(err)
+			})
+			it('shows an error', async () => {
+				dialogs.showError.mockImplementationOnce()
+				wrapper.find('button').trigger('click')
+				await localVue.nextTick()
+				expect(generateCodeChallengeSpy).toHaveBeenCalledTimes(1)
+				await localVue.nextTick()
+				expect(dialogs.showError).toHaveBeenCalledWith(
+					'Failed to save OpenProject OAuth state: some issue'
+				)
+				expect(window.location.replace).not.toHaveBeenCalled()
+			})
 		})
-	})
-	describe('on unsuccessful saving of the state', () => {
-		beforeEach(() => {
-			const err = new Error()
-			err.message = 'some issue'
-			axios.put.mockRejectedValueOnce(err)
+		it('generates a random string', () => {
+			const r1 = wrapper.vm.generateRandomString(128)
+			const r2 = wrapper.vm.generateRandomString(128)
+			expect(r1).not.toEqual(r2)
+			expect(r1).toMatch(/[A-Za-z0-9\-._~]{128}/)
+			expect(r2).toMatch(/[A-Za-z0-9\-._~]{128}/)
 		})
-		it('shows an error', async () => {
-			dialogs.showError.mockImplementationOnce()
-			wrapper.find('button').trigger('click')
-			await localVue.nextTick()
-			expect(generateCodeChallengeSpy).toHaveBeenCalledTimes(1)
-			await localVue.nextTick()
-			expect(dialogs.showError).toHaveBeenCalledWith(
-				'Failed to save OpenProject OAuth state: some issue'
-			)
-			expect(window.location.replace).not.toHaveBeenCalled()
-		})
-	})
-	it('generates a random string', () => {
-		const r1 = wrapper.vm.generateRandomString(128)
-		const r2 = wrapper.vm.generateRandomString(128)
-		expect(r1).not.toEqual(r2)
-		expect(r1).toMatch(/[A-Za-z0-9\-._~]{128}/)
-		expect(r2).toMatch(/[A-Za-z0-9\-._~]{128}/)
 	})
 })
+
+function getWrapper(props = {}) {
+	return shallowMount(OAuthConnectButton, {
+		localVue,
+		mocks: {
+			t: (app, msg) => msg,
+		},
+		propsData: {
+			requestUrl: 'http://openproject/oauth/',
+			adminConfigStatus: false,
+			...props,
+		},
+	})
+}

--- a/tests/jest/components/PersonalSettings.spec.js
+++ b/tests/jest/components/PersonalSettings.spec.js
@@ -33,7 +33,7 @@ describe('PersonalSettings.vue Test', () => {
 			})
 		})
 
-		describe('when admin config status is truthy', () => {
+		describe('when admin config status is ok', () => {
 			describe.each([
 				{ user_name: 'test', token: '' },
 				{ user_name: 'test', token: null },
@@ -82,15 +82,19 @@ describe('PersonalSettings.vue Test', () => {
 				})
 			})
 		})
-		describe('when admin config status is falsy', () => {
+		describe('when admin config status is not ok', () => {
 			beforeEach(async () => {
 				await wrapper.setData({
 					adminConfigStatus: false,
 					state: { user_name: 'test', token: '123' },
 				})
 			})
-			it('should not show the oauth connect button', () => {
-				expect(wrapper.find(oAuthButtonSelector).exists()).toBeFalsy()
+			it('should set proper props to the oauth connect component', () => {
+				expect(wrapper.find(oAuthButtonSelector).exists()).toBeTruthy()
+				expect(wrapper.find(oAuthButtonSelector).props()).toMatchObject({
+					requestUrl: 'https://nextcloud.com/',
+					adminConfigStatus: false,
+				})
 			})
 		})
 	})

--- a/tests/jest/components/PersonalSettings.spec.js
+++ b/tests/jest/components/PersonalSettings.spec.js
@@ -6,6 +6,15 @@ import * as initialState from '@nextcloud/initial-state'
 
 const localVue = createLocalVue()
 
+// eslint-disable-next-line no-import-assign
+initialState.loadState = jest.fn((key, value) => {
+	if (value === 'user-config') {
+		return {
+			request_url: 'https://nextcloud.com/',
+		}
+	} else if (value === 'admin-config-status') return false
+})
+
 describe('PersonalSettings.vue Test', () => {
 	describe('oAuth', () => {
 		const oAuthButtonSelector = 'oauthconnectbutton-stub'
@@ -14,14 +23,6 @@ describe('PersonalSettings.vue Test', () => {
 		const searchBlockSelector = '#openproject-search-block'
 		let wrapper
 		beforeEach(() => {
-			// eslint-disable-next-line no-import-assign
-			initialState.loadState = jest.fn((key, value) => {
-				if (value === 'user-config') {
-					return {
-						request_url: 'https://nextcloud.com/',
-					}
-				} else if (value === 'admin-config-status') return false
-			})
 			wrapper = shallowMount(PersonalSettings, {
 				localVue,
 				mocks: {

--- a/tests/jest/components/PersonalSettings.spec.js
+++ b/tests/jest/components/PersonalSettings.spec.js
@@ -15,10 +15,12 @@ describe('PersonalSettings.vue Test', () => {
 		let wrapper
 		beforeEach(() => {
 			// eslint-disable-next-line no-import-assign
-			initialState.loadState = jest.fn(function() {
-				return {
-					request_url: 'https://localhost',
-				}
+			initialState.loadState = jest.fn((key, value) => {
+				if (value === 'user-config') {
+					return {
+						request_url: 'https://nextcloud.com/',
+					}
+				} else if (value === 'admin-config-status') return false
 			})
 			wrapper = shallowMount(PersonalSettings, {
 				localVue,
@@ -31,49 +33,64 @@ describe('PersonalSettings.vue Test', () => {
 			})
 		})
 
-		describe.each([
-			{ user_name: 'test', token: '' },
-			{ user_name: 'test', token: null },
-			{ user_name: 'test', token: undefined },
-			{ user_name: '', token: '123' },
-			{ user_name: null, token: '123' },
-			{ user_name: undefined, token: '123' },
-			{ user_name: '', token: '' },
-			{ user_name: null, token: '' },
-			{ user_name: '', token: null },
-		])('when username or token not given', (cases) => {
-			beforeEach(async () => {
-				await wrapper.setData({
-					state: cases,
+		describe('when admin config status is truthy', () => {
+			describe.each([
+				{ user_name: 'test', token: '' },
+				{ user_name: 'test', token: null },
+				{ user_name: 'test', token: undefined },
+				{ user_name: '', token: '123' },
+				{ user_name: null, token: '123' },
+				{ user_name: undefined, token: '123' },
+				{ user_name: '', token: '' },
+				{ user_name: null, token: '' },
+				{ user_name: '', token: null },
+			])('when username or token not given', (cases) => {
+				beforeEach(async () => {
+					await wrapper.setData({
+						adminConfigStatus: true,
+						state: cases,
+					})
+				})
+				it('oAuth connect button is displayed', () => {
+					expect(wrapper.find(oAuthButtonSelector).exists()).toBeTruthy()
+				})
+				it('search settings are not displayed', () => {
+					expect(wrapper.find(searchBlockSelector).exists()).toBeFalsy()
+				})
+				it('oAuth disconnect button is not displayed', () => {
+					expect(wrapper.find(oAuthDisconnectButtonSelector).exists()).toBeFalsy()
 				})
 			})
-			it('oAuth connect button is displayed', () => {
-				expect(wrapper.find(oAuthButtonSelector).exists()).toBeTruthy()
-			})
-			it('search settings are not displayed', () => {
-				expect(wrapper.find(searchBlockSelector).exists()).toBeFalsy()
-			})
-			it('oAuth disconnect button is not displayed', () => {
-				expect(wrapper.find(oAuthDisconnectButtonSelector).exists()).toBeFalsy()
+			describe('when username and token are given', () => {
+				beforeEach(async () => {
+					await wrapper.setData({
+						adminConfigStatus: true,
+						state: { user_name: 'test', token: '123' },
+					})
+				})
+				it('oAuth connect button is not displayed', () => {
+					expect(wrapper.find(oAuthButtonSelector).exists()).toBeFalsy()
+				})
+				it('oAuth disconnect button is displayed', () => {
+					expect(wrapper.find(oAuthDisconnectButtonSelector).exists()).toBeTruthy()
+				})
+				it('connected as label is displayed', () => {
+					expect(wrapper.find(connectedAsLabenSelector).text()).toBe('Connected as {user}')
+				})
+				it('oAuth search settings are displayed', () => {
+					expect(wrapper.find(searchBlockSelector).exists()).toBeTruthy()
+				})
 			})
 		})
-		describe('when username and token are given', () => {
+		describe('when admin config status is falsy', () => {
 			beforeEach(async () => {
 				await wrapper.setData({
+					adminConfigStatus: false,
 					state: { user_name: 'test', token: '123' },
 				})
 			})
-			it('oAuth connect button is not displayed', () => {
+			it('should not show the oauth connect button', () => {
 				expect(wrapper.find(oAuthButtonSelector).exists()).toBeFalsy()
-			})
-			it('oAuth disconnect button is displayed', () => {
-				expect(wrapper.find(oAuthDisconnectButtonSelector).exists()).toBeTruthy()
-			})
-			it('connected as label is displayed', () => {
-				expect(wrapper.find(connectedAsLabenSelector).text()).toBe('Connected as {user}')
-			})
-			it('oAuth search settings are displayed', () => {
-				expect(wrapper.find(searchBlockSelector).exists()).toBeTruthy()
 			})
 		})
 	})

--- a/tests/jest/components/__snapshots__/OAuthConnectButton.spec.js.snap
+++ b/tests/jest/components/__snapshots__/OAuthConnectButton.spec.js.snap
@@ -2,6 +2,6 @@
 
 exports[`OAuthConnectButton.vue Test when admin config status is not ok should show message 1`] = `
 <div class="oauth-connect--message">
-  Failed to establish connection. Please contact your administrator.
+  Settings of the OpenProject integration app are not complete. Please contact your NextCloud administrator.
 </div>
 `;

--- a/tests/jest/components/__snapshots__/OAuthConnectButton.spec.js.snap
+++ b/tests/jest/components/__snapshots__/OAuthConnectButton.spec.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`OAuthConnectButton.vue Test when admin config status is not ok should show message 1`] = `
+<div class="oauth-connect--message">
+  Failed to establish connection. Please contact your administrator.
+</div>
+`;

--- a/tests/jest/components/tab/EmptyContent.spec.js
+++ b/tests/jest/components/tab/EmptyContent.spec.js
@@ -9,10 +9,6 @@ describe('EmptyContent.vue Test', () => {
 	const connectButtonSelector = 'oauthconnectbutton-stub'
 
 	describe('connect button', () => {
-		it('should not be displayed if the "showConnect" prop is set as false', () => {
-			wrapper = getWrapper({ showConnect: false })
-			expect(wrapper.find(connectButtonSelector).exists()).toBe(false)
-		})
 		it.each([{
 			state: 'ok',
 			viewed: false,
@@ -22,33 +18,39 @@ describe('EmptyContent.vue Test', () => {
 		}, {
 			state: 'error',
 			viewed: true,
-		}])('shows or hides the connect button depending on the state if the "showConnect" prop is set as true', (cases) => {
-			wrapper = getWrapper({ state: cases.state, showConnect: true })
+		}])('should be displayed depending on the state', (cases) => {
+			wrapper = getWrapper({ state: cases.state, adminConfigStatus: true })
 			expect(wrapper.find(connectButtonSelector).exists()).toBe(cases.viewed)
 		})
 	})
-	it.each([{
-		state: 'no-token',
-		message: 'No OpenProject account connected',
-	}, {
-		state: 'error',
-		message: 'Unexpected Error',
-	}, {
-		state: 'connection-error',
-		message: 'Error connecting to OpenProject',
-	}, {
-		state: 'failed-fetching-workpackages',
-		message: 'Could not fetch work packages from OpenProject',
-	}, {
-		state: 'ok',
-		message: 'No workspaces linked yet',
-	}, {
-		state: 'something else',
-		message: 'invalid state',
-	}])('shows the correct empty message depending on states', async (cases) => {
-		wrapper = getWrapper({ state: cases.state })
-		expect(wrapper.find(emptyContentMessageSelector).exists()).toBeTruthy()
-		expect(wrapper.find(emptyContentMessageSelector).text()).toMatch(cases.message)
+	describe('content title', () => {
+		it('should not be displayed if the admin config status is not ok', () => {
+			wrapper = getWrapper({ adminConfigStatus: false })
+			expect(wrapper.find(emptyContentMessageSelector).exists()).toBe(false)
+		})
+		it.each([{
+			state: 'no-token',
+			message: 'No OpenProject account connected',
+		}, {
+			state: 'error',
+			message: 'Unexpected Error',
+		}, {
+			state: 'connection-error',
+			message: 'Error connecting to OpenProject',
+		}, {
+			state: 'failed-fetching-workpackages',
+			message: 'Could not fetch work packages from OpenProject',
+		}, {
+			state: 'ok',
+			message: 'No workspaces linked yet',
+		}, {
+			state: 'something else',
+			message: 'invalid state',
+		}])('shows the correct empty message depending on states if admin config status is ok', async (cases) => {
+			wrapper = getWrapper({ state: cases.state, adminConfigStatus: true })
+			expect(wrapper.find(emptyContentMessageSelector).exists()).toBeTruthy()
+			expect(wrapper.find(emptyContentMessageSelector).text()).toMatch(cases.message)
+		})
 	})
 })
 
@@ -61,7 +63,7 @@ function getWrapper(propsData = {}) {
 		propsData: {
 			state: 'ok',
 			requestUrl: 'http://openproject/',
-			showConnect: false,
+			adminConfigStatus: false,
 			...propsData,
 		},
 	})

--- a/tests/jest/components/tab/EmptyContent.spec.js
+++ b/tests/jest/components/tab/EmptyContent.spec.js
@@ -3,42 +3,29 @@ import { shallowMount, createLocalVue } from '@vue/test-utils'
 import EmptyContent from '../../../../src/components/tab/EmptyContent'
 const localVue = createLocalVue()
 
-function getWrapper(propsData = {}) {
-	return shallowMount(EmptyContent, {
-		localVue,
-		mocks: {
-			t: (msg) => msg,
-		},
-		propsData,
-	})
-}
 describe('EmptyContent.vue Test', () => {
 	let wrapper
 	const emptyContentMessageSelector = '.empty-content--title'
 	const connectButtonSelector = 'oauthconnectbutton-stub'
 
-	it.each([{
-		state: 'ok',
-		viewed: false,
-	}, {
-		state: 'no-token',
-		viewed: true,
-	}, {
-		state: 'error',
-		viewed: true,
-	}])('shows or hides the connect button depending on the state', (cases) => {
-		wrapper = shallowMount(EmptyContent, {
-			localVue,
-			mocks: {
-				t: (msg) => msg,
-			},
-			propsData: {
-				state: cases.state,
-				requestUrl: 'http://openproject/oauth/',
-			},
+	describe('connect button', () => {
+		it('should not be displayed if the "showConnect" prop is set as false', () => {
+			wrapper = getWrapper({ showConnect: false })
+			expect(wrapper.find(connectButtonSelector).exists()).toBe(false)
 		})
-		wrapper = getWrapper({ state: cases.state })
-		expect(wrapper.find(connectButtonSelector).exists()).toBe(cases.viewed)
+		it.each([{
+			state: 'ok',
+			viewed: false,
+		}, {
+			state: 'no-token',
+			viewed: true,
+		}, {
+			state: 'error',
+			viewed: true,
+		}])('shows or hides the connect button depending on the state if the "showConnect" prop is set as true', (cases) => {
+			wrapper = getWrapper({ state: cases.state, showConnect: true })
+			expect(wrapper.find(connectButtonSelector).exists()).toBe(cases.viewed)
+		})
 	})
 	it.each([{
 		state: 'no-token',
@@ -59,18 +46,23 @@ describe('EmptyContent.vue Test', () => {
 		state: 'something else',
 		message: 'invalid state',
 	}])('shows the correct empty message depending on states', async (cases) => {
-		wrapper = shallowMount(EmptyContent, {
-			localVue,
-			mocks: {
-				t: (msg) => msg,
-			},
-			propsData: {
-				state: cases.state,
-				requestUrl: 'http://openproject/oauth/',
-			},
-		})
 		wrapper = getWrapper({ state: cases.state })
 		expect(wrapper.find(emptyContentMessageSelector).exists()).toBeTruthy()
 		expect(wrapper.find(emptyContentMessageSelector).text()).toMatch(cases.message)
 	})
 })
+
+function getWrapper(propsData = {}) {
+	return shallowMount(EmptyContent, {
+		localVue,
+		mocks: {
+			t: (msg) => msg,
+		},
+		propsData: {
+			state: 'ok',
+			requestUrl: 'http://openproject/',
+			showConnect: false,
+			...propsData,
+		},
+	})
+}

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -1279,7 +1279,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 	}
 
 	/**
-	 * @return array
+	 * @return array[]
 	 */
 	public function adminConfigStatusProvider(): array {
 		return [

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -1277,4 +1277,55 @@ class OpenProjectAPIServiceTest extends TestCase {
 			'admin'
 		);
 	}
+
+	/**
+	 * @return array
+	 */
+	public function adminConfigStatusProvider(): array {
+		return [
+			[
+				'client_id' => '',
+				'client_secret' => '',
+				'oauth_instance_url' => '',
+				'expected' => false,
+			],
+			[
+				'client_id' => 'clientID',
+				'client_secret' => '',
+				'oauth_instance_url' => 'https://openproject',
+				'expected' => false,
+			],
+			[
+				'client_id' => 'clientID',
+				'client_secret' => 'clientSecret',
+				'oauth_instance_url' => '',
+				'expected' => false,
+			],
+			[
+				'client_id' => 'clientID',
+				'client_secret' => 'clientSecret',
+				'oauth_instance_url' => 'https://openproject',
+				'expected' => true,
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider adminConfigStatusProvider
+	 * @return void
+	 */
+	public function testIsAdminConfigOkNoClientId(
+		string $client_id, string $client_secret, string $oauth_instance_url, bool $expected
+	) {
+		$configMock = $this->getMockBuilder(IConfig::class)->getMock();
+		$configMock
+			->method('getAppValue')
+			->withConsecutive(
+				['integration_openproject', 'client_id'],
+				['integration_openproject', 'client_secret'],
+				['integration_openproject', 'oauth_instance_url'],
+			)->willReturnOnConsecutiveCalls($client_id, $client_secret, $oauth_instance_url);
+
+		$this->assertSame($expected, $this->service::isAdminConfigOk($configMock));
+	}
 }

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -1279,7 +1279,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 	}
 
 	/**
-	 * @return array[]
+	 * @return array<mixed>
 	 */
 	public function adminConfigStatusProvider(): array {
 		return [
@@ -1304,7 +1304,31 @@ class OpenProjectAPIServiceTest extends TestCase {
 			[
 				'client_id' => 'clientID',
 				'client_secret' => 'clientSecret',
+				'oauth_instance_url' => 'https://',
+				'expected' => false,
+			],
+			[
+				'client_id' => 'clientID',
+				'client_secret' => 'clientSecret',
+				'oauth_instance_url' => 'openproject.com',
+				'expected' => false,
+			],
+			[
+				'client_id' => 'clientID',
+				'client_secret' => 'clientSecret',
 				'oauth_instance_url' => 'https://openproject',
+				'expected' => true,
+			],
+			[
+				'client_id' => 'clientID',
+				'client_secret' => 'clientSecret',
+				'oauth_instance_url' => 'https://openproject.com/',
+				'expected' => true,
+			],
+			[
+				'client_id' => 'clientID',
+				'client_secret' => 'clientSecret',
+				'oauth_instance_url' => 'https://openproject.com',
 				'expected' => true,
 			],
 		];
@@ -1314,7 +1338,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 	 * @dataProvider adminConfigStatusProvider
 	 * @return void
 	 */
-	public function testIsAdminConfigOkNoClientId(
+	public function testIsAdminConfigOk(
 		string $client_id, string $client_secret, string $oauth_instance_url, bool $expected
 	) {
 		$configMock = $this->getMockBuilder(IConfig::class)->getMock();


### PR DESCRIPTION
## Description
For dashboard widget, sidebar tab, and personal setting:
- check if the admin config is ok (if all values are set and OAuth instance URL is valid)
- show connect button if ok
- show message `Failed to establish the connection. Please contact your administrator.` if not ok

### Related
https://community.openproject.org/projects/nextcloud-integration/work_packages/41211

### Screenshots
![Screenshot from 2022-03-16 11-19-34](https://user-images.githubusercontent.com/39373750/158523452-9f7a8849-8ef1-432a-a33e-4568cc7aea79.png)

