### PR TITLE
Css enhancements for the workpackage component

### DIFF
--- a/src/components/tab/WorkPackage.vue
+++ b/src/components/tab/WorkPackage.vue
@@ -7,11 +7,8 @@
 					{{ workpackage.statusTitle }}
 				</div>
 			</div>
-			<div class="row__id">
-				#{{ workpackage.id }} -
-			</div>
-			<div class="row__project">
-				{{ workpackage.project }}
+			<div class="row__workpackage">
+				#{{ workpackage.id }} - {{ workpackage.project }}
 			</div>
 		</div>
 		<div class="row">
@@ -63,6 +60,7 @@ export default {
 
 	.row {
 		display: flex;
+		align-items: center;
 		padding: 3px;
 		flex-wrap: wrap;
 
@@ -76,6 +74,7 @@ export default {
 			text-align: center;
 			font-size: 0.75rem;
 			border-radius: 2px;
+			margin-right: 4px;
 
 			&__title {
 				mix-blend-mode: multiply;
@@ -85,20 +84,11 @@ export default {
 			}
 		}
 
-		&__id {
-			padding: 5px;
+		&__workpackage {
 			color: #878787;
 			font-size: 0.8rem;
 			height: 20px;
-			line-height: 14px;
-		}
-
-		&__project {
-			padding: 5px 5px 5px 1px;
-			color: #878787;
-			height: 20px;
-			line-height: 14px;
-			font-size: 0.8rem;
+			line-height: 20px;
 		}
 
 		&__subject {
@@ -116,6 +106,7 @@ export default {
 				font-size: 0.75rem;
 				font-weight: bold;
 				text-transform: uppercase;
+				margin-right: 4px;
 			}
 		}
 

--- a/src/components/tab/WorkPackage.vue
+++ b/src/components/tab/WorkPackage.vue
@@ -60,7 +60,6 @@ export default {
 
 	.row {
 		display: flex;
-		align-items: center;
 		padding: 3px;
 		flex-wrap: wrap;
 

--- a/tests/jest/components/tab/__snapshots__/SearchInput.spec.js.snap
+++ b/tests/jest/components/tab/__snapshots__/SearchInput.spec.js.snap
@@ -26,11 +26,8 @@ exports[`SearchInput.vue tests work packages multiselect search list should disp
         in-progress
       </div>
     </div>
-    <div class="row__id">
-      #1 -
-    </div>
-    <div class="row__project">
-      test
+    <div class="row__workpackage">
+      #1 - test
     </div>
   </div>
   <div class="row">

--- a/tests/jest/components/tab/__snapshots__/WorkPackage.spec.js.snap
+++ b/tests/jest/components/tab/__snapshots__/WorkPackage.spec.js.snap
@@ -8,11 +8,8 @@ exports[`ProjectsTab.vue Test shows work packages information 1`] = `
         in-progress
       </div>
     </div>
-    <div class="row__id">
-      #1 -
-    </div>
-    <div class="row__project">
-      test
+    <div class="row__workpackage">
+      #1 - test
     </div>
   </div>
   <div class="row">

--- a/tests/jest/views/__snapshots__/ProjectsTab.spec.js.snap
+++ b/tests/jest/views/__snapshots__/ProjectsTab.spec.js.snap
@@ -12,11 +12,8 @@ exports[`ProjectsTab.vue Test fetchWorkpackages shows the linked workpackages 1`
           open
         </div>
       </div>
-      <div class="row__id">
-        #123 -
-      </div>
-      <div class="row__project">
-        a big project
+      <div class="row__workpackage">
+        #123 - a big project
       </div>
     </div>
     <div class="row">
@@ -44,11 +41,8 @@ exports[`ProjectsTab.vue Test fetchWorkpackages shows the linked workpackages 1`
           प्रगति हुदैछ
         </div>
       </div>
-      <div class="row__id">
-        #589 -
-      </div>
-      <div class="row__project">
-        नेपालको विकास गर्ने
+      <div class="row__workpackage">
+        #589 - नेपालको विकास गर्ने
       </div>
     </div>
     <div class="row">
@@ -84,11 +78,8 @@ exports[`ProjectsTab.vue Test fetchWorkpackages shows the linked workpackages 2`
           open
         </div>
       </div>
-      <div class="row__id">
-        #123 -
-      </div>
-      <div class="row__project">
-        a big project
+      <div class="row__workpackage">
+        #123 - a big project
       </div>
     </div>
     <div class="row">
@@ -116,11 +107,8 @@ exports[`ProjectsTab.vue Test fetchWorkpackages shows the linked workpackages 2`
           प्रगति हुदैछ
         </div>
       </div>
-      <div class="row__id">
-        #589 -
-      </div>
-      <div class="row__project">
-        नेपालको विकास गर्ने
+      <div class="row__workpackage">
+        #589 - नेपालको विकास गर्ने
       </div>
     </div>
     <div class="row">
@@ -156,11 +144,8 @@ exports[`ProjectsTab.vue Test onSave shows the just linked workpackage 1`] = `
           in-progress
         </div>
       </div>
-      <div class="row__id">
-        #1 -
-      </div>
-      <div class="row__project">
-        test
+      <div class="row__workpackage">
+        #1 - test
       </div>
     </div>
     <div class="row">


### PR DESCRIPTION
## Description
- center align work package id and project information
- right margin for work package status and type title

## Screenshots
### Before
![Screenshot from 2022-03-21 16-37-18](https://user-images.githubusercontent.com/39373750/159247021-3bba3511-8e5c-4368-a2a8-a17c1f7f7bb8.png)

### After
![Screenshot from 2022-03-21 16-31-07](https://user-images.githubusercontent.com/39373750/159246708-e57dc477-6d6c-4cd8-991b-9d03bd0e55aa.png)



Signed-off-by: Parajuli Kiran <kiranparajuli589@gmail.com>