### PR TITLE
Fix tab icon color in dark mode

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -26,6 +26,6 @@
 	background-image: url(./../img/app.svg);
 }
 
-body.theme--dark .icon-openproject .icon-noConnection, body.theme--dark .icon-open-project::after {
+body.theme--dark .icon-openproject, .icon-noConnection, .icon-open-project::after {
 	filter: none;
 }


### PR DESCRIPTION
## Description

after some recent CSS modifications, openproject icon color in the sidebar tab is black for dark theme
this pr should fix this case

## Screenshots
**Before**
![Screenshot from 2022-03-31 15-06-26](https://user-images.githubusercontent.com/39373750/161022386-8b68e20a-c627-44dc-992b-5bb7c0ffaad4.png)
**After**
![Screenshot from 2022-03-31 15-05-55](https://user-images.githubusercontent.com/39373750/161022403-7607f201-1275-47a4-8094-011dbf4a2c6f.png)


Signed-off-by: Parajuli Kiran <kiranparajuli589@gmail.com>