### PR TITLE
get OAuth config in request function and don't pass the data through the different layers

### DIFF
--- a/lib/Controller/OpenProjectAPIController.php
+++ b/lib/Controller/OpenProjectAPIController.php
@@ -125,9 +125,7 @@ class OpenProjectAPIController extends Controller {
 		if ($this->accessToken === '' || !OpenProjectAPIService::validateOpenProjectURL($this->openprojectUrl)) {
 			return new DataResponse('', Http::STATUS_BAD_REQUEST);
 		}
-		$result = $this->openprojectAPIService->getNotifications(
-			$this->openprojectUrl, $this->accessToken, $this->refreshToken, $this->clientID, $this->clientSecret, $this->userId, $since, 7
-		);
+		$result = $this->openprojectAPIService->getNotifications($this->userId, $since, 7);
 		if (!isset($result['error'])) {
 			$response = new DataResponse($result);
 		} else {
@@ -153,11 +151,6 @@ class OpenProjectAPIController extends Controller {
 			);
 		}
 		$result = $this->openprojectAPIService->searchWorkPackage(
-			$this->openprojectUrl,
-			$this->accessToken,
-			$this->refreshToken,
-			$this->clientID,
-			$this->clientSecret,
 			$this->userId,
 			$searchQuery,
 			$fileId
@@ -192,11 +185,6 @@ class OpenProjectAPIController extends Controller {
 
 		try {
 			$result = $this->openprojectAPIService->linkWorkPackageToFile(
-				$this->openprojectUrl,
-				$this->accessToken,
-				$this->refreshToken,
-				$this->clientID,
-				$this->clientSecret,
 				$workpackageId,
 				$fileId,
 				$fileName,
@@ -227,7 +215,7 @@ class OpenProjectAPIController extends Controller {
 			return new DataResponse('', Http::STATUS_BAD_REQUEST);
 		}
 		$result = $this->openprojectAPIService->getOpenProjectWorkPackageStatus(
-			$this->openprojectUrl, $this->accessToken, $this->refreshToken, $this->clientID, $this->clientSecret, $this->userId, $id
+			$this->userId, $id
 		);
 		if (!isset($result['error'])) {
 			$response = new DataResponse($result);
@@ -251,7 +239,7 @@ class OpenProjectAPIController extends Controller {
 			return new DataResponse('', Http::STATUS_BAD_REQUEST);
 		}
 		$result = $this->openprojectAPIService->getOpenProjectWorkPackageType(
-			$this->openprojectUrl, $this->accessToken, $this->refreshToken, $this->clientID, $this->clientSecret, $this->userId, $id
+			$this->userId, $id
 		);
 		if (!isset($result['error'])) {
 			$response = new DataResponse($result);

--- a/lib/Search/OpenProjectSearchProvider.php
+++ b/lib/Search/OpenProjectSearchProvider.php
@@ -126,16 +126,13 @@ class OpenProjectSearchProvider implements IProvider {
 
 		$openprojectUrl = $this->config->getAppValue(Application::APP_ID, 'oauth_instance_url');
 		$accessToken = $this->config->getUserValue($user->getUID(), Application::APP_ID, 'token');
-		$refreshToken = $this->config->getUserValue($user->getUID(), Application::APP_ID, 'refresh_token');
-		$clientID = $this->config->getAppValue(Application::APP_ID, 'client_id');
-		$clientSecret = $this->config->getAppValue(Application::APP_ID, 'client_secret');
 
 		$searchEnabled = $this->config->getUserValue($user->getUID(), Application::APP_ID, 'search_enabled', '0') === '1';
 		if ($accessToken === '' || !$searchEnabled) {
 			return SearchResult::paginated($this->getName(), [], 0);
 		}
 
-		$searchResults = $this->service->searchWorkPackage($openprojectUrl, $accessToken, $refreshToken, $clientID, $clientSecret, $user->getUID(), $term);
+		$searchResults = $this->service->searchWorkPackage($user->getUID(), $term);
 		$searchResults = array_slice($searchResults, $offset, $limit);
 
 		if (isset($searchResults['error'])) {

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -116,7 +116,6 @@ class OpenProjectAPIService {
 		$accessToken = $this->config->getUserValue($userId, Application::APP_ID, 'token');
 		$notificationEnabled = ($this->config->getUserValue($userId, Application::APP_ID, 'notification_enabled', '0') === '1');
 		if ($accessToken && $notificationEnabled) {
-			$refreshToken = $this->config->getUserValue($userId, Application::APP_ID, 'refresh_token');
 			$clientID = $this->config->getAppValue(Application::APP_ID, 'client_id');
 			$clientSecret = $this->config->getAppValue(Application::APP_ID, 'client_secret');
 			$openprojectUrl = $this->config->getAppValue(Application::APP_ID, 'oauth_instance_url');
@@ -127,9 +126,7 @@ class OpenProjectAPIService {
 				$myOPUserId = $this->config->getUserValue($userId, Application::APP_ID, 'user_id');
 				if ($myOPUserId !== '') {
 					$myOPUserId = (int) $myOPUserId;
-					$notifications = $this->getNotifications(
-						$openprojectUrl, $accessToken, $refreshToken, $clientID, $clientSecret, $userId, $lastNotificationCheck
-					);
+					$notifications = $this->getNotifications($userId, $lastNotificationCheck);
 					if (!isset($notifications['error']) && count($notifications) > 0) {
 						$newLastNotificationCheck = $notifications[0]['updatedAt'];
 						$this->config->setUserValue($userId, Application::APP_ID, 'last_notification_check', $newLastNotificationCheck);
@@ -198,19 +195,14 @@ class OpenProjectAPIService {
 	}
 
 	/**
-	 * @param string $url
-	 * @param string $accessToken
-	 * @param string $refreshToken
-	 * @param string $clientID
-	 * @param string $clientSecret
 	 * @param string $userId
 	 * @param ?string $since
 	 * @param ?int $limit
 	 * @return array<mixed>
 	 */
-	public function getNotifications(string $url, string $accessToken,
-									string $refreshToken, string $clientID, string $clientSecret, string $userId,
-									?string $since = null, ?int $limit = null): array {
+	public function getNotifications(
+		string $userId, ?string $since = null, ?int $limit = null
+	): array {
 		if ($since) {
 			$filters = '[{"updatedAt":{"operator":"<>d","values":["' . $since . '","' . $this->now() . '"]}},{"status":{"operator":"!","values":["14"]}}]';
 		} else {
@@ -226,9 +218,7 @@ class OpenProjectAPIService {
 			'sortBy' => '[["updatedAt", "desc"]]',
 			// 'limit' => $limit,
 		];
-		$result = $this->request(
-			$url, $accessToken, $refreshToken, $clientID, $clientSecret, $userId, 'work_packages', $params
-		);
+		$result = $this->request($userId, 'work_packages', $params);
 		if (isset($result['error'])) {
 			return $result;
 		} elseif (!isset($result['_embedded']['elements'])) {
@@ -243,11 +233,6 @@ class OpenProjectAPIService {
 	}
 
 	/**
-	 * @param string $url
-	 * @param string $accessToken
-	 * @param string $refreshToken
-	 * @param string $clientID
-	 * @param string $clientSecret
 	 * @param string $userId
 	 * @param string|null $query
 	 * @param int|null $fileId
@@ -257,9 +242,9 @@ class OpenProjectAPIService {
 	 * @throws \OCP\PreConditionNotMetException
 	 * @throws \Safe\Exceptions\JsonException
 	 */
-	public function searchWorkPackage(string $url, string $accessToken,
-							string $refreshToken, string $clientID, string $clientSecret, string $userId,
-							string $query = null, int $fileId = null, int $offset = 0, int $limit = 5): array {
+	public function searchWorkPackage(
+		string $userId, string $query = null, int $fileId = null, int $offset = 0, int $limit = 5
+	): array {
 		$resultsById = [];
 		$filters = [];
 
@@ -276,9 +261,7 @@ class OpenProjectAPIService {
 			'sortBy' => '[["updatedAt", "desc"]]',
 			// 'limit' => $limit,
 		];
-		$searchDescResult = $this->request(
-			$url, $accessToken, $refreshToken, $clientID, $clientSecret, $userId, 'work_packages', $params
-		);
+		$searchDescResult = $this->request($userId, 'work_packages', $params);
 
 		if (isset($searchDescResult['error'])) {
 			return $searchDescResult;
@@ -300,9 +283,7 @@ class OpenProjectAPIService {
 				'sortBy' => '[["updatedAt", "desc"]]',
 				// 'limit' => $limit,
 			];
-			$searchSubjectResult = $this->request(
-			$url, $accessToken, $refreshToken, $clientID, $clientSecret, $userId, 'work_packages', $params
-		);
+			$searchSubjectResult = $this->request($userId, 'work_packages', $params);
 
 			if (isset($searchSubjectResult['error'])) {
 				return $searchSubjectResult;
@@ -359,11 +340,6 @@ class OpenProjectAPIService {
 	}
 
 	/**
-	 * @param string $openprojectUrl
-	 * @param string $accessToken
-	 * @param string $refreshToken
-	 * @param string $clientID
-	 * @param string $clientSecret
 	 * @param string $userId
 	 * @param string $endPoint
 	 * @param array<mixed> $params
@@ -371,9 +347,16 @@ class OpenProjectAPIService {
 	 * @return array<mixed>
 	 * @throws \OCP\PreConditionNotMetException
 	 */
-	public function request(string $openprojectUrl, string $accessToken, string $refreshToken,
-							string $clientID, string $clientSecret, string $userId,
+	public function request(string $userId,
 							string $endPoint, array $params = [], string $method = 'GET'): array {
+		$accessToken = $this->config->getUserValue($userId, Application::APP_ID, 'token');
+		$refreshToken = $this->config->getUserValue($userId, Application::APP_ID, 'refresh_token');
+		$clientID = $this->config->getAppValue(Application::APP_ID, 'client_id');
+		$clientSecret = $this->config->getAppValue(Application::APP_ID, 'client_secret');
+		$openprojectUrl = $this->config->getAppValue(Application::APP_ID, 'oauth_instance_url');
+		if (!$openprojectUrl || !OpenProjectAPIService::validateOpenProjectURL($openprojectUrl)) {
+			return ['error' => 'OpenProject URL is invalid', 'statusCode' => 500];
+		}
 		try {
 			$url = $openprojectUrl . '/api/v3/' . $endPoint;
 			$options = [
@@ -433,9 +416,7 @@ class OpenProjectAPIService {
 					$accessToken = $result['access_token'];
 					$this->config->setUserValue($userId, Application::APP_ID, 'token', $accessToken);
 					// retry the request with new access token
-					return $this->request(
-						$openprojectUrl, $accessToken, $refreshToken, $clientID, $clientSecret, $userId, $endPoint, $params, $method
-					);
+					return $this->request($userId, $endPoint, $params, $method);
 				}
 			}
 			// try to get the error in the response
@@ -520,25 +501,12 @@ class OpenProjectAPIService {
 	/**
 	 * authenticated request to get status of a work package
 	 *
-	 * @param string $url
-	 * @param string $accessToken
-	 * @param string $refreshToken
-	 * @param string $clientID
-	 * @param string $clientSecret
 	 * @param string $userId
 	 * @param string $statusId
 	 * @return string[]
 	 */
-	public function getOpenProjectWorkPackageStatus(
-		string $url,
-		string $accessToken,
-		string $refreshToken,
-		string $clientID,
-		string $clientSecret,
-		string $userId,
-		string $statusId): array {
-		$result = $this->request(
-			$url, $accessToken, $refreshToken, $clientID, $clientSecret, $userId, 'statuses/' . $statusId);
+	public function getOpenProjectWorkPackageStatus(string $userId, string $statusId): array {
+		$result = $this->request($userId, 'statuses/' . $statusId);
 		if (!isset($result['id'])) {
 			return ['error' => 'Malformed response'];
 		}
@@ -548,26 +516,12 @@ class OpenProjectAPIService {
 	/**
 	 * authenticated request to get status of a work package
 	 *
-	 * @param string $url
-	 * @param string $accessToken
-	 * @param string $refreshToken
-	 * @param string $clientID
-	 * @param string $clientSecret
 	 * @param string $userId
 	 * @param string $typeId
 	 * @return string[]
 	 */
-	public function getOpenProjectWorkPackageType(
-		string $url,
-		string $accessToken,
-		string $refreshToken,
-		string $clientID,
-		string $clientSecret,
-		string $userId,
-		string $typeId
-	): array {
-		$result = $this->request(
-			$url, $accessToken, $refreshToken, $clientID, $clientSecret, $userId, 'types/' . $typeId);
+	public function getOpenProjectWorkPackageType(string $userId, string $typeId): array {
+		$result = $this->request($userId, 'types/' . $typeId);
 		if (!isset($result['id'])) {
 			return ['error' => 'Malformed response'];
 		}
@@ -623,11 +577,6 @@ class OpenProjectAPIService {
 	 * @return int
 	 */
 	public function linkWorkPackageToFile(
-		string $openprojectUrl,
-		string $accessToken,
-		string $refreshToken,
-		string $clientID,
-		string $clientSecret,
 		int $workpackageId,
 		int $fileId,
 		string $fileName,
@@ -665,7 +614,7 @@ class OpenProjectAPIService {
 
 		$params['body'] = \Safe\json_encode($body);
 		$result = $this->request(
-			$openprojectUrl, $accessToken, $refreshToken, $clientID, $clientSecret, $userId, 'work_packages/' . $workpackageId. '/file_links', $params, 'POST'
+			$userId, 'work_packages/' . $workpackageId. '/file_links', $params, 'POST'
 		);
 
 		if (isset($result['error'])) {

--- a/tests/lib/Controller/ConfigControllerTest.php
+++ b/tests/lib/Controller/ConfigControllerTest.php
@@ -67,12 +67,6 @@ class ConfigControllerTest extends TestCase {
 		$apiServiceMock
 			->method('request')
 			->with(
-				'http://openproject.org',
-				'oAuthAccessToken',
-				'oauth',
-				'oAuthRefreshToken',
-				'clientID',
-				'clientSecret',
 				'testUser',
 				'users/me'
 			)

--- a/tests/lib/Controller/OpenProjectAPIControllerTest.php
+++ b/tests/lib/Controller/OpenProjectAPIControllerTest.php
@@ -214,11 +214,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 			->method('searchWorkPackage')
 			->with(
 				$this->anything(),
-				$this->anything(),
-				$this->anything(),
-				$this->anything(),
-				$this->anything(),
-				$this->anything(),
 				$searchQuery,
 				$fileId
 			)

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -142,17 +142,19 @@ class OpenProjectAPIServiceTest extends TestCase {
 
 	/**
 	 * @param IRootFolder|null $storageMock
+	 * @param string $oAuthToken
 	 * @return OpenProjectAPIService
 	 */
-	private function getOpenProjectAPIService($storageMock = null) {
-		$config = $this->createMock(IConfig::class);
+	private function getOpenProjectAPIService(
+		$storageMock = null, $oAuthToken = '1234567890'
+	) {
 		$certificateManager = $this->getMockBuilder('\OCP\ICertificateManager')->getMock();
 		$certificateManager->method('getAbsoluteBundlePath')->willReturn('/');
 		$logger = $this->createMock(ILogger::class);
 
 		$client = new GuzzleClient();
 		$ocClient = new Client(
-			$config,
+			$this->createMock(IConfig::class),
 			$logger,
 			$certificateManager,
 			$client,
@@ -174,6 +176,45 @@ class OpenProjectAPIServiceTest extends TestCase {
 		if ($storageMock === null) {
 			$storageMock = $this->createMock(\OCP\Files\IRootFolder::class);
 		}
+		$configMock = $this->getMockBuilder(IConfig::class)->getMock();
+
+		$configMock
+			->method('getUserValue')
+			->withConsecutive(
+				['testUser', 'integration_openproject', 'token'],
+				['testUser', 'integration_openproject', 'refresh_token'],
+				['testUser', 'integration_openproject', 'token'],
+			)
+			->willReturnOnConsecutiveCalls(
+				$oAuthToken,
+				'oAuthRefreshToken',
+				'new-Token'
+			);
+
+		$pactMockServerConfig = new MockServerEnvConfig();
+
+		$configMock
+			->method('getAppValue')
+			->withConsecutive(
+				['integration_openproject', 'client_id'],
+				['integration_openproject', 'client_secret'],
+				['integration_openproject', 'oauth_instance_url'],
+
+				// for second request after invalid token reply
+				['integration_openproject', 'client_id'],
+				['integration_openproject', 'client_secret'],
+				['integration_openproject', 'oauth_instance_url'],
+			)
+			->willReturnOnConsecutiveCalls(
+				$this->clientId,
+				$this->clientSecret,
+				$pactMockServerConfig->getBaseUri()->__toString(),
+
+				// for second request after invalid token reply
+				$this->clientId,
+				$this->clientSecret,
+				$pactMockServerConfig->getBaseUri()->__toString()
+			);
 
 		return new OpenProjectAPIService(
 			'integration_openproject',
@@ -181,7 +222,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 			$avatarManagerMock,
 			$this->createMock(\Psr\Log\LoggerInterface::class),
 			$this->createMock(\OCP\IL10N::class),
-			$this->createMock(\OCP\IConfig::class),
+			$configMock,
 			$this->createMock(\OCP\Notification\IManager::class),
 			$clientService,
 			$storageMock
@@ -276,14 +317,14 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$service->method('request')
 			->withConsecutive(
 				[
-					'url','token', 'refresh', 'id', 'secret', 'user', 'work_packages',
+					'user', 'work_packages',
 					[
 						'filters' => '[{"description":{"operator":"~","values":["search query"]}},{"status":{"operator":"!","values":["14"]}}]',
 						'sortBy' => '[["updatedAt", "desc"]]',
 					]
 				],
 				[
-					'url','token', 'refresh', 'id', 'secret', 'user', 'work_packages',
+					'user', 'work_packages',
 					[
 						'filters' => '[{"subject":{"operator":"~","values":["search query"]}},{"status":{"operator":"!","values":["14"]}}]',
 						'sortBy' => '[["updatedAt", "desc"]]',
@@ -294,9 +335,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 				$descriptionResponse,
 				$subjectResponse
 			);
-		$result = $service->searchWorkPackage(
-			'url', 'token', 'refresh', 'id', 'secret', 'user', 'search query'
-		);
+		$result = $service->searchWorkPackage('user', 'search query');
 		$this->assertSame($expectedResult, $result);
 	}
 
@@ -308,7 +347,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$service->method('request')
 			->withConsecutive(
 				[
-					'url','token', 'refresh', 'id', 'secret', 'user', 'work_packages',
+					'user', 'work_packages',
 					[
 						'filters' => '[{"file_link_origin_id":{"operator":"=","values":["123"]}}]',
 						'sortBy' => '[["updatedAt", "desc"]]',
@@ -318,9 +357,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 			->willReturnOnConsecutiveCalls(
 				["_embedded" => ["elements" => [['id' => 1], ['id' => 2], ['id' => 3]]]]
 			);
-		$result = $service->searchWorkPackage(
-			'url', 'token', 'refresh', 'id', 'secret', 'user', null, 123
-		);
+		$result = $service->searchWorkPackage('user', null, 123);
 		$this->assertSame([['id' => 1], ['id' => 2], ['id' => 3]], $result);
 	}
 
@@ -332,14 +369,14 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$service->method('request')
 			->withConsecutive(
 				[
-					'url','token', 'refresh', 'id', 'secret', 'user', 'work_packages',
+					'user', 'work_packages',
 					[
 						'filters' => '[{"file_link_origin_id":{"operator":"=","values":["123"]}},{"description":{"operator":"~","values":["search query"]}},{"status":{"operator":"!","values":["14"]}}]',
 						'sortBy' => '[["updatedAt", "desc"]]',
 					]
 				],
 				[
-					'url','token', 'refresh', 'id', 'secret', 'user', 'work_packages',
+					'user', 'work_packages',
 					[
 						'filters' => '[{"subject":{"operator":"~","values":["search query"]}},{"status":{"operator":"!","values":["14"]}}]',
 						'sortBy' => '[["updatedAt", "desc"]]',
@@ -350,9 +387,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 				["_embedded" => ["elements" => [['id' => 1], ['id' => 2], ['id' => 3]]]],
 				["_embedded" => ["elements" => [['id' => 4], ['id' => 5], ['id' => 6]]]]
 			);
-		$result = $service->searchWorkPackage(
-			'url', 'token', 'refresh', 'id', 'secret', 'user', 'search query', 123
-		);
+		$result = $service->searchWorkPackage('user', 'search query', 123);
 		$this->assertSame([['id' => 1], ['id' => 2], ['id' => 3], ['id' => 4], ['id' => 5], ['id' => 6]], $result);
 	}
 
@@ -363,9 +398,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$service = $this->getServiceMock();
 		$service->method('request')
 			->willReturn(['error' => 'some issue', 'statusCode' => 404 ]);
-		$result = $service->searchWorkPackage(
-			'url', 'token', 'refresh', 'id', 'secret', 'user', 'search query', 123
-		);
+		$result = $service->searchWorkPackage('user', 'search query', 123);
 		$this->assertSame(['error' => 'some issue', 'statusCode' => 404 ], $result);
 	}
 
@@ -380,9 +413,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 				["_embedded" => ["elements" => [['id' => 1], ['id' => 2], ['id' => 3]]]],
 				['error' => 'some issue', 'statusCode' => 404 ]
 			);
-		$result = $service->searchWorkPackage(
-			'url', 'token', 'refresh', 'id', 'secret', 'user', 'search query', 123
-		);
+		$result = $service->searchWorkPackage('user', 'search query', 123);
 		$this->assertSame(['error' => 'some issue', 'statusCode' => 404 ], $result);
 	}
 
@@ -410,12 +441,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 			->willRespondWith($providerResponse);
 
 		$result = $this->service->getNotifications(
-			$this->mockServerBaseUri,
-			'1234567890',
-			'',
-			$this->clientId,
-			$this->clientSecret,
-			'admin'
+			'testUser'
 		);
 		$this->assertSame([['some' => 'data']], $result);
 	}
@@ -439,7 +465,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$service = $this->getServiceMock();
 		$service->method('request')
 			->willReturn($response);
-		$result = $service->getNotifications('', '', '', '', '', '');
+		$result = $service->getNotifications('', '');
 		$this->assertSame(["error" => "Malformed response"], $result);
 	}
 
@@ -450,7 +476,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$service = $this->getServiceMock();
 		$service->method('request')
 			->willReturn(['error' => 'my error']);
-		$result = $service->getNotifications('', '', '', '', '', '', '');
+		$result = $service->getNotifications('', '');
 		$this->assertSame(["error" => "my error"], $result);
 	}
 
@@ -464,13 +490,13 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$service->expects($this->once())
 			->method('request')
 			->with(
-				'url', 'token', 'refresh', 'id', 'secret', 'user', 'work_packages',
+				'user', 'work_packages',
 				[
 					'filters' => '[{"updatedAt":{"operator":"<>d","values":["2022-01-01T12:01:01Z","2022-01-27T08:15:48Z"]}},{"status":{"operator":"!","values":["14"]}}]',
 					'sortBy' => '[["updatedAt", "desc"]]'
 				]);
 
-		$service->getNotifications('url', 'token', 'refresh', 'id', 'secret', 'user', '2022-01-01T12:01:01Z');
+		$service->getNotifications('user', '2022-01-01T12:01:01Z');
 	}
 
 	/**
@@ -480,7 +506,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$service = $this->getServiceMock();
 		$service->method('request')
 			->willReturn(["_embedded" => ["elements" => [['id' => 1], ['id' => 2], ['id' => 3]]]]);
-		$result = $service->getNotifications('', '', '', '', '', '', '', 2);
+		$result = $service->getNotifications('', '', 2);
 		$this->assertSame([['id' => 1], ['id' => 2]], $result);
 	}
 
@@ -506,12 +532,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 			->willRespondWith($providerResponse);
 
 		$result = $this->service->request(
-			$this->mockServerBaseUri,
-			'1234567890',
-			'',
-			$this->clientId,
-			$this->clientSecret,
-			'admin',
+			'testUser',
 			'work_packages'
 		);
 		$this->assertSame(["_embedded" => ["elements" => []]], $result);
@@ -544,7 +565,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 			->setBody(
 				'client_id=' . $this->clientId .
 				'&client_secret=' . $this->clientSecret .
-				'&grant_type=refresh_token&refresh_token=myRefreshToken'
+				'&grant_type=refresh_token&refresh_token=oAuthRefreshToken'
 			);
 
 		$refreshTokenResponse = new ProviderResponse();
@@ -573,13 +594,9 @@ class OpenProjectAPIServiceTest extends TestCase {
 			->with($consumerRequestNewOAuthToken)
 			->willRespondWith($providerResponseNewOAuthToken);
 
-		$result = $this->service->request(
-			$this->mockServerBaseUri,
-			'invalid',
-			'myRefreshToken',
-			$this->clientId,
-			$this->clientSecret,
-			'admin',
+		$service = $this->getOpenProjectAPIService(null, 'invalid');
+		$result = $service->request(
+			'testUser',
 			'work_packages'
 		);
 		$this->assertSame(["_embedded" => ["elements" => [['id' => 1], ['id' => 2]]]], $result);
@@ -604,12 +621,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 			->willRespondWith($providerResponse);
 
 		$result = $this->service->request(
-			$this->mockServerBaseUri,
-			'1234567890',
-			'',
-			$this->clientId,
-			$this->clientSecret,
-			'admin',
+			'testUser',
 			'not_existing'
 		);
 		$this->assertSame([
@@ -713,12 +725,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 			->willRespondWith($providerResponse);
 
 		$result = $this->service->getOpenProjectWorkPackageStatus(
-			$this->mockServerBaseUri,
-			'1234567890',
-			'',
-			$this->clientId,
-			$this->clientSecret,
-			'admin',
+			'testUser',
 			'7'
 		);
 		$this->assertSame(["_type" => "Status", "id" => 7, "name" => "In progress",
@@ -733,7 +740,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$service->method('request')
 			->willReturn(["_type" => "Status", "id" => 7, "name" => "In progress",
 				"isClosed" => false, "color" => "#CC5DE8", "isDefault" => false, "isReadonly" => false, "defaultDoneRatio" => null, "position" => 7]);
-		$result = $service->getOpenProjectWorkPackageStatus('url', 'token', 'refresh', 'id', 'secret', 'user', 'statusId');
+		$result = $service->getOpenProjectWorkPackageStatus('user', 'statusId');
 		$this->assertSame(["_type" => "Status", "id" => 7, "name" => "In progress",
 			"isClosed" => false, "color" => "#CC5DE8", "isDefault" => false, "isReadonly" => false, "defaultDoneRatio" => null, "position" => 7], $result);
 	}
@@ -745,7 +752,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$service = $this->getServiceMock();
 		$service->method('request')
 			->willReturn(['error' => 'Malformed response']);
-		$result = $service->getOpenProjectWorkPackageStatus('', '', '', '', '', '', '');
+		$result = $service->getOpenProjectWorkPackageStatus('', '');
 		$this->assertSame(['error' => 'Malformed response'], $result);
 	}
 
@@ -771,12 +778,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 			->willRespondWith($providerResponse);
 
 		$result = $this->service->getOpenProjectWorkPackageType(
-			$this->mockServerBaseUri,
-			'1234567890',
-			'',
-			$this->clientId,
-			$this->clientSecret,
-			'admin',
+			'testUser',
 			'3'
 		);
 
@@ -794,7 +796,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 				"_type" => "Type", "id" => 3, "name" => "Phase",
 				"color" => "#CC5DE8", "position" => 4, "isDefault" => true, "isMilestone" => false, "createdAt" => "2022-01-12T08:53:15Z", "updatedAt" => "2022-01-12T08:53:34Z"
 			]);
-		$result = $service->getOpenProjectWorkPackageType('url', 'token', 'refresh', 'id', 'secret', 'user', 'typeId');
+		$result = $service->getOpenProjectWorkPackageType('user', 'typeId');
 		$this->assertSame([
 			"_type" => "Type", "id" => 3, "name" => "Phase",
 			"color" => "#CC5DE8", "position" => 4, "isDefault" => true, "isMilestone" => false, "createdAt" => "2022-01-12T08:53:15Z", "updatedAt" => "2022-01-12T08:53:34Z"
@@ -808,7 +810,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$service = $this->getServiceMock();
 		$service->method('request')
 			->willReturn(['error' => 'Malformed response']);
-		$result = $service->getOpenProjectWorkPackageType('', '', '', '', '', '', '');
+		$result = $service->getOpenProjectWorkPackageType('', '');
 		$this->assertSame(['error' => 'Malformed response'], $result);
 	}
 
@@ -949,12 +951,11 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$service->expects($this->once())
 			->method('request')
 			->with(
-				'url', 'token', 'refresh', 'id', 'secret', 'user', 'work_packages/123/file_links',
+				'user', 'work_packages/123/file_links',
 				['body' => \Safe\json_encode($this->validFileLinkRequestBody)]
 			);
 
 		$result = $service->linkWorkPackageToFile(
-			'url', 'token', 'refresh', 'id', 'secret',
 			123, 5503, 'logo.png', 'http://nextcloud.org', 'user'
 		);
 		$this->assertSame(2456, $result);
@@ -977,7 +978,6 @@ class OpenProjectAPIServiceTest extends TestCase {
 
 		$this->expectException(NotPermittedException::class);
 		$service->linkWorkPackageToFile(
-			'url', 'token', 'refresh', 'id', 'secret',
 			123, 5503, 'logo.png', 'http://nextcloud.org', 'user'
 		);
 	}
@@ -1000,7 +1000,6 @@ class OpenProjectAPIServiceTest extends TestCase {
 
 		$this->expectException(NotFoundException::class);
 		$result = $service->linkWorkPackageToFile(
-			'url', 'token', 'refresh', 'id', 'secret',
 			123, 5503, 'logo.png', 'http://nextcloud.org', 'user'
 		);
 	}
@@ -1023,19 +1022,34 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$clientService = $this->getMockBuilder('\OCP\Http\Client\IClientService')->getMock();
 		$clientService->method('newClient')->willReturn($ocClient);
 
+		$configMock = $this->getMockBuilder(IConfig::class)
+			->getMock();
+		$configMock
+			->method('getAppValue')
+			->withConsecutive(
+				['integration_openproject', 'client_id'],
+				['integration_openproject', 'client_secret'],
+				['integration_openproject', 'oauth_instance_url'],
+			)
+			->willReturnOnConsecutiveCalls(
+				$this->clientId,
+				$this->clientSecret,
+				'http://openproject.org',
+			);
+
 		$service = new OpenProjectAPIService(
 			'integration_openproject',
 			$this->createMock(\OCP\IUserManager::class),
 			$this->createMock(\OCP\IAvatarManager::class),
 			$this->createMock(\Psr\Log\LoggerInterface::class),
 			$this->createMock(\OCP\IL10N::class),
-			$this->createMock(\OCP\IConfig::class),
+			$configMock,
 			$this->createMock(\OCP\Notification\IManager::class),
 			$clientService,
 			$this->createMock(\OCP\Files\IRootFolder::class),
 		);
 
-		$response = $service->request('', '', '', '', '', '', '', []);
+		$response = $service->request('', '', []);
 		$this->assertSame($expectedError, $response['error']);
 		$this->assertSame($expectedHttpStatusCode, $response['statusCode']);
 	}
@@ -1063,16 +1077,11 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$service = $this->getOpenProjectAPIService($storageMock);
 
 		$result = $service->linkWorkPackageToFile(
-			$this->mockServerBaseUri,
-			'1234567890',
-			'',
-			$this->clientId,
-			$this->clientSecret,
 			123,
 			5503,
 			'logo.png',
 			'http://nextcloud.org',
-			'admin'
+			'testUser'
 		);
 
 		$this->assertSame(1337, $result);
@@ -1122,16 +1131,11 @@ class OpenProjectAPIServiceTest extends TestCase {
 
 		$this->expectException(OpenprojectErrorException::class);
 		$service->linkWorkPackageToFile(
-			$this->mockServerBaseUri,
-			'1234567890',
-			'',
-			$this->clientId,
-			$this->clientSecret,
 			123,
 			5503,
 			'logo.png',
 			'',
-			'admin'
+			'testUser'
 		);
 	}
 
@@ -1179,16 +1183,11 @@ class OpenProjectAPIServiceTest extends TestCase {
 
 		$this->expectException(OpenprojectErrorException::class);
 		$service->linkWorkPackageToFile(
-			$this->mockServerBaseUri,
-			'1234567890',
-			'',
-			$this->clientId,
-			$this->clientSecret,
 			123,
 			5503,
 			'logo.png',
 			'http://not-existing',
-			'admin'
+			'testUser'
 		);
 	}
 
@@ -1218,20 +1217,15 @@ class OpenProjectAPIServiceTest extends TestCase {
 			->willRespondWith($providerResponse);
 
 		$storageMock = $this->getStorageMock();
-		$service = $this->getOpenProjectAPIService($storageMock);
+		$service = $this->getOpenProjectAPIService($storageMock, 'MissingPermission');
 
 		$this->expectException(OpenprojectErrorException::class);
 		$service->linkWorkPackageToFile(
-			$this->mockServerBaseUri,
-			'MissingPermission',
-			'',
-			$this->clientId,
-			$this->clientSecret,
 			123,
 			5503,
 			'logo.png',
 			'http://nextcloud.org',
-			'admin'
+			'testUser'
 		);
 	}
 
@@ -1265,16 +1259,11 @@ class OpenProjectAPIServiceTest extends TestCase {
 
 		$this->expectException(OpenprojectErrorException::class);
 		$service->linkWorkPackageToFile(
-			$this->mockServerBaseUri,
-			'1234567890',
-			'',
-			$this->clientId,
-			$this->clientSecret,
 			999999,
 			5503,
 			'logo.png',
 			'http://nextcloud.org',
-			'admin'
+			'testUser'
 		);
 	}
 


### PR DESCRIPTION
get configuration like token, url, etc. in the function that needs it `request` and don't pass this data through multiple levels

I think the code is more readable that way.

Thoughts?