### PR TITLE
change postgresql port mapping to not conflict with openproject db

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     container_name: integration_openproject_db
     restart: always
     ports:
-      - "5433:5432"
+      - "2345:5432"
     volumes:
       - db:/var/lib/postgresql/data
     environment:
@@ -23,7 +23,7 @@ services:
       - nextcloud:/var/www/html
       - ${APP_DIR:-./../../custom_apps}:/var/www/html/custom_apps
     environment:
-      - POSTGRES_HOST=localhost:5433
+      - POSTGRES_HOST=localhost:2345
       - POSTGRES_DB=nextcloud
       - POSTGRES_USER=nextcloud
       - POSTGRES_PASSWORD=nextcloud


### PR DESCRIPTION
While using a local open project setup with PostgreSQL DB and docker-compose for nextcloud and the integration app:
```bash
foreman start -f Procfile.dev
```
exits being not happy with port `5433` for the database.
```console
Error response from daemon: driver failed programming external connectivity on endpoint integration_openproject_db (1ec90895fe355fa3bc3cbaf4c694596cde695bf9672f33ba3a9d2d8a519bc51e): Error starting userland proxy: listen tcp4 0.0.0.0:5433: bind: address already in use
```

With this PR, the integration app DB port is mapped to more unique code for the host machine.

Signed-off-by: Kiran Parajuli <kiranparajuli589@gmail.com>