### PR TITLE
Automatically create a NC OAuth client for OpenProject

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -14,6 +14,7 @@ return [
 		['name' => 'config#oauthRedirect', 'url' => '/oauth-redirect', 'verb' => 'GET'],
 		['name' => 'config#setConfig', 'url' => '/config', 'verb' => 'PUT'],
 		['name' => 'config#setAdminConfig', 'url' => '/admin-config', 'verb' => 'PUT'],
+		['name' => 'config#autoOauthCreation', 'url' => '/nc-oauth', 'verb' => 'POST'],
 		['name' => 'openProjectAPI#getNotifications', 'url' => '/notifications', 'verb' => 'GET'],
 		['name' => 'openProjectAPI#getOpenProjectUrl', 'url' => '/url', 'verb' => 'GET'],
 		['name' => 'openProjectAPI#getOpenProjectAvatar', 'url' => '/avatar', 'verb' => 'GET'],

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -123,12 +123,12 @@ class ConfigController extends Controller {
 			$this->config->setAppValue(Application::APP_ID, $key, trim($value));
 		}
 		if (isset($values['oauth_instance_url'])) {
-			$oauthClientInternalId = $this->config->getAppValue(Application::APP_ID, 'nc-oauth-client-id', '');
+			$oauthClientInternalId = $this->config->getAppValue(Application::APP_ID, 'nc_oauth_client_id', '');
 			if ($oauthClientInternalId !== '') {
 				$id = (int) $oauthClientInternalId;
 				$this->oauthService->deleteClient($id);
 			}
-			$this->config->deleteAppValue(Application::APP_ID, 'nc-oauth-client-id');
+			$this->config->deleteAppValue(Application::APP_ID, 'nc_oauth_client_id');
 		}
 		return new DataResponse(1);
 	}
@@ -242,7 +242,7 @@ class ConfigController extends Controller {
 	 * @return DataResponse
 	 */
 	public function autoOauthCreation(): DataResponse {
-		$oauthClientInternalId = $this->config->getAppValue(Application::APP_ID, 'nc-oauth-client-id', '');
+		$oauthClientInternalId = $this->config->getAppValue(Application::APP_ID, 'nc_oauth_client_id', '');
 		if ($oauthClientInternalId !== '') {
 			$id = (int) $oauthClientInternalId;
 			$clientInfo = $this->oauthService->getClientInfo($id);
@@ -251,8 +251,9 @@ class ConfigController extends Controller {
 			}
 		}
 
-		$clientInfo = $this->oauthService->createNcOauthClient('OpenProject client', 'https://to.be.generated');
-		$this->config->setAppValue(Application::APP_ID, 'nc-oauth-client-id', $clientInfo['id']);
+		$opUrl = $this->config->getAppValue(Application::APP_ID, 'oauth_instance_url', '');
+		$clientInfo = $this->oauthService->createNcOauthClient('OpenProject client', rtrim($opUrl, '/') . '/oauth/redirect');
+		$this->config->setAppValue(Application::APP_ID, 'nc_oauth_client_id', $clientInfo['id']);
 		return new DataResponse($clientInfo);
 	}
 

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -123,6 +123,11 @@ class ConfigController extends Controller {
 			$this->config->setAppValue(Application::APP_ID, $key, trim($value));
 		}
 		if (isset($values['oauth_instance_url'])) {
+			$oauthClientInternalId = $this->config->getAppValue(Application::APP_ID, 'nc-oauth-client-id', '');
+			if ($oauthClientInternalId !== '') {
+				$id = (int) $oauthClientInternalId;
+				$this->oauthService->deleteClient($id);
+			}
 			$this->config->deleteAppValue(Application::APP_ID, 'nc-oauth-client-id');
 		}
 		return new DataResponse(1);

--- a/lib/Service/OauthService.php
+++ b/lib/Service/OauthService.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Nextcloud - openproject
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Julien Veyssier
+ * @copyright Julien Veyssier 2022
+ */
+
+namespace OCA\OpenProject\Service;
+
+
+use OCA\OAuth2\Db\Client;
+use OCA\OAuth2\Db\ClientMapper;
+use OCA\OAuth2\Exceptions\ClientNotFoundException;
+use OCP\Security\ISecureRandom;
+
+use OCA\OpenProject\AppInfo\Application;
+
+class OauthService {
+	/**
+	 * @var ISecureRandom
+	 */
+	private $secureRandom;
+
+	public const validChars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+	/**
+	 * @var ClientMapper
+	 */
+	private $clientMapper;
+
+	/**
+	 * Service to manipulate Nextcloud oauth clients
+	 */
+	public function __construct(string $appName,
+								ClientMapper $clientMapper,
+								ISecureRandom $secureRandom) {
+		$this->appName = $appName;
+		$this->secureRandom = $secureRandom;
+		$this->clientMapper = $clientMapper;
+	}
+
+	/**
+	 * @param string $name
+	 * @param string $redirectUri
+	 * @return array
+	 */
+	public function createNcOauthClient(string $name, string $redirectUri): array {
+		$client = new Client();
+		$client->setName($name);
+		$client->setRedirectUri($redirectUri);
+		$client->setSecret($this->secureRandom->generate(64, self::validChars));
+		$client->setClientIdentifier($this->secureRandom->generate(64, self::validChars));
+		$client = $this->clientMapper->insert($client);
+
+		return $this->generateClientInfo($client);
+	}
+
+	/**
+	 * @param string $id
+	 * @return array|null
+	 */
+	public function getClientInfo(string $id): ?array {
+		try {
+			$client = $this->clientMapper->getByUid($id);
+			return $this->generateClientInfo($client);
+		} catch (ClientNotFoundException $e) {
+			return null;
+		}
+	}
+
+	/**
+	 * @param Client $client
+	 * @return array
+	 */
+	private function generateClientInfo(Client $client): array {
+		return [
+			'id' => $client->getId(),
+			'name' => $client->getName(),
+			'redirectUri' => $client->getRedirectUri(),
+			'clientId' => $client->getClientIdentifier(),
+			'clientSecret' => $client->getSecret(),
+		];
+	}
+}

--- a/lib/Service/OauthService.php
+++ b/lib/Service/OauthService.php
@@ -12,6 +12,7 @@
 namespace OCA\OpenProject\Service;
 
 
+use OCA\OAuth2\Db\AccessTokenMapper;
 use OCA\OAuth2\Db\Client;
 use OCA\OAuth2\Db\ClientMapper;
 use OCA\OAuth2\Exceptions\ClientNotFoundException;
@@ -30,16 +31,22 @@ class OauthService {
 	 * @var ClientMapper
 	 */
 	private $clientMapper;
+	/**
+	 * @var AccessTokenMapper
+	 */
+	private $accessTokenMapper;
 
 	/**
 	 * Service to manipulate Nextcloud oauth clients
 	 */
 	public function __construct(string $appName,
 								ClientMapper $clientMapper,
+								AccessTokenMapper $accessTokenMapper,
 								ISecureRandom $secureRandom) {
 		$this->appName = $appName;
 		$this->secureRandom = $secureRandom;
 		$this->clientMapper = $clientMapper;
+		$this->accessTokenMapper = $accessTokenMapper;
 	}
 
 	/**
@@ -83,5 +90,18 @@ class OauthService {
 			'clientId' => $client->getClientIdentifier(),
 			'clientSecret' => $client->getSecret(),
 		];
+	}
+
+	/**
+	 * @param int $id
+	 * @return void
+	 */
+	public function deleteClient(int $id): void {
+		try{
+			$client = $this->clientMapper->getByUid($id);
+			$this->accessTokenMapper->deleteByClientId($id);
+			$this->clientMapper->delete($client);
+		} catch (ClientNotFoundException $e) {
+		}
 	}
 }

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -43,7 +43,7 @@ class Admin implements ISettings {
 
 		// get automatically created NC oauth client for OP
 		$clientInfo = null;
-		$oauthClientInternalId = $this->config->getAppValue(Application::APP_ID, 'nc-oauth-client-id', '');
+		$oauthClientInternalId = $this->config->getAppValue(Application::APP_ID, 'nc_oauth_client_id', '');
 		if ($oauthClientInternalId !== '') {
 			$id = (int)$oauthClientInternalId;
 			$clientInfo = $this->oauthService->getClientInfo($id);

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -17,7 +17,7 @@
 				v-model="state.oauth_instance_url"
 				type="text"
 				:placeholder="t('integration_openproject', 'OpenProject address')"
-				@input="onInput">
+				@input="onInput(true)">
 			<label for="openproject-client-id">
 				<a class="icon icon-category-auth" />
 				{{ t('integration_openproject', 'Client ID') }}
@@ -40,6 +40,31 @@
 				:placeholder="t('integration_openproject', 'Client secret of the OAuth app in OpenProject')"
 				@focus="readonly = false"
 				@input="onInput">
+			<button v-if="state.nc_oauth_client === null"
+				@click="onNextcloudOauthCreateClick">
+				{{ t('integration_openproject', 'Create a Nextcloud OAuth client for OpenProject') }}
+			</button>
+			<span v-if="state.nc_oauth_client === null" />
+			<label v-if="state.nc_oauth_client !== null"
+				for="nextcloud-client-id">
+				<a class="icon icon-category-auth" />
+				{{ t('integration_openproject', 'Nextcloud client ID') }}
+			</label>
+			<input v-if="state.nc_oauth_client !== null"
+				id="openproject-client-id"
+				:value="state.nc_oauth_client.clientId"
+				type="text"
+				:readonly="true">
+			<label v-if="state.nc_oauth_client !== null"
+				for="nextcloud-client-secret">
+				<a class="icon icon-category-auth" />
+				{{ t('integration_openproject', 'Nextcloud client secret') }}
+			</label>
+			<input v-if="state.nc_oauth_client !== null"
+				id="openproject-client-secret"
+				:value="state.nc_oauth_client.clientSecret"
+				type="text"
+				:readonly="true">
 		</div>
 	</div>
 </template>
@@ -69,11 +94,14 @@ export default {
 		}
 	},
 	methods: {
-		onInput() {
+		onInput(resetNcOauthClient = false) {
 			const that = this
 			delay(() => {
 				that.saveOptions()
 			}, 2000)()
+			if (resetNcOauthClient) {
+				this.state.nc_oauth_client = null
+			}
 		},
 		saveOptions() {
 			const req = {
@@ -94,6 +122,17 @@ export default {
 						+ ': ' + error.response.request.responseText
 					)
 				})
+		},
+		onNextcloudOauthCreateClick() {
+			const url = generateUrl('/apps/integration_openproject/nc-oauth')
+			axios.post(url).then((response) => {
+				this.state.nc_oauth_client = response.data
+			}).catch((error) => {
+				showError(
+					t('integration_openproject', 'Failed to create Nextcloud OAuth client')
+					+ ': ' + error.response.request.responseText
+				)
+			})
 		},
 	},
 }


### PR DESCRIPTION
Hey, here is a basic implementation of automatic creation of a Nextcloud OAuth client for the currently configured OpenProject instance.

Basically, in the admin settings, a button shows up if no NC OAuth client has been created yet. It triggers the creation of a NC OAuth client and the ID/secret are then displayed. When the OP instance URL changes, the client is automatically deleted.

TODO:
* [ ] The generated redirect URL is most likely invalid. It is now `https://OP_INSTANCE_URL/oauth/redirect`
* [ ] Improve admin settings design, messages and labels

@wielinde It looks like that:
![op](https://user-images.githubusercontent.com/11291457/162420160-30a5a76e-b460-420d-8c8f-b8057067ce3c.gif)
