### PR TITLE
refactor `getOpenProjectOauthURL` so that it throws an exception if any needed value is not set

### DIFF
--- a/lib/Dashboard/OpenProjectWidget.php
+++ b/lib/Dashboard/OpenProjectWidget.php
@@ -106,10 +106,11 @@ class OpenProjectWidget implements IWidget {
 		Util::addScript(Application::APP_ID, Application::APP_ID . '-dashboard');
 		Util::addStyle(Application::APP_ID, 'dashboard');
 
-		$requestUrl = OpenProjectAPIService::getOpenProjectOauthURL($this->config, $this->url);
-		$isAdminConfigOk = OpenProjectAPIService::isAdminConfigOk($this->config);
-
-		$this->initialStateService->provideInitialState('request-url', $requestUrl);
-		$this->initialStateService->provideInitialState('admin-config-status', $isAdminConfigOk);
+		try {
+			$requestUrl = OpenProjectAPIService::getOpenProjectOauthURL($this->config, $this->url);
+			$this->initialStateService->provideInitialState('request-url', $requestUrl);
+		} catch (\Exception $e) {
+			$this->initialStateService->provideInitialState('request-url', false);
+		}
 	}
 }

--- a/lib/Listener/LoadSidebarScript.php
+++ b/lib/Listener/LoadSidebarScript.php
@@ -75,10 +75,11 @@ class LoadSidebarScript implements IEventListener {
 		}
 		Util::addStyle(Application::APP_ID, 'tab');
 
-		$requestUrl = OpenProjectAPIService::getOpenProjectOauthURL($this->config, $this->url);
-		$isAdminConfigOk = OpenProjectAPIService::isAdminConfigOk($this->config);
-
-		$this->initialStateService->provideInitialState('request-url', $requestUrl);
-		$this->initialStateService->provideInitialState('admin-config-status', $isAdminConfigOk);
+		try {
+			$requestUrl = OpenProjectAPIService::getOpenProjectOauthURL($this->config, $this->url);
+			$this->initialStateService->provideInitialState('request-url', $requestUrl);
+		} catch (\Exception $e) {
+			$this->initialStateService->provideInitialState('request-url', false);
+		}
 	}
 }

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -582,8 +582,12 @@ class OpenProjectAPIService {
 	 * generates an oauth url to OpenProject containing client_id & redirect_uri as parameter
 	 * please note that the state parameter is still missing, that needs to be generated dynamically
 	 * and saved to the DB before calling the OAuth URI
+	 * @throws Exception
 	 */
 	public static function getOpenProjectOauthURL(IConfig $config, IURLGenerator $urlGenerator): string {
+		if (!self::isAdminConfigOk($config)) {
+			throw new \Exception('OpenProject admin config is not valid!');
+		}
 		$clientID = $config->getAppValue(Application::APP_ID, 'client_id');
 		$oauthUrl = $config->getAppValue(Application::APP_ID, 'oauth_instance_url');
 		$redirectUri = $urlGenerator->linkToRouteAbsolute(Application::APP_ID . '.config.oauthRedirect');

--- a/lib/Settings/Personal.php
+++ b/lib/Settings/Personal.php
@@ -51,21 +51,23 @@ class Personal implements ISettings {
 		$notificationEnabled = $this->config->getUserValue($this->userId, Application::APP_ID, 'notification_enabled', '0');
 		$navigationEnabled = $this->config->getUserValue($this->userId, Application::APP_ID, 'navigation_enabled', '0');
 
-		$isAdminConfigOk = OpenProjectAPIService::isAdminConfigOk($this->config);
-
-		// for OAuth
-		$requestUrl = OpenProjectAPIService::getOpenProjectOauthURL($this->config, $this->url);
-
 		$userConfig = [
 			'token' => $token,
 			'search_enabled' => ($searchEnabled === '1'),
 			'notification_enabled' => ($notificationEnabled === '1'),
 			'navigation_enabled' => ($navigationEnabled === '1'),
 			'user_name' => $userName,
-			'request_url' => $requestUrl,
 		];
-		$this->initialStateService->provideInitialState('user-config', $userConfig);
-		$this->initialStateService->provideInitialState('admin-config-status', $isAdminConfigOk);
+
+		try {
+			$requestUrl = OpenProjectAPIService::getOpenProjectOauthURL($this->config, $this->url);
+			$userConfig['request_url'] = $requestUrl;
+		} catch (\Exception $e) {
+			$userConfig['request_url'] = false;
+		} finally {
+			$this->initialStateService->provideInitialState('user-config', $userConfig);
+		}
+
 		return new TemplateResponse(Application::APP_ID, 'personalSettings');
 	}
 

--- a/makefile
+++ b/makefile
@@ -60,6 +60,10 @@ phpstan:
 	composer run phpstan
 
 .PHONY: test
+phpunit:
+	vendor/phpunit/phpunit/phpunit
+
+.PHONY: test
 test:
 	npm run test:unit
 	vendor/phpunit/phpunit/phpunit

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"stylelint": "stylelint css src",
 		"stylelint:fix": "stylelint css src --fix",
 		"test:unit": "jest --silent",
-		"test:unit:watch": "jest --watch"
+		"test:unit:watch": "jest --watch --no-coverage"
 	},
 	"repository": {
 		"type": "git",

--- a/src/components/OAuthConnectButton.vue
+++ b/src/components/OAuthConnectButton.vue
@@ -1,5 +1,5 @@
 <template>
-	<button v-if="adminConfigStatus"
+	<button v-if="!!requestUrl"
 		class="oauth-connect--button"
 		@click="onOAuthClick">
 		<span class="icon icon-external" />

--- a/src/components/OAuthConnectButton.vue
+++ b/src/components/OAuthConnectButton.vue
@@ -20,12 +20,8 @@ export default {
 
 	props: {
 		requestUrl: {
-			type: String,
+			type: [String, Boolean],
 			required: true,
-		},
-		adminConfigStatus: {
-			type: Boolean,
-			default: false,
 		},
 	},
 

--- a/src/components/PersonalSettings.vue
+++ b/src/components/PersonalSettings.vue
@@ -40,7 +40,7 @@
 					@input="onNotificationChange">
 				<label for="notification-openproject">{{ t('integration_openproject', 'Enable notifications for activity in my work packages') }}</label>
 			</div>
-			<OAuthConnectButton v-else :request-url="requestUrl" :admin-config-status="adminConfigStatus" />
+			<OAuthConnectButton v-else :request-url="requestUrl" />
 		</div>
 	</div>
 </template>
@@ -61,20 +61,19 @@ export default {
 		SettingsTitle, OAuthConnectButton,
 	},
 
-	props: [],
-
 	data() {
 		return {
 			loading: false,
 			state: loadState('integration_openproject', 'user-config'),
-			requestUrl: loadState('integration_openproject', 'user-config').request_url,
-			adminConfigStatus: loadState('integration_openproject', 'admin-config-status'),
 		}
 	},
 
 	computed: {
+		requestUrl() {
+			return this.state.request_url
+		},
 		connected() {
-			if (!this.adminConfigStatus) return false
+			if (!this.requestUrl) return false
 			return this.state.token && this.state.token !== ''
 				&& this.state.user_name && this.state.user_name !== ''
 		},

--- a/src/components/tab/EmptyContent.vue
+++ b/src/components/tab/EmptyContent.vue
@@ -4,11 +4,11 @@
 			<div class="empty-content--icon">
 				<img :src="flowSvg" alt="flow">
 			</div>
-			<div v-if="adminConfigStatus" class="empty-content--title">
+			<div v-if="!!requestUrl" class="empty-content--title">
 				{{ emptyContentMessage }}
 			</div>
 			<div v-if="showConnectButton" class="empty-content--connect-button">
-				<OAuthConnectButton :request-url="requestUrl" :admin-config-status="adminConfigStatus" />
+				<OAuthConnectButton :request-url="requestUrl" />
 			</div>
 		</div>
 	</div>
@@ -29,16 +29,12 @@ export default {
 			default: 'ok',
 		},
 		requestUrl: {
-			type: String,
+			type: [String, Boolean],
 			required: true,
 		},
 		errorMessage: {
 			type: String,
 			default: '',
-		},
-		adminConfigStatus: {
-			type: Boolean,
-			required: true,
 		},
 	},
 	data() {

--- a/src/components/tab/EmptyContent.vue
+++ b/src/components/tab/EmptyContent.vue
@@ -2,7 +2,8 @@
 	<div class="empty-content">
 		<div class="empty-content--wrapper">
 			<div class="empty-content--icon">
-				<img :src="flowSvg" alt="flow">
+				<img v-if="!!requestUrl" :src="flowSvg" alt="flow">
+				<div v-else class="icon-error" />
 			</div>
 			<div v-if="!!requestUrl" class="empty-content--title">
 				{{ emptyContentMessage }}
@@ -69,7 +70,7 @@ export default {
 
 <style scoped lang="scss">
 .empty-content {
-	height: 100%;
+  height: 100%;
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -81,9 +82,12 @@ export default {
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		img {
+		img, .icon-error {
 			height: 50px;
 			width: 50px;
+		}
+		.icon-error {
+			background-size: 50px;
 		}
 	}
 	&--title {

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -92,7 +92,9 @@ export default {
 			return ''
 		},
 		emptyContentIcon() {
-			if (this.state === 'no-token') {
+			if (!this.requestUrl) {
+				return 'icon-error'
+			} else if (this.state === 'no-token') {
 				return 'icon-openproject'
 			} else if (this.state === 'error') {
 				return 'icon-close'

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -7,11 +7,11 @@
 			<EmptyContent v-if="emptyContentMessage"
 				:icon="emptyContentIcon">
 				<template #desc>
-					<div v-if="adminConfigStatus">
+					<div v-if="!!requestUrl">
 						{{ emptyContentMessage }}
 					</div>
 					<div v-if="showOauthConnect" class="connect-button">
-						<OAuthConnectButton :request-url="requestUrl" :admin-config-status="adminConfigStatus" />
+						<OAuthConnectButton :request-url="requestUrl" />
 					</div>
 				</template>
 			</EmptyContent>
@@ -51,7 +51,6 @@ export default {
 			loop: null,
 			state: 'loading',
 			requestUrl: loadState('integration_openproject', 'request-url'),
-			adminConfigStatus: loadState('integration_openproject', 'admin-config-status'),
 			settingsUrl: generateUrl('/settings/user/connected-accounts'),
 			themingColor: OCA.Theming ? OCA.Theming.color.replace('#', '') : '0082C9',
 			windowVisibility: true,

--- a/src/views/ProjectsTab.vue
+++ b/src/views/ProjectsTab.vue
@@ -22,7 +22,8 @@
 
 <template>
 	<div class="projects">
-		<SearchInput :file-info="fileInfo"
+		<SearchInput v-if="!!requestUrl"
+			:file-info="fileInfo"
 			@saved="onSaved" />
 		<div v-if="isLoading" class="icon-loading" />
 		<div v-else-if="workpackages.length > 0" id="openproject-linked-workpackages">

--- a/src/views/ProjectsTab.vue
+++ b/src/views/ProjectsTab.vue
@@ -36,8 +36,7 @@
 		<EmptyContent v-else
 			id="openproject-empty-content"
 			:state="state"
-			:request-url="requestUrl"
-			:admin-config-status="adminConfigStatus" />
+			:request-url="requestUrl" />
 	</div>
 </template>
 
@@ -59,11 +58,10 @@ export default {
 	},
 	data: () => ({
 		error: '',
-		fileInfo: { },
+		fileInfo: {},
 		state: 'loading',
 		workpackages: [],
 		requestUrl: loadState('integration_openproject', 'request-url'),
-		adminConfigStatus: loadState('integration_openproject', 'admin-config-status'),
 	}),
 	computed: {
 		isLoading() {

--- a/tests/jest/components/OAuthConnectButton.spec.js
+++ b/tests/jest/components/OAuthConnectButton.spec.js
@@ -18,13 +18,13 @@ describe('OAuthConnectButton.vue Test', () => {
 		window.location = location
 		jest.clearAllMocks()
 	})
-	describe('when admin config status is not ok', () => {
+	describe('when the request url is not valid', () => {
 		it('should show message', async () => {
-			wrapper = getWrapper({ adminConfigStatus: false })
+			wrapper = getWrapper({ requestUrl: false })
 			expect(wrapper).toMatchSnapshot()
 		})
 	})
-	describe('when admin config status is ok', () => {
+	describe('when the request url is valid', () => {
 		beforeEach(() => {
 			delete window.location
 			window.location = { replace: jest.fn() }
@@ -34,7 +34,7 @@ describe('OAuthConnectButton.vue Test', () => {
 			generateCodeChallengeSpy = jest.spyOn(
 				OAuthConnectButton.methods, 'generateCodeChallenge'
 			)
-			wrapper = getWrapper({ adminConfigStatus: true })
+			wrapper = getWrapper()
 		})
 		describe('on successful saving of the state & challenge', () => {
 			beforeEach(() => {
@@ -103,7 +103,6 @@ function getWrapper(props = {}) {
 		},
 		propsData: {
 			requestUrl: 'http://openproject/oauth/',
-			adminConfigStatus: false,
 			...props,
 		},
 	})

--- a/tests/jest/components/PersonalSettings.spec.js
+++ b/tests/jest/components/PersonalSettings.spec.js
@@ -7,12 +7,10 @@ import * as initialState from '@nextcloud/initial-state'
 const localVue = createLocalVue()
 
 // eslint-disable-next-line no-import-assign
-initialState.loadState = jest.fn((key, value) => {
-	if (value === 'user-config') {
-		return {
-			request_url: 'https://nextcloud.com/',
-		}
-	} else if (value === 'admin-config-status') return false
+initialState.loadState = jest.fn(() => {
+	return {
+		request_url: 'https://nextcloud.com/',
+	}
 })
 
 describe('PersonalSettings.vue Test', () => {
@@ -34,7 +32,7 @@ describe('PersonalSettings.vue Test', () => {
 			})
 		})
 
-		describe('when admin config status is ok', () => {
+		describe('when the request url is valid', () => {
 			describe.each([
 				{ user_name: 'test', token: '' },
 				{ user_name: 'test', token: null },
@@ -48,8 +46,10 @@ describe('PersonalSettings.vue Test', () => {
 			])('when username or token not given', (cases) => {
 				beforeEach(async () => {
 					await wrapper.setData({
-						adminConfigStatus: true,
-						state: cases,
+						state: {
+							request_url: 'http://someurl.com',
+							...cases,
+						},
 					})
 				})
 				it('oAuth connect button is displayed', () => {
@@ -65,8 +65,7 @@ describe('PersonalSettings.vue Test', () => {
 			describe('when username and token are given', () => {
 				beforeEach(async () => {
 					await wrapper.setData({
-						adminConfigStatus: true,
-						state: { user_name: 'test', token: '123' },
+						state: { user_name: 'test', token: '123', request_url: 'http://someurl.com' },
 					})
 				})
 				it('oAuth connect button is not displayed', () => {
@@ -83,18 +82,16 @@ describe('PersonalSettings.vue Test', () => {
 				})
 			})
 		})
-		describe('when admin config status is not ok', () => {
+		describe('when request url is not valid', () => {
 			beforeEach(async () => {
 				await wrapper.setData({
-					adminConfigStatus: false,
-					state: { user_name: 'test', token: '123' },
+					state: { user_name: 'test', token: '123', request_url: false },
 				})
 			})
 			it('should set proper props to the oauth connect component', () => {
 				expect(wrapper.find(oAuthButtonSelector).exists()).toBeTruthy()
 				expect(wrapper.find(oAuthButtonSelector).props()).toMatchObject({
-					requestUrl: 'https://nextcloud.com/',
-					adminConfigStatus: false,
+					requestUrl: false,
 				})
 			})
 		})

--- a/tests/jest/components/__snapshots__/OAuthConnectButton.spec.js.snap
+++ b/tests/jest/components/__snapshots__/OAuthConnectButton.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`OAuthConnectButton.vue Test when admin config status is not ok should show message 1`] = `
+exports[`OAuthConnectButton.vue Test when the request url is not valid should show message 1`] = `
 <div class="oauth-connect--message">
   Settings of the OpenProject integration app are not complete. Please contact your Nextcloud administrator.
 </div>

--- a/tests/jest/components/tab/EmptyContent.spec.js
+++ b/tests/jest/components/tab/EmptyContent.spec.js
@@ -19,13 +19,13 @@ describe('EmptyContent.vue Test', () => {
 			state: 'error',
 			viewed: true,
 		}])('should be displayed depending on the state', (cases) => {
-			wrapper = getWrapper({ state: cases.state, adminConfigStatus: true })
+			wrapper = getWrapper({ state: cases.state })
 			expect(wrapper.find(connectButtonSelector).exists()).toBe(cases.viewed)
 		})
 	})
 	describe('content title', () => {
-		it('should not be displayed if the admin config status is not ok', () => {
-			wrapper = getWrapper({ adminConfigStatus: false })
+		it('should not be displayed if the request url is not valid', () => {
+			wrapper = getWrapper({ requestUrl: false })
 			expect(wrapper.find(emptyContentMessageSelector).exists()).toBe(false)
 		})
 		it.each([{
@@ -46,7 +46,7 @@ describe('EmptyContent.vue Test', () => {
 		}, {
 			state: 'something else',
 			message: 'invalid state',
-		}])('shows the correct empty message depending on states if admin config status is ok', async (cases) => {
+		}])('shows the correct empty message depending on states if the request url is valid', async (cases) => {
 			wrapper = getWrapper({ state: cases.state, adminConfigStatus: true })
 			expect(wrapper.find(emptyContentMessageSelector).exists()).toBeTruthy()
 			expect(wrapper.find(emptyContentMessageSelector).text()).toMatch(cases.message)
@@ -63,7 +63,6 @@ function getWrapper(propsData = {}) {
 		propsData: {
 			state: 'ok',
 			requestUrl: 'http://openproject/',
-			adminConfigStatus: false,
 			...propsData,
 		},
 	})

--- a/tests/jest/views/ProjectsTab.spec.js
+++ b/tests/jest/views/ProjectsTab.spec.js
@@ -15,11 +15,26 @@ describe('ProjectsTab.vue Test', () => {
 	const emptyContentSelector = '#openproject-empty-content'
 	const workPackagesSelector = '#openproject-linked-workpackages'
 	const existingRelationSelector = '.existing-relations'
+	const searchInputStubSelector = 'searchinput-stub'
 
 	beforeEach(() => {
 		// eslint-disable-next-line no-import-assign
 		initialState.loadState = jest.fn(() => 'https://openproject/oauth/')
 		wrapper = shallowMount(ProjectsTab, { localVue })
+	})
+	describe('search input existence', () => {
+		it('should not exist if the request url is not valid', async () => {
+			await wrapper.setData({
+				requestUrl: false,
+			})
+			expect(wrapper.find(searchInputStubSelector).exists()).toBeFalsy()
+		})
+		it('should exist if the request url is valid', async () => {
+			await wrapper.setData({
+				requestUrl: 'https://open.project/',
+			})
+			expect(wrapper.find(searchInputStubSelector).exists()).toBeTruthy()
+		})
 	})
 	describe('loading icon', () => {
 		it('shows the loading icon during "loading" state', async () => {

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -821,8 +821,11 @@ class OpenProjectAPIServiceTest extends TestCase {
 			->method('getAppValue')
 			->withConsecutive(
 				['integration_openproject', 'client_id'],
+				['integration_openproject', 'client_secret'],
 				['integration_openproject', 'oauth_instance_url'],
-			)->willReturnOnConsecutiveCalls('clientID', 'https://openproject');
+				['integration_openproject', 'client_id'],
+				['integration_openproject', 'oauth_instance_url'],
+			)->willReturnOnConsecutiveCalls('clientID', 'SECRET', 'https://openproject', 'clientID', 'https://openproject');
 
 		$url = $this->createMock(IURLGenerator::class);
 		$url->expects($this->once())
@@ -837,6 +840,25 @@ class OpenProjectAPIServiceTest extends TestCase {
 			'&response_type=code',
 			$result
 		);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testGetOpenProjectOauthURLWithInvalidAdminConfig() {
+		$url = $this->createMock(IURLGenerator::class);
+		$configMock = $this->getMockBuilder(IConfig::class)->getMock();
+		$configMock
+			->method('getAppValue')
+			->withConsecutive(
+				['integration_openproject', 'client_id'],
+				['integration_openproject', 'client_secret'],
+				['integration_openproject', 'oauth_instance_url'],
+			)->willReturnOnConsecutiveCalls('clientid', 'clientsecret', 'Openproject');
+
+		$this->expectException(\Exception::class);
+		$this->expectExceptionMessage('OpenProject admin config is not valid!');
+		$this->service::getOpenProjectOauthURL($configMock, $url);
 	}
 
 	/**


### PR DESCRIPTION
### Description
- throw exception from `getOpenProjectOauthURL` if request url is not valid
- show admin settings invalid message if request URL is not valid in dashboard widget, sidebar, and personal settings components
- show/hide search input in the sidebar tab according to the request URL
- error icon when request URL is invalid for dashboard widget and empty content in the sidebar

### Screenshots
![Screenshot from 2022-03-18 10-42-53](https://user-images.githubusercontent.com/39373750/158941562-d1c25a69-c92b-450a-b08c-7116bc7c2ebb.png)

### Related
OP#41211 > 3rd todo item
https://community.openproject.org/projects/nextcloud-integration/work_packages/41211