### PR TITLE
[OP#41127] filter work packages by storage and sort by status

### DIFF
--- a/lib/Controller/OpenProjectAPIController.php
+++ b/lib/Controller/OpenProjectAPIController.php
@@ -153,7 +153,8 @@ class OpenProjectAPIController extends Controller {
 		$result = $this->openprojectAPIService->searchWorkPackage(
 			$this->userId,
 			$searchQuery,
-			$fileId
+			$fileId,
+			$this->urlGenerator->getBaseUrl()
 		);
 
 		if (!isset($result['error'])) {

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -236,6 +236,7 @@ class OpenProjectAPIService {
 	 * @param string $userId
 	 * @param string|null $query
 	 * @param int|null $fileId
+	 * @param string|null $storageUrl
 	 * @param int $offset
 	 * @param int $limit
 	 * @return array<mixed>
@@ -243,8 +244,18 @@ class OpenProjectAPIService {
 	 * @throws \Safe\Exceptions\JsonException
 	 */
 	public function searchWorkPackage(
-		string $userId, string $query = null, int $fileId = null, int $offset = 0, int $limit = 5
+		string $userId,
+		string $query = null,
+		int $fileId = null,
+		string $storageUrl = null,
+		int $offset = 0,
+		int $limit = 5
 	): array {
+		$linkableStorageFilter = [
+			'linkable_to_storage_url' =>
+				['operator' => '=', 'values' => [$storageUrl]]
+		];
+		$openStatusFilter = ['status' => ['operator' => 'o', 'values' => []]];
 		$resultsById = [];
 		$filters = [];
 
@@ -254,7 +265,10 @@ class OpenProjectAPIService {
 		}
 		if ($query !== null) {
 			$filters[] = ['description' => ['operator' => '~', 'values' => [$query]]];
-			$filters[] = ['status' => ['operator' => '!', 'values' => ['14']]];
+			$filters[] = $openStatusFilter;
+			if ($storageUrl !== null) {
+				$filters[] = $linkableStorageFilter;
+			}
 		}
 		$params = [
 			'filters' => \Safe\json_encode($filters),
@@ -276,8 +290,11 @@ class OpenProjectAPIService {
 		if ($query !== null) {
 			$filters = [
 				['subject' => ['operator' => '~', 'values' => [$query]]],
-				['status' => ['operator' => '!', 'values' => ['14']]]
+				$openStatusFilter
 			];
+			if ($storageUrl !== null) {
+				$filters[] = $linkableStorageFilter;
+			}
 			$params = [
 				'filters' => \Safe\json_encode($filters),
 				'sortBy' => '[["updatedAt", "desc"]]',

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -253,7 +253,7 @@ class OpenProjectAPIService {
 	): array {
 		$linkableStorageFilter = [
 			'linkable_to_storage_url' =>
-				['operator' => '=', 'values' => [$storageUrl]]
+				['operator' => '=', 'values' => [urlencode($storageUrl)]]
 		];
 		$openStatusFilter = ['status' => ['operator' => 'o', 'values' => []]];
 		$resultsById = [];

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -255,7 +255,7 @@ class OpenProjectAPIService {
 			'linkable_to_storage_url' =>
 				['operator' => '=', 'values' => [urlencode($storageUrl)]]
 		];
-		$openStatusFilter = ['status' => ['operator' => 'o', 'values' => []]];
+		$sortBy =  [['status', 'asc'],['updatedAt', 'desc']];
 		$resultsById = [];
 		$filters = [];
 
@@ -265,14 +265,13 @@ class OpenProjectAPIService {
 		}
 		if ($query !== null) {
 			$filters[] = ['description' => ['operator' => '~', 'values' => [$query]]];
-			$filters[] = $openStatusFilter;
 			if ($storageUrl !== null) {
 				$filters[] = $linkableStorageFilter;
 			}
 		}
 		$params = [
 			'filters' => \Safe\json_encode($filters),
-			'sortBy' => '[["updatedAt", "desc"]]',
+			'sortBy' => \Safe\json_encode($sortBy),
 			// 'limit' => $limit,
 		];
 		$searchDescResult = $this->request($userId, 'work_packages', $params);
@@ -290,14 +289,13 @@ class OpenProjectAPIService {
 		if ($query !== null) {
 			$filters = [
 				['subject' => ['operator' => '~', 'values' => [$query]]],
-				$openStatusFilter
 			];
 			if ($storageUrl !== null) {
 				$filters[] = $linkableStorageFilter;
 			}
 			$params = [
 				'filters' => \Safe\json_encode($filters),
-				'sortBy' => '[["updatedAt", "desc"]]',
+				'sortBy' => \Safe\json_encode($sortBy),
 				// 'limit' => $limit,
 			];
 			$searchSubjectResult = $this->request($userId, 'work_packages', $params);

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -255,7 +255,7 @@ class OpenProjectAPIService {
 			'linkable_to_storage_url' =>
 				['operator' => '=', 'values' => [urlencode($storageUrl)]]
 		];
-		$sortBy =  [['status', 'asc'],['updatedAt', 'desc']];
+		$sortBy = [['status', 'asc'],['updatedAt', 'desc']];
 		$resultsById = [];
 		$filters = [];
 

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -333,14 +333,14 @@ class OpenProjectAPIServiceTest extends TestCase {
 				[
 					'user', 'work_packages',
 					[
-						'filters' => '[{"description":{"operator":"~","values":["search query"]}},{"status":{"operator":"!","values":["14"]}}]',
+						'filters' => '[{"description":{"operator":"~","values":["search query"]}},{"status":{"operator":"o","values":[]}}]',
 						'sortBy' => '[["updatedAt", "desc"]]',
 					]
 				],
 				[
 					'user', 'work_packages',
 					[
-						'filters' => '[{"subject":{"operator":"~","values":["search query"]}},{"status":{"operator":"!","values":["14"]}}]',
+						'filters' => '[{"subject":{"operator":"~","values":["search query"]}},{"status":{"operator":"o","values":[]}}]',
 						'sortBy' => '[["updatedAt", "desc"]]',
 					]
 				]
@@ -353,6 +353,55 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$this->assertSame($expectedResult, $result);
 	}
 
+	/**
+	 * @param array<mixed> $descriptionResponse
+	 * @param array<mixed> $subjectResponse
+	 * @param array<mixed> $expectedResult
+	 * @return void
+	 * @dataProvider searchWorkPackageDataProvider
+	 */
+	public function testSearchWorkPackageQueryAndStorage(
+		array $descriptionResponse, array $subjectResponse, array $expectedResult
+	) {
+		$service = $this->getServiceMock();
+		$service->method('request')
+			->withConsecutive(
+				[
+					'user', 'work_packages',
+					[
+						'filters' => '[' .
+										'{"description":' .
+											'{"operator":"~","values":["search query"]}'.
+										'},'.
+										'{"status":{"operator":"o","values":[]}},'.
+										'{"linkable_to_storage_url":'.
+											'{"operator":"=","values":["https:\/\/nc.my-server.org"]}}'.
+									']',
+						'sortBy' => '[["updatedAt", "desc"]]',
+					]
+				],
+				[
+					'user', 'work_packages',
+					[
+						'filters' => '[' .
+										'{"subject":' .
+											'{"operator":"~","values":["search query"]}'.
+										'},'.
+										'{"status":{"operator":"o","values":[]}},'.
+										'{"linkable_to_storage_url":'.
+											'{"operator":"=","values":["https:\/\/nc.my-server.org"]}}'.
+									']',
+						'sortBy' => '[["updatedAt", "desc"]]',
+					]
+				]
+			)
+			->willReturnOnConsecutiveCalls(
+				$descriptionResponse,
+				$subjectResponse
+			);
+		$result = $service->searchWorkPackage('user', 'search query', null, 'https://nc.my-server.org');
+		$this->assertSame($expectedResult, $result);
+	}
 	/**
 	 * @return void
 	 */
@@ -385,14 +434,14 @@ class OpenProjectAPIServiceTest extends TestCase {
 				[
 					'user', 'work_packages',
 					[
-						'filters' => '[{"file_link_origin_id":{"operator":"=","values":["123"]}},{"description":{"operator":"~","values":["search query"]}},{"status":{"operator":"!","values":["14"]}}]',
+						'filters' => '[{"file_link_origin_id":{"operator":"=","values":["123"]}},{"description":{"operator":"~","values":["search query"]}},{"status":{"operator":"o","values":[]}}]',
 						'sortBy' => '[["updatedAt", "desc"]]',
 					]
 				],
 				[
 					'user', 'work_packages',
 					[
-						'filters' => '[{"subject":{"operator":"~","values":["search query"]}},{"status":{"operator":"!","values":["14"]}}]',
+						'filters' => '[{"subject":{"operator":"~","values":["search query"]}},{"status":{"operator":"o","values":[]}}]',
 						'sortBy' => '[["updatedAt", "desc"]]',
 					]
 				]

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -375,7 +375,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 										'},'.
 										'{"status":{"operator":"o","values":[]}},'.
 										'{"linkable_to_storage_url":'.
-											'{"operator":"=","values":["https:\/\/nc.my-server.org"]}}'.
+											'{"operator":"=","values":["https%3A%2F%2Fnc.my-server.org"]}}'.
 									']',
 						'sortBy' => '[["updatedAt", "desc"]]',
 					]
@@ -389,7 +389,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 										'},'.
 										'{"status":{"operator":"o","values":[]}},'.
 										'{"linkable_to_storage_url":'.
-											'{"operator":"=","values":["https:\/\/nc.my-server.org"]}}'.
+											'{"operator":"=","values":["https%3A%2F%2Fnc.my-server.org"]}}'.
 									']',
 						'sortBy' => '[["updatedAt", "desc"]]',
 					]
@@ -399,7 +399,9 @@ class OpenProjectAPIServiceTest extends TestCase {
 				$descriptionResponse,
 				$subjectResponse
 			);
-		$result = $service->searchWorkPackage('user', 'search query', null, 'https://nc.my-server.org');
+		$result = $service->searchWorkPackage(
+			'user', 'search query', null, 'https://nc.my-server.org'
+		);
 		$this->assertSame($expectedResult, $result);
 	}
 	/**

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -333,15 +333,15 @@ class OpenProjectAPIServiceTest extends TestCase {
 				[
 					'user', 'work_packages',
 					[
-						'filters' => '[{"description":{"operator":"~","values":["search query"]}},{"status":{"operator":"o","values":[]}}]',
-						'sortBy' => '[["updatedAt", "desc"]]',
+						'filters' => '[{"description":{"operator":"~","values":["search query"]}}]',
+						'sortBy' => '[["status","asc"],["updatedAt","desc"]]',
 					]
 				],
 				[
 					'user', 'work_packages',
 					[
-						'filters' => '[{"subject":{"operator":"~","values":["search query"]}},{"status":{"operator":"o","values":[]}}]',
-						'sortBy' => '[["updatedAt", "desc"]]',
+						'filters' => '[{"subject":{"operator":"~","values":["search query"]}}]',
+						'sortBy' => '[["status","asc"],["updatedAt","desc"]]',
 					]
 				]
 			)
@@ -373,11 +373,10 @@ class OpenProjectAPIServiceTest extends TestCase {
 										'{"description":' .
 											'{"operator":"~","values":["search query"]}'.
 										'},'.
-										'{"status":{"operator":"o","values":[]}},'.
 										'{"linkable_to_storage_url":'.
 											'{"operator":"=","values":["https%3A%2F%2Fnc.my-server.org"]}}'.
 									']',
-						'sortBy' => '[["updatedAt", "desc"]]',
+						'sortBy' => '[["status","asc"],["updatedAt","desc"]]',
 					]
 				],
 				[
@@ -387,11 +386,10 @@ class OpenProjectAPIServiceTest extends TestCase {
 										'{"subject":' .
 											'{"operator":"~","values":["search query"]}'.
 										'},'.
-										'{"status":{"operator":"o","values":[]}},'.
 										'{"linkable_to_storage_url":'.
 											'{"operator":"=","values":["https%3A%2F%2Fnc.my-server.org"]}}'.
 									']',
-						'sortBy' => '[["updatedAt", "desc"]]',
+						'sortBy' => '[["status","asc"],["updatedAt","desc"]]',
 					]
 				]
 			)
@@ -415,7 +413,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 					'user', 'work_packages',
 					[
 						'filters' => '[{"file_link_origin_id":{"operator":"=","values":["123"]}}]',
-						'sortBy' => '[["updatedAt", "desc"]]',
+						'sortBy' => '[["status","asc"],["updatedAt","desc"]]',
 					]
 				],
 			)
@@ -436,15 +434,15 @@ class OpenProjectAPIServiceTest extends TestCase {
 				[
 					'user', 'work_packages',
 					[
-						'filters' => '[{"file_link_origin_id":{"operator":"=","values":["123"]}},{"description":{"operator":"~","values":["search query"]}},{"status":{"operator":"o","values":[]}}]',
-						'sortBy' => '[["updatedAt", "desc"]]',
+						'filters' => '[{"file_link_origin_id":{"operator":"=","values":["123"]}},{"description":{"operator":"~","values":["search query"]}}]',
+						'sortBy' => '[["status","asc"],["updatedAt","desc"]]',
 					]
 				],
 				[
 					'user', 'work_packages',
 					[
-						'filters' => '[{"subject":{"operator":"~","values":["search query"]}},{"status":{"operator":"o","values":[]}}]',
-						'sortBy' => '[["updatedAt", "desc"]]',
+						'filters' => '[{"subject":{"operator":"~","values":["search query"]}}]',
+						'sortBy' => '[["status","asc"],["updatedAt","desc"]]',
 					]
 				]
 			)


### PR DESCRIPTION
when searching by query (to link a wp to file):
- don't filter by a magic status id, but by the meta-status "open" 
- additionally filter out packages that cannot be linked to the current storage

CC @Kharonus