### PR TITLE
use fit-content for workpackage status

### DIFF
--- a/src/components/tab/WorkPackage.vue
+++ b/src/components/tab/WorkPackage.vue
@@ -67,8 +67,8 @@ export default {
 		flex-wrap: wrap;
 
 		&__status {
-			padding: 5px;
-			width: 98px;
+			padding: 5px 10px;
+			width: fit-content;
 			height: 20px;
 			justify-content: center;
 			display: flex;


### PR DESCRIPTION
## Description
currently, we're using a static width for work package status in the search result.

work package status text may have variable length, so the static width may lead to UI inconsistency like:

`very-long-status-te`~~xt~~ is missed because it does not fit inside specified static width
`bug................`  a long gap for short status

This PR makes use of dynamic width for the work package status indicator.