### PR TITLE
[Bug/42140] the search result isnt cleared when a work package is selected

### DIFF
--- a/src/components/tab/SearchInput.vue
+++ b/src/components/tab/SearchInput.vue
@@ -89,14 +89,17 @@ export default {
 		fileInfo(oldFile, newFile) {
 			if (oldFile.id !== newFile.id) {
 				this.resetState()
-				// FIXME: https://github.com/shentao/vue-multiselect/issues/633
-				if (this.$refs.workPackageMultiSelect?.$refs?.VueMultiselect?.search) {
-					this.$refs.workPackageMultiSelect.$refs.VueMultiselect.search = ''
-				}
+				this.emptySearchInput()
 			}
 		},
 	},
 	methods: {
+		emptySearchInput() {
+			// FIXME: https://github.com/shentao/vue-multiselect/issues/633
+			if (this.$refs.workPackageMultiSelect?.$refs?.VueMultiselect?.search) {
+				this.$refs.workPackageMultiSelect.$refs.VueMultiselect.search = ''
+			}
+		},
 		resetState() {
 			this.searchResults = []
 			this.state = STATE_OK
@@ -137,6 +140,8 @@ export default {
 			try {
 				await axios.post(url, params, config)
 				this.$emit('saved', selectedOption)
+				this.resetState()
+				this.emptySearchInput()
 			} catch (e) {
 				showError(
 					this.translate('Failed to link file to work-package')

--- a/tests/jest/components/tab/SearchInput.spec.js
+++ b/tests/jest/components/tab/SearchInput.spec.js
@@ -389,6 +389,15 @@ describe('SearchInput.vue tests', () => {
 				)
 				postSpy.mockRestore()
 			})
+			it('should reset the state of the search input', async () => {
+				const multiselectItem = wrapper.find(multiSelectItemSelector)
+				expect(wrapper.vm.searchResults.length).toBe(1)
+				expect(wrapper.find('input').element.value).toBe('orga')
+				await multiselectItem.trigger('click')
+				expect(wrapper.vm.searchResults.length).toBe(0)
+				expect(wrapper.find('input').element.value).toBe('')
+
+			})
 			it('should show an error when linking failed', async () => {
 				const err = new Error()
 				err.response = { status: 422 }


### PR DESCRIPTION
### Description
Reset the search input state after a work package is linked successfully

### Related
OP#42140
https://community.openproject.org/projects/nextcloud-integration/work_packages/42140/github