### PR TITLE
Use options from the latest search response

### DIFF
--- a/src/components/tab/SearchInput.vue
+++ b/src/components/tab/SearchInput.vue
@@ -133,10 +133,8 @@ export default {
 			}
 		},
 		async makeSearchRequest(search) {
-			if (search.length <= SEARCH_CHAR_LIMIT) {
-				this.resetState()
-				return
-			}
+			this.resetState()
+			if (search.length <= SEARCH_CHAR_LIMIT) return
 			this.state = STATE_LOADING
 			const url = generateUrl('/apps/integration_openproject/work-packages')
 			const req = {}

--- a/tests/jest/components/tab/__snapshots__/SearchInput.spec.js.snap
+++ b/tests/jest/components/tab/__snapshots__/SearchInput.spec.js.snap
@@ -49,3 +49,19 @@ exports[`SearchInput.vue tests work packages multiselect search list should disp
   </div>
 </div>
 `;
+
+exports[`SearchInput.vue tests work packages multiselect search list should only use the options from the latest search response 1`] = `
+Object {
+  "workpackage": Object {
+    "assignee": "some assignee",
+    "id": 1,
+    "picture": "http://localhost/apps/integration_openproject/avatar?userId=&userName=some assignee",
+    "project": "some project",
+    "statusCol": "",
+    "statusTitle": "some status",
+    "subject": "some subject",
+    "typeCol": "",
+    "typeTitle": "some type",
+  },
+}
+`;


### PR DESCRIPTION
## Description
Previously, the new search results were pushed to the existing list which leads us to show not related work packages in the multi-select options.

With this PR, every time a new request is being made, the search results list is cleared beforehand.

### Related
https://community.openproject.org/projects/nextcloud-integration/work_packages/41495
OP#41495

Signed-off-by: Kiran Parajuli <kiranparajuli589@gmail.com>