### PR TITLE
[OP #41290] Implementation of navigation and link deletion

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -22,6 +22,6 @@ return [
 		['name' => 'openProjectAPI#getWorkPackageFileLinks', 'url' => '/work_packages/', 'verb' => 'GET'],
 		['name' => 'openProjectAPI#getOpenProjectWorkPackageStatus', 'url' => '/statuses/{id}', 'verb' => 'GET'],
 		['name' => 'openProjectAPI#getOpenProjectWorkPackageType', 'url' => '/types/{id}', 'verb' => 'GET'],
-		['name' => 'openProjectAPI#deleteFileLink', 'url' => '/file_links/{fileLinkId}', 'verb' => 'DELETE'],
+		['name' => 'openProjectAPI#deleteFileLink', 'url' => '/file_links/{id}', 'verb' => 'DELETE'],
 	]
 ];

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -19,7 +19,9 @@ return [
 		['name' => 'openProjectAPI#getOpenProjectAvatar', 'url' => '/avatar', 'verb' => 'GET'],
 		['name' => 'openProjectAPI#getSearchedWorkPackages', 'url' => '/work-packages', 'verb' => 'GET'],
 		['name' => 'openProjectAPI#linkWorkPackageToFile', 'url' => '/work-packages', 'verb' => 'POST'],
+		['name' => 'openProjectAPI#getWorkPackageFileLinks', 'url' => '/work_packages/', 'verb' => 'GET'],
 		['name' => 'openProjectAPI#getOpenProjectWorkPackageStatus', 'url' => '/statuses/{id}', 'verb' => 'GET'],
 		['name' => 'openProjectAPI#getOpenProjectWorkPackageType', 'url' => '/types/{id}', 'verb' => 'GET'],
+		['name' => 'openProjectAPI#deleteFileLink', 'url' => '/file_links/{fileLinkId}', 'verb' => 'DELETE'],
 	]
 ];

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -19,7 +19,7 @@ return [
 		['name' => 'openProjectAPI#getOpenProjectAvatar', 'url' => '/avatar', 'verb' => 'GET'],
 		['name' => 'openProjectAPI#getSearchedWorkPackages', 'url' => '/work-packages', 'verb' => 'GET'],
 		['name' => 'openProjectAPI#linkWorkPackageToFile', 'url' => '/work-packages', 'verb' => 'POST'],
-		['name' => 'openProjectAPI#getWorkPackageFileLinks', 'url' => '/work_packages/', 'verb' => 'GET'],
+		['name' => 'openProjectAPI#getWorkPackageFileLinks', 'url' => '/work-packages/{id}/file-links', 'verb' => 'GET'],
 		['name' => 'openProjectAPI#getOpenProjectWorkPackageStatus', 'url' => '/statuses/{id}', 'verb' => 'GET'],
 		['name' => 'openProjectAPI#getOpenProjectWorkPackageType', 'url' => '/types/{id}', 'verb' => 'GET'],
 		['name' => 'openProjectAPI#deleteFileLink', 'url' => '/file-links/{id}', 'verb' => 'DELETE'],

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -22,6 +22,6 @@ return [
 		['name' => 'openProjectAPI#getWorkPackageFileLinks', 'url' => '/work_packages/', 'verb' => 'GET'],
 		['name' => 'openProjectAPI#getOpenProjectWorkPackageStatus', 'url' => '/statuses/{id}', 'verb' => 'GET'],
 		['name' => 'openProjectAPI#getOpenProjectWorkPackageType', 'url' => '/types/{id}', 'verb' => 'GET'],
-		['name' => 'openProjectAPI#deleteFileLink', 'url' => '/file_links/{id}', 'verb' => 'DELETE'],
+		['name' => 'openProjectAPI#deleteFileLink', 'url' => '/file-links/{id}', 'verb' => 'DELETE'],
 	]
 ];

--- a/lib/Controller/OpenProjectAPIController.php
+++ b/lib/Controller/OpenProjectAPIController.php
@@ -204,10 +204,10 @@ class OpenProjectAPIController extends Controller {
 
 	/**
 	 * @NoAdminRequired
-	 * @param int $workpackageId
+	 * @param int $id
 	 * @return DataResponse
 	 */
-	public function getWorkPackageFileLinks(int $id) {
+	public function getWorkPackageFileLinks(int $id): DataResponse {
 		if ($this->accessToken === '' || !OpenProjectAPIService::validateOpenProjectURL($this->openprojectUrl)) {
 			return new DataResponse('', Http::STATUS_BAD_REQUEST);
 		}
@@ -220,7 +220,7 @@ class OpenProjectAPIController extends Controller {
 		} catch (OpenprojectErrorException $e) {
 			return new DataResponse($e->getMessage(), Http::STATUS_BAD_REQUEST);
 		} catch (NotPermittedException | NotFoundException $e) {
-			return new DataResponse('file not found', Http::STATUS_NOT_FOUND);
+			return new DataResponse('work package not found', Http::STATUS_NOT_FOUND);
 		} catch (Exception $e) {
 			return new DataResponse($e->getMessage(), Http::STATUS_INTERNAL_SERVER_ERROR);
 		}

--- a/lib/Controller/OpenProjectAPIController.php
+++ b/lib/Controller/OpenProjectAPIController.php
@@ -232,14 +232,14 @@ class OpenProjectAPIController extends Controller {
 	 * @param int $fileLinkId
 	 * @return DataResponse
 	 */
-	public function deleteFileLink(int $fileLinkId): DataResponse {
+	public function deleteFileLink(int $id): DataResponse {
 		if ($this->accessToken === '' || !OpenProjectAPIService::validateOpenProjectURL($this->openprojectUrl)) {
 			return new DataResponse('', Http::STATUS_BAD_REQUEST);
 		}
 
 		try {
 			$result = $this->openprojectAPIService->deleteFileLink(
-				$fileLinkId,
+				$id,
 				$this->userId,
 			);
 		} catch (OpenprojectErrorException $e) {

--- a/lib/Controller/OpenProjectAPIController.php
+++ b/lib/Controller/OpenProjectAPIController.php
@@ -229,7 +229,7 @@ class OpenProjectAPIController extends Controller {
 
 	/**
 	 * @NoAdminRequired
-	 * @param int $fileLinkId
+	 * @param int $id
 	 * @return DataResponse
 	 */
 	public function deleteFileLink(int $id): DataResponse {

--- a/lib/Controller/OpenProjectAPIController.php
+++ b/lib/Controller/OpenProjectAPIController.php
@@ -219,8 +219,8 @@ class OpenProjectAPIController extends Controller {
 			);
 		} catch (OpenprojectErrorException $e) {
 			return new DataResponse($e->getMessage(), Http::STATUS_BAD_REQUEST);
-		} catch (NotPermittedException | NotFoundException $e) {
-			return new DataResponse('work package not found', Http::STATUS_NOT_FOUND);
+		} catch (NotFoundException $e) {
+			return new DataResponse($e->getMessage(), Http::STATUS_NOT_FOUND);
 		} catch (Exception $e) {
 			return new DataResponse($e->getMessage(), Http::STATUS_INTERNAL_SERVER_ERROR);
 		}
@@ -244,8 +244,8 @@ class OpenProjectAPIController extends Controller {
 			);
 		} catch (OpenprojectErrorException $e) {
 			return new DataResponse($e->getMessage(), Http::STATUS_BAD_REQUEST);
-		} catch (NotPermittedException | NotFoundException $e) {
-			return new DataResponse('file not found', Http::STATUS_NOT_FOUND);
+		} catch (NotFoundException $e) {
+			return new DataResponse($e->getMessage(), Http::STATUS_NOT_FOUND);
 		} catch (Exception $e) {
 			return new DataResponse($e->getMessage(), Http::STATUS_INTERNAL_SERVER_ERROR);
 		}

--- a/lib/Controller/OpenProjectAPIController.php
+++ b/lib/Controller/OpenProjectAPIController.php
@@ -203,6 +203,56 @@ class OpenProjectAPIController extends Controller {
 	}
 
 	/**
+	 * @NoAdminRequired
+	 * @param int $workpackageId
+	 * @return DataResponse
+	 */
+	public function getWorkPackageFileLinks(int $workpackageId) {
+		if ($this->accessToken === '' || !OpenProjectAPIService::validateOpenProjectURL($this->openprojectUrl)) {
+			return new DataResponse('', Http::STATUS_BAD_REQUEST);
+		}
+
+		try {
+			$result = $this->openprojectAPIService->getWorkPackageFileLinks(
+				$workpackageId,
+				$this->userId,
+			);
+		} catch (OpenprojectErrorException $e) {
+			return new DataResponse($e->getMessage(), Http::STATUS_BAD_REQUEST);
+		} catch (NotPermittedException | NotFoundException $e) {
+			return new DataResponse('file not found', Http::STATUS_NOT_FOUND);
+		} catch (Exception $e) {
+			return new DataResponse($e->getMessage(), Http::STATUS_INTERNAL_SERVER_ERROR);
+		}
+		return new DataResponse($result);
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @param int $fileLinkId
+	 * @return DataResponse
+	 */
+	public function deleteFileLink(int $fileLinkId): DataResponse {
+		if ($this->accessToken === '' || !OpenProjectAPIService::validateOpenProjectURL($this->openprojectUrl)) {
+			return new DataResponse('', Http::STATUS_BAD_REQUEST);
+		}
+
+		try {
+			$result = $this->openprojectAPIService->deleteFileLink(
+				$fileLinkId,
+				$this->userId,
+			);
+		} catch (OpenprojectErrorException $e) {
+			return new DataResponse($e->getMessage(), Http::STATUS_BAD_REQUEST);
+		} catch (NotPermittedException | NotFoundException $e) {
+			return new DataResponse('file not found', Http::STATUS_NOT_FOUND);
+		} catch (Exception $e) {
+			return new DataResponse($e->getMessage(), Http::STATUS_INTERNAL_SERVER_ERROR);
+		}
+		return new DataResponse($result);
+	}
+
+	/**
 	 * get status of work packages
 	 *
 	 * @NoAdminRequired

--- a/lib/Controller/OpenProjectAPIController.php
+++ b/lib/Controller/OpenProjectAPIController.php
@@ -207,14 +207,14 @@ class OpenProjectAPIController extends Controller {
 	 * @param int $workpackageId
 	 * @return DataResponse
 	 */
-	public function getWorkPackageFileLinks(int $workpackageId) {
+	public function getWorkPackageFileLinks(int $id) {
 		if ($this->accessToken === '' || !OpenProjectAPIService::validateOpenProjectURL($this->openprojectUrl)) {
 			return new DataResponse('', Http::STATUS_BAD_REQUEST);
 		}
 
 		try {
 			$result = $this->openprojectAPIService->getWorkPackageFileLinks(
-				$workpackageId,
+				$id,
 				$this->userId,
 			);
 		} catch (OpenprojectErrorException $e) {

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -409,7 +409,9 @@ class OpenProjectAPIService {
 				$response = $this->client->put($url, $options);
 			} elseif ($method === 'DELETE') {
 				$response = $this->client->delete($url, $options);
-				return ['success' => true];
+				if ($response->getStatusCode() === 204) {
+					return ['success' => true];
+				}
 			} else {
 				return ['error' => $this->l10n->t('Bad HTTP method')];
 			}

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -660,7 +660,8 @@ class OpenProjectAPIService {
 	/**
 	 * @param int $workpackageId
 	 * @param string $userId
-	 * @return array
+	 * @return array<mixed>
+	 * @throws NotFoundException
 	 * @throws OpenprojectErrorException
 	 * @throws OpenprojectResponseException
 	 */
@@ -685,8 +686,9 @@ class OpenProjectAPIService {
 	/**
 	 * @param int $fileLinkId
 	 * @param string $userId
-	 * @return array
-	 * @throws OpenprojectErrorException
+	 * @return array<mixed>
+	 * @throws NotFoundException
+	 * @throws OpenprojectErrorException|OpenprojectResponseException
 	 */
 	public function deleteFileLink(int $fileLinkId, string $userId): array {
 		$header = [
@@ -698,6 +700,11 @@ class OpenProjectAPIService {
 		);
 		if (isset($result['error'])) {
 			throw new OpenprojectErrorException($result['error']);
+		}
+		if (
+			!isset($result['success'])
+		) {
+			throw new OpenprojectResponseException('Malformed response');
 		}
 		return $result;
 	}

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -396,7 +396,9 @@ class OpenProjectAPIService {
 					$paramsContent .= http_build_query($params);
 					$url .= '?' . $paramsContent;
 				} else {
-					$options['body'] = $params['body'];
+					if (isset($params['body'])) {
+						$options['body'] = $params['body'];
+					}
 					$options['headers']['Content-Type'] = 'application/json';
 				}
 			}

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -409,6 +409,7 @@ class OpenProjectAPIService {
 				$response = $this->client->put($url, $options);
 			} elseif ($method === 'DELETE') {
 				$response = $this->client->delete($url, $options);
+				return ['success' => true];
 			} else {
 				return ['error' => $this->l10n->t('Bad HTTP method')];
 			}

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -32,7 +32,7 @@ use OCP\Files\NotPermittedException;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\ServerException;
 use GuzzleHttp\Exception\ConnectException;
-
+use OCP\AppFramework\Http;
 
 use OCA\OpenProject\AppInfo\Application;
 
@@ -401,6 +401,8 @@ class OpenProjectAPIService {
 					}
 					$options['headers']['Content-Type'] = 'application/json';
 				}
+			} elseif ($method === 'DELETE') {
+				$options['headers']['Content-Type'] = 'application/json';
 			}
 
 			if ($method === 'GET') {
@@ -411,7 +413,7 @@ class OpenProjectAPIService {
 				$response = $this->client->put($url, $options);
 			} elseif ($method === 'DELETE') {
 				$response = $this->client->delete($url, $options);
-				if ($response->getStatusCode() === 204) {
+				if ($response->getStatusCode() === Http::STATUS_NO_CONTENT) {
 					return ['success' => true];
 				}
 			} else {
@@ -691,19 +693,13 @@ class OpenProjectAPIService {
 	 * @throws OpenprojectErrorException|OpenprojectResponseException
 	 */
 	public function deleteFileLink(int $fileLinkId, string $userId): array {
-		$header = [
-			'Content-Type' => 'application/json'
-		];
-		$params['header'] = \Safe\json_encode($header);
 		$result = $this->request(
-			$userId, 'file_links/' . $fileLinkId, $params, 'DELETE'
+			$userId, 'file_links/' . $fileLinkId, [""], 'DELETE'
 		);
 		if (isset($result['error'])) {
 			throw new OpenprojectErrorException($result['error']);
 		}
-		if (
-			!isset($result['success'])
-		) {
+		if (!isset($result['success'])) {
 			throw new OpenprojectResponseException('Malformed response');
 		}
 		return $result;

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -684,8 +684,12 @@ class OpenProjectAPIService {
 	 * @throws OpenprojectErrorException
 	 */
 	public function deleteFileLink(int $fileLinkId, string $userId): array {
+		$header = [
+			'Content-Type' => 'application/json'
+		];
+		$params['header'] = \Safe\json_encode($header);
 		$result = $this->request(
-			$userId, 'file_links/' . $fileLinkId, [], 'DELETE'
+			$userId, 'file_links/' . $fileLinkId, $params, 'DELETE'
 		);
 		if (isset($result['error'])) {
 			throw new OpenprojectErrorException($result['error']);

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -604,7 +604,7 @@ class OpenProjectAPIService {
 		string $fileName,
 		string $storageUrl,
 		string $userId
-	) {
+	): int {
 		$file = $this->getNode($userId, $fileId);
 		if (!$file->isReadable()) {
 			throw new NotPermittedException();

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -653,6 +653,47 @@ class OpenProjectAPIService {
 	}
 
 	/**
+	 * @param int $workpackageId
+	 * @param string $userId
+	 * @return array
+	 * @throws OpenprojectErrorException
+	 * @throws OpenprojectResponseException
+	 */
+	public function getWorkPackageFileLinks(int $workpackageId, string $userId): array {
+		$result = $this->request(
+			$userId, 'work_packages/' . $workpackageId. '/file_links'
+		);
+		if (isset($result['error'])) {
+			throw new OpenprojectErrorException($result['error']);
+		}
+		if (
+			!isset($result['_type']) ||
+			$result['_type'] !== 'Collection' ||
+			!isset($result['_embedded']) ||
+			!isset($result['_embedded']['elements'])
+		) {
+			throw new OpenprojectResponseException('Malformed response');
+		}
+		return $result['_embedded']['elements'];
+	}
+
+	/**
+	 * @param int $fileLinkId
+	 * @param string $userId
+	 * @return array
+	 * @throws OpenprojectErrorException
+	 */
+	public function deleteFileLink(int $fileLinkId, string $userId): array {
+		$result = $this->request(
+			$userId, 'file_links/' . $fileLinkId, [], 'DELETE'
+		);
+		if (isset($result['error'])) {
+			throw new OpenprojectErrorException($result['error']);
+		}
+		return $result;
+	}
+
+	/**
 	 * checks if every admin config variables are set
 	 * checks if the oauth instance url is valid
 	 *

--- a/src/utils/workpackageHelper.js
+++ b/src/utils/workpackageHelper.js
@@ -40,6 +40,7 @@ export const workpackageHelper = {
 		const statusId = this.replaceHrefToGetId(workPackage._links.status.href)
 		const typeId = this.replaceHrefToGetId(workPackage._links.type.href)
 		const userId = this.replaceHrefToGetId(workPackage._links.assignee.href)
+		const projectId = this.replaceHrefToGetId(workPackage._links.project.href)
 		const userName = workPackage._links.assignee.title
 		const avatarUrl = generateUrl('/apps/integration_openproject/avatar?')
 			+ encodeURIComponent('userId')
@@ -52,6 +53,7 @@ export const workpackageHelper = {
 			id: workPackage.id,
 			subject: workPackage.subject,
 			project: workPackage._links.project.title,
+			projectId,
 			statusTitle: workPackage._links.status.title,
 			typeTitle: workPackage._links.type.title,
 			assignee: userName,

--- a/src/views/ProjectsTab.vue
+++ b/src/views/ProjectsTab.vue
@@ -73,6 +73,7 @@ export default {
 		state: 'loading',
 		workpackages: [],
 		requestUrl: loadState('integration_openproject', 'request-url'),
+		color: null,
 	}),
 	computed: {
 		isLoading() {
@@ -93,6 +94,9 @@ export default {
 			this.workpackages = []
 			this.state = 'loading'
 			await this.fetchWorkpackages(this.fileInfo.id)
+		},
+		changeBackground(){
+			this.color = '#F3F3F3'
 		},
 		checkForErrorCode(statusCode) {
 			if (statusCode === 200 || statusCode === 204) return
@@ -251,6 +255,9 @@ export default {
 		height: 0;
 		margin: 0px 10px;
 		border-bottom: 1px solid rgb(237 237 237);
+	}
+	.linked-workpackages:hover{
+		background-color: #F3F3F3;
 	}
 }
 

--- a/src/views/ProjectsTab.vue
+++ b/src/views/ProjectsTab.vue
@@ -35,8 +35,10 @@
 				:key="workpackage.id"
 				class="linked-workpackages">
 				<div class="linked-workpackages--workpackage">
-					<WorkPackage :workpackage="workpackage" />
-					<div class="linked-workpackages--workpackage--unlink icon-noConnection" />
+					<WorkPackage :workpackage="workpackage"
+								 v-on:click.native="getWorkPackageUrl(workpackage.id, workpackage.projectId)" />
+					<div class="linked-workpackages--workpackage--unlink icon-noConnection" 
+					@click="deleteWorkPackageLink(workpackage.id, fileInfo.id)" />
 				</div>
 				<div :class="{ 'workpackage-seperator': index !== workpackages.length-1 }" />
 			</div>
@@ -255,9 +257,6 @@ export default {
 		height: 0;
 		margin: 0px 10px;
 		border-bottom: 1px solid rgb(237 237 237);
-	}
-	.linked-workpackages:hover{
-		background-color: #F3F3F3;
 	}
 }
 

--- a/src/views/ProjectsTab.vue
+++ b/src/views/ProjectsTab.vue
@@ -132,7 +132,7 @@ export default {
 			if (response.status === 200) {
 				id = this.processLink(response.data, fileId)
 			}
-			const url = generateUrl('/apps/integration_openproject/file_links/' + id)
+			const url = generateUrl('/apps/integration_openproject/file-links/' + id)
 			response = await axios.delete(url)
 			this.checkForErrorCode(response.status)
 			if (response.status === 200) {

--- a/src/views/ProjectsTab.vue
+++ b/src/views/ProjectsTab.vue
@@ -126,18 +126,26 @@ export default {
 			window.open(workpackageUrl)
 		},
 		async deleteWorkPackageLink(workpackageId, fileId) {
-			let response = await axios.get(generateUrl('/apps/integration_openproject/work_packages?workpackageId=' + workpackageId))
+			let response = await axios.get(generateUrl(`/apps/integration_openproject/work-packages/${workpackageId}/file-links`))
 			this.checkForErrorCode(response.status)
 			let id
 			if (response.status === 200) {
 				id = this.processLink(response.data, fileId)
 			}
+
 			const url = generateUrl('/apps/integration_openproject/file-links/' + id)
-			response = await axios.delete(url)
-			this.checkForErrorCode(response.status)
-			if (response.status === 200) {
-				this.workpackages = this.workpackages.filter(workpackage => workpackage.id !== workpackageId)
+
+			try {
+				response = await axios.delete(url)
+				if (response.status === 200) {
+					this.workpackages = this.workpackages.filter(workpackage => workpackage.id !== workpackageId)
+				}
+			} catch (e) {
+				showError(
+					t('integration_openproject','Failed to delete file link to work-package')
+				)
 			}
+
 		},
 		processLink(data, fileId) {
 			let linkId

--- a/src/views/ProjectsTab.vue
+++ b/src/views/ProjectsTab.vue
@@ -131,11 +131,10 @@ export default {
 		},
 		unlink(workpackageId, fileId) {
 			OC.dialogs.confirmDestructive(
-				n('integration_openproject',
-					'Are you sure you want to unlink the work package?',
-					'Are you sure you want to unlink the work package?',
+				t('integration_openproject',
+					'Are you sure you want to unlink the work package?'
 				),
-				t('integration_openproject', 'Confirm deletion'),
+				t('integration_openproject', 'Confirm unlink'),
 				{
 					type: OC.dialogs.YES_NO_BUTTONS,
 					confirm: t('integration_openproject', 'unlink'),

--- a/src/views/ProjectsTab.vue
+++ b/src/views/ProjectsTab.vue
@@ -128,14 +128,14 @@ export default {
 		async deleteWorkPackageLink(workpackageId, fileId) {
 			let response = await axios.get(generateUrl('/apps/integration_openproject/work_packages?workpackageId=' + workpackageId))
 			this.checkForErrorCode(response.status)
-			let fileLinkId
+			let id
 			if (response.status === 200) {
-				fileLinkId = this.processLink(response.data, fileId)
+				id = this.processLink(response.data, fileId)
 			}
-			response = await axios.delete(generateUrl('/apps/integration_openproject/file_links/' + fileLinkId))
-			console.log(response)
+			const url = generateUrl('/apps/integration_openproject/file_links/' + id)
+			response = await axios.delete(url)
 			this.checkForErrorCode(response.status)
-			if (response.status === 204) {
+			if (response.status === 200) {
 				this.workpackages = this.workpackages.filter(workpackage => workpackage.id !== workpackageId)
 			}
 		},

--- a/src/views/ProjectsTab.vue
+++ b/src/views/ProjectsTab.vue
@@ -131,8 +131,10 @@ export default {
 			let fileLinkId
 			if (response.status === 200) {
 				fileLinkId = this.processLink(response.data, fileId)
+				console.log(typeof fileLinkId)
 			}
-			response = await axios.delete(generateUrl('/apps/integration_openproject/file_links/' + parseInt(fileLinkId)))
+
+			response = await axios.delete(generateUrl('/apps/integration_openproject/file_links/' + fileLinkId))
 			this.checkForErrorCode(response.status)
 			if (response.status === 200) {
 				this.workpackages = this.workpackages.filter(workpackage => workpackage.id !== workpackageId)

--- a/src/views/ProjectsTab.vue
+++ b/src/views/ProjectsTab.vue
@@ -95,7 +95,7 @@ export default {
 			await this.fetchWorkpackages(this.fileInfo.id)
 		},
 		checkForErrorCode(statusCode) {
-			if (statusCode === 200) return
+			if (statusCode === 200 || statusCode === 204) return
 			if (statusCode === 401) {
 				this.state = STATE_NO_TOKEN
 			} else {
@@ -131,12 +131,11 @@ export default {
 			let fileLinkId
 			if (response.status === 200) {
 				fileLinkId = this.processLink(response.data, fileId)
-				console.log(typeof fileLinkId)
 			}
-
 			response = await axios.delete(generateUrl('/apps/integration_openproject/file_links/' + fileLinkId))
+			console.log(response)
 			this.checkForErrorCode(response.status)
-			if (response.status === 200) {
+			if (response.status === 204) {
 				this.workpackages = this.workpackages.filter(workpackage => workpackage.id !== workpackageId)
 			}
 		},

--- a/tests/jest/components/tab/__snapshots__/SearchInput.spec.js.snap
+++ b/tests/jest/components/tab/__snapshots__/SearchInput.spec.js.snap
@@ -25,6 +25,7 @@ Object {
     "id": "1",
     "picture": "/server/index.php/apps/integration_openproject/avatar?userId=1&userName=System",
     "project": "test",
+    "projectId": "15",
     "statusCol": "blue",
     "statusTitle": "in-progress",
     "subject": "Organize work-packages",

--- a/tests/jest/components/tab/__snapshots__/SearchInput.spec.js.snap
+++ b/tests/jest/components/tab/__snapshots__/SearchInput.spec.js.snap
@@ -51,6 +51,7 @@ Object {
     "id": 1,
     "picture": "http://localhost/apps/integration_openproject/avatar?userId=&userName=some assignee",
     "project": "some project",
+    "projectId": "",
     "statusCol": "",
     "statusTitle": "some status",
     "subject": "some subject",

--- a/tests/jest/fixtures/workPackagesSearchResponse.json
+++ b/tests/jest/fixtures/workPackagesSearchResponse.json
@@ -3,6 +3,7 @@
         "id" : "1",
         "subject" : "Organize work-packages",
         "project" : "test",
+        "projectId" : "15",
         "statusTitle" :"in-progress",
         "typeTitle" : "task",
         "assignee" : "test",

--- a/tests/jest/fixtures/workPackagesSearchResponseNoAssignee.json
+++ b/tests/jest/fixtures/workPackagesSearchResponseNoAssignee.json
@@ -3,6 +3,7 @@
 		"id": "1",
 		"subject": "Organize work-packages",
 		"project": "test",
+		"projectId" : "15",
 		"statusTitle": "in-progress",
 		"typeTitle": "task",
 		"assignee": "",

--- a/tests/jest/views/ProjectsTab.spec.js
+++ b/tests/jest/views/ProjectsTab.spec.js
@@ -16,6 +16,8 @@ describe('ProjectsTab.vue Test', () => {
 	const workPackagesSelector = '#openproject-linked-workpackages'
 	const existingRelationSelector = '.existing-relations'
 	const searchInputStubSelector = 'searchinput-stub'
+	const linkedWorkpackageSelector = '.workpackage'
+	const workPackageUnlinkSelector = '.linked-workpackages--workpackage--unlink'
 
 	beforeEach(() => {
 		// eslint-disable-next-line no-import-assign
@@ -279,6 +281,41 @@ describe('ProjectsTab.vue Test', () => {
 			expect(wrapper.find(existingRelationSelector).exists()).toBeTruthy()
 			expect(workPackages.exists()).toBeTruthy()
 			expect(workPackages).toMatchSnapshot()
+		})
+	})
+	describe('on clicking the work package', () => {
+		it('opens it in open project', async () => {
+			axios.get
+				.mockImplementationOnce(() => Promise.resolve({
+					status: 200,
+					data: 'http://openproject',
+				}))
+			window.open = jest.fn()
+			wrapper = mountWrapper()
+			await wrapper.setData({
+				workpackages: workPackagesSearchResponse,
+			})
+			await localVue.nextTick()
+			await wrapper.find(linkedWorkpackageSelector).trigger('click')
+			await localVue.nextTick()
+			expect(window.open).toHaveBeenCalledTimes(1)
+			expect(window.open).toHaveBeenCalledWith(
+				'http://openproject/projects/15/work_packages/1'
+			)
+		})
+	})
+	describe('unlink', () => {
+		it.only('removes the file and work package relation', async () => {
+			wrapper = mountWrapper()
+			await wrapper.setData({
+				workpackages: workPackagesSearchResponse,
+			})
+			await localVue.nextTick()
+			await expect(wrapper.find(workPackageUnlinkSelector).exists()).toBeTruthy()
+			await wrapper.find(linkedWorkpackageSelector).trigger('mouseover')
+			await localVue.nextTick()
+			await wrapper.find(workPackageUnlinkSelector).trigger('click')
+			await expect(wrapper.find('.oc-dialog').exists()).toBeTruthy()
 		})
 	})
 })

--- a/tests/jest/views/ProjectsTab.spec.js
+++ b/tests/jest/views/ProjectsTab.spec.js
@@ -370,11 +370,9 @@ describe('ProjectsTab.vue Test', () => {
 			)
 			wrapper = mountWrapper()
 			await wrapper.vm.unlinkWorkPackage(15, 6)
-			expect(axiosGetSpy).toHaveBeenCalledTimes(1)
 			expect(axiosGetSpy).toBeCalledWith(
 				'http://localhost/apps/integration_openproject/work-packages/15/file-links'
 			)
-			expect(axiosDeleteSpy).toHaveBeenCalledTimes(1)
 			expect(axiosDeleteSpy).toBeCalledWith('http://localhost/apps/integration_openproject/file-links/66')
 		})
 	})

--- a/tests/jest/views/__snapshots__/ProjectsTab.spec.js.snap
+++ b/tests/jest/views/__snapshots__/ProjectsTab.spec.js.snap
@@ -193,8 +193,6 @@ exports[`ProjectsTab.vue Test onSave shows the just linked workpackage 1`] = `
         </div>
       </div>
       <div class="linked-workpackages--workpackage--unlink icon-noConnection"></div>
-      </div>
-      <div class="linked-workpackages--workpackage--unlink icon-noConnection"></div>
     </div>
     <div class=""></div>
   </div>

--- a/tests/jest/views/__snapshots__/ProjectsTab.spec.js.snap
+++ b/tests/jest/views/__snapshots__/ProjectsTab.spec.js.snap
@@ -193,6 +193,8 @@ exports[`ProjectsTab.vue Test onSave shows the just linked workpackage 1`] = `
         </div>
       </div>
       <div class="linked-workpackages--workpackage--unlink icon-noConnection"></div>
+      </div>
+      <div class="linked-workpackages--workpackage--unlink icon-noConnection"></div>
     </div>
     <div class=""></div>
   </div>

--- a/tests/lib/Controller/OpenProjectAPIControllerTest.php
+++ b/tests/lib/Controller/OpenProjectAPIControllerTest.php
@@ -15,6 +15,8 @@ use OCP\IRequest;
 use OCP\AppFramework\Http;
 use OCP\IURLGenerator;
 use PHPUnit\Framework\TestCase;
+use Exception;
+use OCP\Files\NotFoundException;
 
 class OpenProjectAPIControllerTest extends TestCase {
 	/** @var IConfig $configMock */
@@ -375,5 +377,149 @@ class OpenProjectAPIControllerTest extends TestCase {
 		$response = $controller->getOpenProjectWorkPackageType('3');
 		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
 		$this->assertSame(['error' => 'something went wrong'], $response->getData());
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testGetWorkPackageFileLinks(): void {
+		$this->getUserValueMock();
+		$service = $this->getMockBuilder(OpenProjectAPIService::class)
+			->disableOriginalConstructor()
+			->onlyMethods(['getWorkPackageFileLinks'])
+			->getMock();
+		$service->expects($this->once())
+			->method('getWorkPackageFileLinks')
+			->willReturn(["_type" => "FileLink", "id" => 8, "createdAt" => "2022-04-06T05:14:24Z", "updatedAt" => "2022-04-06T05:14:24Z"]);
+
+		$controller = new OpenProjectAPIController(
+			'integration_openproject', $this->requestMock, $this->configMock, $service, $this->urlGeneratorMock, 'test'
+		);
+		$response = $controller->getWorkPackageFileLinks(7);
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(["_type" => "FileLink", "id" => 8, "createdAt" => "2022-04-06T05:14:24Z", "updatedAt" => "2022-04-06T05:14:24Z"], $response->getData());
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testGetWorkPackageFileLinksErrorResponse(): void {
+		$this->getUserValueMock('');
+		$service = $this->createMock(OpenProjectAPIService::class);
+		$controller = new OpenProjectAPIController(
+			'integration_openproject', $this->requestMock, $this->configMock, $service, $this->urlGeneratorMock, 'test'
+		);
+		$response = $controller->getWorkPackageFileLinks(7);
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testGetWorkPackageFileLinksNotFound(): void {
+		$this->getUserValueMock();
+		$service = $this->getMockBuilder(OpenProjectAPIService::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$service
+			->method('getWorkPackageFileLinks')
+			->willThrowException(new NotFoundException('work package not found'));
+		$controller = new OpenProjectAPIController(
+			'integration_openproject', $this->requestMock, $this->configMock, $service, $this->urlGeneratorMock, 'test'
+		);
+		$response = $controller->getWorkPackageFileLinks(7);
+		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		$this->assertSame('work package not found', $response->getData());
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testGetWorkPackageFileLinksInternalServerError(): void {
+		$this->getUserValueMock();
+		$service = $this->getMockBuilder(OpenProjectAPIService::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$service
+			->method('getWorkPackageFileLinks')
+			->willThrowException(new Exception('something went wrong'));
+		$controller = new OpenProjectAPIController(
+			'integration_openproject', $this->requestMock, $this->configMock, $service, $this->urlGeneratorMock, 'test'
+		);
+		$response = $controller->getWorkPackageFileLinks(7);
+		$this->assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
+		$this->assertSame('something went wrong', $response->getData());
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testdeleteFileLink(): void {
+		$this->getUserValueMock();
+		$service = $this->getMockBuilder(OpenProjectAPIService::class)
+			->disableOriginalConstructor()
+			->onlyMethods(['deleteFileLink'])
+			->getMock();
+		$service->expects($this->once())
+			->method('deleteFileLink')
+			->willReturn(['success' => true]);
+
+		$controller = new OpenProjectAPIController(
+			'integration_openproject', $this->requestMock, $this->configMock, $service, $this->urlGeneratorMock, 'test'
+		);
+		$response = $controller->deleteFileLink(7);
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['success' => true], $response->getData());
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testdeleteFileLinkErrorResponse(): void {
+		$this->getUserValueMock('');
+		$service = $this->createMock(OpenProjectAPIService::class);
+		$controller = new OpenProjectAPIController(
+			'integration_openproject', $this->requestMock, $this->configMock, $service, $this->urlGeneratorMock, 'test'
+		);
+		$response = $controller->deleteFileLink(7);
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testdeleteFileLinkFileNotFound(): void {
+		$this->getUserValueMock();
+		$service = $this->getMockBuilder(OpenProjectAPIService::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$service
+			->method('deleteFileLink')
+			->willThrowException(new NotFoundException('file not found'));
+		$controller = new OpenProjectAPIController(
+			'integration_openproject', $this->requestMock, $this->configMock, $service, $this->urlGeneratorMock, 'test'
+		);
+		$response = $controller->deleteFileLink(7);
+		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		$this->assertSame('file not found', $response->getData());
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testdeleteFileLinkInternalServerError(): void {
+		$this->getUserValueMock();
+		$service = $this->getMockBuilder(OpenProjectAPIService::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$service
+			->method('deleteFileLink')
+			->willThrowException(new Exception('something went wrong'));
+		$controller = new OpenProjectAPIController(
+			'integration_openproject', $this->requestMock, $this->configMock, $service, $this->urlGeneratorMock, 'test'
+		);
+		$response = $controller->deleteFileLink(7);
+		$this->assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
+		$this->assertSame('something went wrong', $response->getData());
 	}
 }

--- a/tests/lib/Controller/OpenProjectAPIControllerTest.php
+++ b/tests/lib/Controller/OpenProjectAPIControllerTest.php
@@ -390,14 +390,26 @@ class OpenProjectAPIControllerTest extends TestCase {
 			->getMock();
 		$service->expects($this->once())
 			->method('getWorkPackageFileLinks')
-			->willReturn(["_type" => "FileLink", "id" => 8, "createdAt" => "2022-04-06T05:14:24Z", "updatedAt" => "2022-04-06T05:14:24Z"]);
+			->willReturn([[
+				'id' => 8,
+				'_type' => "FileLink",
+				'originData' => [
+					'id' => 5
+				]
+			]]);
 
 		$controller = new OpenProjectAPIController(
 			'integration_openproject', $this->requestMock, $this->configMock, $service, $this->urlGeneratorMock, 'test'
 		);
 		$response = $controller->getWorkPackageFileLinks(7);
 		$this->assertSame(Http::STATUS_OK, $response->getStatus());
-		$this->assertSame(["_type" => "FileLink", "id" => 8, "createdAt" => "2022-04-06T05:14:24Z", "updatedAt" => "2022-04-06T05:14:24Z"], $response->getData());
+		$this->assertSame([[
+			'id' => 8,
+			'_type' => "FileLink",
+			'originData' => [
+				'id' => 5
+			]
+		]], $response->getData());
 	}
 
 	/**
@@ -454,7 +466,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 	/**
 	 * @return void
 	 */
-	public function testdeleteFileLink(): void {
+	public function testDeleteFileLink(): void {
 		$this->getUserValueMock();
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
@@ -475,7 +487,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 	/**
 	 * @return void
 	 */
-	public function testdeleteFileLinkErrorResponse(): void {
+	public function testDeleteFileLinkErrorResponse(): void {
 		$this->getUserValueMock('');
 		$service = $this->createMock(OpenProjectAPIService::class);
 		$controller = new OpenProjectAPIController(
@@ -488,7 +500,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 	/**
 	 * @return void
 	 */
-	public function testdeleteFileLinkFileNotFound(): void {
+	public function testDeleteFileLinkFileNotFound(): void {
 		$this->getUserValueMock();
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
@@ -507,7 +519,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 	/**
 	 * @return void
 	 */
-	public function testdeleteFileLinkInternalServerError(): void {
+	public function testDeleteFileLinkInternalServerError(): void {
 		$this->getUserValueMock();
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -18,6 +18,7 @@ use OC\Avatar\GuestAvatar;
 use OC\Http\Client\Client;
 use OC_Util;
 use OCA\OpenProject\Exception\OpenprojectErrorException;
+use OCA\OpenProject\Exception\OpenprojectResponseException;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
@@ -1458,4 +1459,119 @@ class OpenProjectAPIServiceTest extends TestCase {
 
 		$this->assertSame($expected, $this->service::isAdminConfigOk($configMock));
 	}
+
+	/**
+	 * @return void
+	 */
+	public function testGetWorkPackageFileLinksResponse(): void {
+		$service = $this->getServiceMock();
+		$service->method('request')
+			->willReturn([
+				'_type' => 'Collection',
+				'_embedded' => [
+					'elements' => [
+						[
+							'id' => 8,
+							'_type' => "FileLink",
+							'originData' => [
+								'id' => 5
+							],
+						]
+					]
+				]
+			]);
+		$result = $service->getWorkPackageFileLinks(7, 'user');
+		$this->assertSame([[
+			'id' => 8,
+			'_type' => "FileLink",
+			'originData' => [
+				'id' => 5
+			]
+		]], $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testGetWorkPackageFileLinksErrorResponse(): void {
+		$service = $this->getServiceMock();
+		$service->method('request')
+			->willReturn([
+				'error' => 'something went wrong',
+			]);
+		$this->expectException(OpenprojectErrorException::class);
+		$service->getWorkPackageFileLinks(7, 'user');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testGetWorkPackageFileLinksMalFormedResponse(): void {
+		$service = $this->getServiceMock();
+		$service->method('request')
+				->willReturn([
+					'_type' => '',
+				]);
+		$this->expectException(OpenprojectResponseException::class);
+		$service->getWorkPackageFileLinks(7, 'user');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testDeleteFileLinkResponse(): void {
+		$service = $this->getServiceMock();
+		$service->method('request')
+			->willReturn([
+				'success' => true
+			]);
+		$result = $service->deleteFileLink(7, 'user');
+		$this->assertSame([
+			'success' => true
+		], $result);
+	}
+
+
+	/**
+	 * @return void
+	 */
+	public function testDeleteFileLinkErrorResponse(): void {
+		$service = $this->getServiceMock();
+		$service->method('request')
+			->willReturn([
+				'error' => 'something went wrong',
+			]);
+		$this->expectException(OpenprojectErrorException::class);
+		$service->deleteFileLink(7, 'user');
+	}
+
+//	/**
+//	 * @return void
+//	 */
+//	public function testGetWorkPackageFileLinksPact(): void {
+//		$consumerRequest = new ConsumerRequest();
+//		$consumerRequest
+//			->setMethod('GET')
+//			->setPath('/api/v3/work_package/7/3')
+//			->setHeaders(["Authorization" => "Bearer 1234567890"]);
+//		$providerResponse = new ProviderResponse();
+//		$providerResponse
+//			->setStatus(Http::STATUS_OK)
+//			->addHeader('Content-Type', 'application/json')
+//			->setBody(["_type" => "Type", "id" => 3, "name" => "Phase",
+//				"color" => "#CC5DE8", "position" => 4, "isDefault" => true, "isMilestone" => false, "createdAt" => "2022-01-12T08:53:15Z", "updatedAt" => "2022-01-12T08:53:34Z"]);
+//
+//		$this->builder
+//			->uponReceiving('a GET request to /type ')
+//			->with($consumerRequest)
+//			->willRespondWith($providerResponse);
+//
+//		$result = $this->service->getOpenProjectWorkPackageType(
+//			'testUser',
+//			'3'
+//		);
+//
+//		$this->assertSame(["_type" => "Type", "id" => 3, "name" => "Phase",
+//			"color" => "#CC5DE8", "position" => 4, "isDefault" => true, "isMilestone" => false, "createdAt" => "2022-01-12T08:53:15Z", "updatedAt" => "2022-01-12T08:53:34Z"], $result);
+//	}
 }


### PR DESCRIPTION
https://community.openproject.org/wp/41290

This PR adds:
- Implementation of navigation to open project work package while clicking on the linked wp in the project tab
- Implementation of unlinking of the work package and file upon clicking a unlink button that appears on hover 
- Unit tests and pact tests

## UI Design 

### light theme
![unlinkDialog](https://user-images.githubusercontent.com/41103328/162922876-75198c0a-6363-4d66-aa10-f7f4f4510586.png)
![deleted](https://user-images.githubusercontent.com/41103328/162922881-54f72fad-5b6b-4fd6-bcba-f6f4c28af856.png)

### dark theme
![dialogDark](https://user-images.githubusercontent.com/41103328/162922982-a9355d47-b20a-457d-a444-091e589e59a8.png)
![unlinked](https://user-images.githubusercontent.com/41103328/162922987-b653465b-e6d8-4ef6-a78f-9c74c7b04865.png)

