### PR TITLE
[OP#41430] periodically check openproject oauth token

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -21,5 +21,6 @@ return [
 		['name' => 'openProjectAPI#linkWorkPackageToFile', 'url' => '/work-packages', 'verb' => 'POST'],
 		['name' => 'openProjectAPI#getOpenProjectWorkPackageStatus', 'url' => '/statuses/{id}', 'verb' => 'GET'],
 		['name' => 'openProjectAPI#getOpenProjectWorkPackageType', 'url' => '/types/{id}', 'verb' => 'GET'],
+		['name' => 'openProjectAPI#getOpenProjectOauthTokenStatus', 'url' => '/oauth-token', 'verb' => 'GET'],
 	]
 ];

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -685,6 +685,33 @@ class OpenProjectAPIService {
 	}
 
 	/**
+	 * authenticated request to get status of a work package
+	 *
+	 * @param string $url
+	 * @param string $accessToken
+	 * @param string $refreshToken
+	 * @param string $clientID
+	 * @param string $clientSecret
+	 * @param string $userId
+	 * @param string $typeId
+	 * @return bool
+	 */
+	public function isOpenProjectOauthTokenValid(
+		string $url,
+		string $accessToken,
+		string $refreshToken,
+		string $clientID,
+		string $clientSecret,
+		string $userId
+	): bool {
+		$result = $this->request(
+			$url, $accessToken, $refreshToken, $clientID, $clientSecret, $userId, 'users/me');
+
+
+		return (isset($result['login']) && $result['login'] !== '');
+	}
+
+	/**
 	 * checks if every admin config variables are set
 	 * checks if the oauth instance url is valid
 	 *

--- a/src/views/ProjectsTab.vue
+++ b/src/views/ProjectsTab.vue
@@ -51,6 +51,8 @@ import { generateUrl } from '@nextcloud/router'
 import SearchInput from '../components/tab/SearchInput'
 import { loadState } from '@nextcloud/initial-state'
 
+const POLLING_INTERVAL = 30
+
 export default {
 	name: 'ProjectsTab',
 	components: {
@@ -70,6 +72,10 @@ export default {
 		isLoading() {
 			return this.state === 'loading'
 		},
+	},
+	beforeMount() {
+		this.refreshOauthToken()
+		setInterval(this.refreshOauthToken, POLLING_INTERVAL * 1000)
 	},
 	methods: {
 		/**
@@ -91,6 +97,10 @@ export default {
 		},
 		onSaved(data) {
 			this.workpackages.push(data)
+		},
+		async refreshOauthToken() {
+			const url = generateUrl('/apps/integration_openproject/oauth-token')
+			await axios.get(url)
 		},
 		async fetchWorkpackages(fileId) {
 			const req = {}


### PR DESCRIPTION
check periodically if the oauth token is still valid (by querying `/users/me`) and if the endpoint returns an anonymous user try to refresh the token. If the refresh also failed delete all tokens and by that force the user to login again

https://user-images.githubusercontent.com/2425577/158577046-da262b31-6370-40c1-a289-c3d4ea74c563.mp4

.