### PR TITLE
l10n: Correct instance name

### DIFF
--- a/src/components/OAuthConnectButton.vue
+++ b/src/components/OAuthConnectButton.vue
@@ -32,7 +32,7 @@ export default {
 
 	computed: {
 		adminConfigNotOkMessage() {
-			return t('integration_openproject', 'Settings of the OpenProject integration app are not complete. Please contact your NextCloud administrator.')
+			return t('integration_openproject', 'Settings of the OpenProject integration app are not complete. Please contact your Nextcloud administrator.')
 		},
 	},
 

--- a/tests/jest/components/__snapshots__/OAuthConnectButton.spec.js.snap
+++ b/tests/jest/components/__snapshots__/OAuthConnectButton.spec.js.snap
@@ -2,6 +2,6 @@
 
 exports[`OAuthConnectButton.vue Test when admin config status is not ok should show message 1`] = `
 <div class="oauth-connect--message">
-  Settings of the OpenProject integration app are not complete. Please contact your NextCloud administrator.
+  Settings of the OpenProject integration app are not complete. Please contact your Nextcloud administrator.
 </div>
 `;


### PR DESCRIPTION
_Reported by a translator from Transifex._

Signed-off-by: Valdnet <47037905+Valdnet@users.noreply.github.com>