### PR TITLE
[Bug/42097] relations/notifications even when the oauth information is not complete

### DIFF
--- a/src/components/tab/EmptyContent.vue
+++ b/src/components/tab/EmptyContent.vue
@@ -61,7 +61,7 @@ export default {
 			return require('../../../img/addLink.svg')
 		},
 		showConnectButton() {
-			return [STATE.ERROR, STATE.NO_TOKEN].includes(this.state)
+			return [STATE.ERROR, STATE.NO_TOKEN, STATE.CONNECTION_ERROR].includes(this.state)
 		},
 		emptyContentTitleMessage() {
 			if (this.state === STATE.NO_TOKEN) {

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -139,6 +139,10 @@ export default {
 			clearInterval(this.loop)
 		},
 		async launchLoop() {
+			if (!this.requestUrl) {
+				this.state = STATE.ERROR
+				return
+			}
 			// get openproject URL first
 			try {
 				const response = await axios.get(generateUrl('/apps/integration_openproject/url'))

--- a/src/views/ProjectsTab.vue
+++ b/src/views/ProjectsTab.vue
@@ -96,7 +96,12 @@ export default {
 			this.fileInfo = fileInfo
 			this.workpackages = []
 			this.state = STATE.LOADING
-			await this.fetchWorkpackages(this.fileInfo.id)
+			if (this.requestUrl) {
+				// only fetch if we have a request url
+				await this.fetchWorkpackages(this.fileInfo.id)
+			} else {
+				this.state = STATE.CONNECTION_ERROR
+			}
 		},
 		checkForErrorCode(statusCode) {
 			if (statusCode === 200 || statusCode === 204) return

--- a/tests/jest/components/tab/EmptyContent.spec.js
+++ b/tests/jest/components/tab/EmptyContent.spec.js
@@ -19,6 +19,9 @@ describe('EmptyContent.vue Test', () => {
 		}, {
 			state: STATE.ERROR,
 			viewed: true,
+		}, {
+			state: STATE.CONNECTION_ERROR,
+			viewed: true,
 		}])('should be displayed depending on the state', (cases) => {
 			wrapper = getWrapper({ state: cases.state })
 			expect(wrapper.find(connectButtonSelector).exists()).toBe(cases.viewed)

--- a/tests/jest/views/ProjectsTab.spec.js
+++ b/tests/jest/views/ProjectsTab.spec.js
@@ -215,6 +215,17 @@ describe('ProjectsTab.vue Test', () => {
 			await wrapper.vm.update({ id: 123 })
 			expect(wrapper.vm.state).toBe(STATE.OK)
 		})
+		it('sets the "connection-error" state if the request url is not valid', async () => {
+			const wrapper = mountWrapper()
+			axios.get
+				.mockImplementation(() => Promise.resolve({ status: 200, data: [] }))
+			await wrapper.setData({
+				requestUrl: false,
+			})
+			await wrapper.vm.update({ id: 123 })
+			expect(wrapper.vm.state).toBe(STATE.CONNECTION_ERROR)
+			expect(wrapper).toMatchSnapshot()
+		})
 		it.each([
 			{ statusColor: { color: '#A5D8FF' }, typeColor: { color: '#00B0F0' } },
 			{ statusColor: { }, typeColor: { } },
@@ -405,6 +416,7 @@ function mountWrapper() {
 		stubs: {
 			SearchInput: true,
 			Avatar: true,
+			EmptyContent: false,
 		},
 		data: () => ({
 			error: '',

--- a/tests/jest/views/__snapshots__/ProjectsTab.spec.js.snap
+++ b/tests/jest/views/__snapshots__/ProjectsTab.spec.js.snap
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ProjectsTab.vue Test fetchWorkpackages sets the "connection-error" state if the request url is not valid 1`] = `
+<div class="projects">
+  <!---->
+  <div class="empty-content" id="openproject-empty-content">
+    <div class="empty-content--wrapper">
+      <div class="empty-content--icon"><img src="" alt="error"></div>
+      <!---->
+      <div class="empty-content--connect-button">
+        <div class="oauth-connect--message">
+          Some OpenProject integration application settings are not working. Please contact your Nextcloud administrator.
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`ProjectsTab.vue Test fetchWorkpackages shows the linked workpackages 1`] = `
 <div class="" id="openproject-linked-workpackages">
   <div class="existing-relations">


### PR DESCRIPTION
### Description
OP#42097,
- do not fetch work packages if the admin config is not ok
- do not fetch notifications if the admin config is not ok

### Related
https://community.openproject.org/projects/nextcloud-integration/work_packages/42097