### PR TITLE
OP#41949 allways send storageUrl

### DIFF
--- a/lib/Controller/OpenProjectAPIController.php
+++ b/lib/Controller/OpenProjectAPIController.php
@@ -25,7 +25,6 @@ use OCP\AppFramework\Controller;
 
 use OCA\OpenProject\Service\OpenProjectAPIService;
 use OCA\OpenProject\AppInfo\Application;
-use OCP\IURLGenerator;
 
 class OpenProjectAPIController extends Controller {
 
@@ -58,16 +57,10 @@ class OpenProjectAPIController extends Controller {
 	 */
 	private $openprojectUrl;
 
-	/**
-	 * @var IURLGenerator
-	 */
-	private $urlGenerator;
-
 	public function __construct(string $appName,
 								IRequest $request,
 								IConfig $config,
 								OpenProjectAPIService $openprojectAPIService,
-								IURLGenerator         $urlGenerator,
 								?string $userId) {
 		parent::__construct($appName, $request);
 		$this->openprojectAPIService = $openprojectAPIService;
@@ -77,7 +70,6 @@ class OpenProjectAPIController extends Controller {
 		$this->clientID = $config->getAppValue(Application::APP_ID, 'client_id');
 		$this->clientSecret = $config->getAppValue(Application::APP_ID, 'client_secret');
 		$this->openprojectUrl = $config->getAppValue(Application::APP_ID, 'oauth_instance_url');
-		$this->urlGenerator = $urlGenerator;
 	}
 
 	/**
@@ -153,8 +145,7 @@ class OpenProjectAPIController extends Controller {
 		$result = $this->openprojectAPIService->searchWorkPackage(
 			$this->userId,
 			$searchQuery,
-			$fileId,
-			$this->urlGenerator->getBaseUrl()
+			$fileId
 		);
 
 		if (!isset($result['error'])) {
@@ -182,14 +173,11 @@ class OpenProjectAPIController extends Controller {
 			return new DataResponse('', Http::STATUS_BAD_REQUEST);
 		}
 
-		$storageUrl = $this->urlGenerator->getBaseUrl();
-
 		try {
 			$result = $this->openprojectAPIService->linkWorkPackageToFile(
 				$workpackageId,
 				$fileId,
 				$fileName,
-				$storageUrl,
 				$this->userId,
 			);
 		} catch (OpenprojectErrorException $e) {

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -72,6 +72,12 @@ class OpenProjectAPIService {
 
 	/** @var IRootFolder */
 	private $storage;
+
+	/**
+	 * @var IURLGenerator
+	 */
+	private $urlGenerator;
+
 	/**
 	 * Service to make requests to OpenProject v3 (JSON) API
 	 */
@@ -84,7 +90,8 @@ class OpenProjectAPIService {
 								IConfig $config,
 								INotificationManager $notificationManager,
 								IClientService $clientService,
-								IRootFolder $storage) {
+								IRootFolder $storage,
+								IURLGenerator $urlGenerator) {
 		$this->appName = $appName;
 		$this->userManager = $userManager;
 		$this->avatarManager = $avatarManager;
@@ -94,6 +101,7 @@ class OpenProjectAPIService {
 		$this->notificationManager = $notificationManager;
 		$this->client = $clientService->newClient();
 		$this->storage = $storage;
+		$this->urlGenerator = $urlGenerator;
 	}
 
 	/**
@@ -233,10 +241,15 @@ class OpenProjectAPIService {
 	}
 
 	/**
+	 * wrapper around IURLGenerator::getBaseUrl() to make it easier to mock in tests
+	 */
+	public function getBaseUrl(): string {
+		return $this->urlGenerator->getBaseUrl();
+	}
+	/**
 	 * @param string $userId
 	 * @param string|null $query
 	 * @param int|null $fileId
-	 * @param string|null $storageUrl
 	 * @param int $offset
 	 * @param int $limit
 	 * @return array<mixed>
@@ -247,15 +260,9 @@ class OpenProjectAPIService {
 		string $userId,
 		string $query = null,
 		int $fileId = null,
-		string $storageUrl = null,
 		int $offset = 0,
 		int $limit = 5
 	): array {
-		$linkableStorageFilter = [
-			'linkable_to_storage_url' =>
-				['operator' => '=', 'values' => [urlencode($storageUrl)]]
-		];
-		$sortBy = [['status', 'asc'],['updatedAt', 'desc']];
 		$resultsById = [];
 		$filters = [];
 
@@ -265,55 +272,58 @@ class OpenProjectAPIService {
 		}
 		if ($query !== null) {
 			$filters[] = ['description' => ['operator' => '~', 'values' => [$query]]];
-			if ($storageUrl !== null) {
-				$filters[] = $linkableStorageFilter;
-			}
 		}
-		$params = [
-			'filters' => \Safe\json_encode($filters),
-			'sortBy' => \Safe\json_encode($sortBy),
-			// 'limit' => $limit,
-		];
-		$searchDescResult = $this->request($userId, 'work_packages', $params);
-
-		if (isset($searchDescResult['error'])) {
-			return $searchDescResult;
-		}
-
-		if (isset($searchDescResult['_embedded'], $searchDescResult['_embedded']['elements'])) {
-			foreach ($searchDescResult['_embedded']['elements'] as $wp) {
-				$resultsById[$wp['id']] = $wp;
-			}
+		$resultsById = $this->searchRequest($userId, $filters);
+		if (isset($resultsById['error'])) {
+			return $resultsById;
 		}
 		// search by subject
 		if ($query !== null) {
 			$filters = [
 				['subject' => ['operator' => '~', 'values' => [$query]]],
 			];
-			if ($storageUrl !== null) {
-				$filters[] = $linkableStorageFilter;
-			}
-			$params = [
-				'filters' => \Safe\json_encode($filters),
-				'sortBy' => \Safe\json_encode($sortBy),
-				// 'limit' => $limit,
-			];
-			$searchSubjectResult = $this->request($userId, 'work_packages', $params);
-
-			if (isset($searchSubjectResult['error'])) {
-				return $searchSubjectResult;
-			}
-
-			if (isset($searchSubjectResult['_embedded'], $searchSubjectResult['_embedded']['elements'])) {
-				foreach ($searchSubjectResult['_embedded']['elements'] as $wp) {
-					$resultsById[$wp['id']] = $wp;
-				}
+			$resultsById = $this->searchRequest($userId, $filters, $resultsById);
+			if (isset($resultsById['error'])) {
+				return $resultsById;
 			}
 		}
 
 		return array_values($resultsById);
 	}
 
+	/**
+	 * @param string $userId
+	 * @param array<mixed> $filters
+	 * @param array<mixed> $resultsById
+	 * @return array<mixed>
+	 * @throws \OCP\PreConditionNotMetException
+	 * @throws \Safe\Exceptions\JsonException
+	 */
+	private function searchRequest(string $userId, array $filters, array $resultsById = []): array {
+		$sortBy = [['status', 'asc'],['updatedAt', 'desc']];
+		$filters[] = [
+			'linkable_to_storage_url' =>
+				['operator' => '=', 'values' => [urlencode($this->getBaseUrl())]]
+		];
+
+		$params = [
+			'filters' => \Safe\json_encode($filters),
+			'sortBy' => \Safe\json_encode($sortBy),
+			// 'limit' => $limit,
+		];
+		$searchResult = $this->request($userId, 'work_packages', $params);
+
+		if (isset($searchResult['error'])) {
+			return $searchResult;
+		}
+
+		if (isset($searchResult['_embedded'], $searchResult['_embedded']['elements'])) {
+			foreach ($searchResult['_embedded']['elements'] as $wp) {
+				$resultsById[$wp['id']] = $wp;
+			}
+		}
+		return $resultsById;
+	}
 	/**
 	 * authenticated request to get an image from openproject
 	 *
@@ -606,7 +616,6 @@ class OpenProjectAPIService {
 		int $workpackageId,
 		int $fileId,
 		string $fileName,
-		string $storageUrl,
 		string $userId
 	): int {
 		$file = $this->getNode($userId, $fileId);
@@ -630,7 +639,7 @@ class OpenProjectAPIService {
 						],
 						'_links' => [
 							'storageUrl' => [
-								'href' => $storageUrl
+								'href' => $this->getBaseUrl()
 							]
 						]
 					]

--- a/tests/lib/Controller/OpenProjectAPIControllerTest.php
+++ b/tests/lib/Controller/OpenProjectAPIControllerTest.php
@@ -13,7 +13,6 @@ use OCA\OpenProject\Service\OpenProjectAPIService;
 use OCP\IConfig;
 use OCP\IRequest;
 use OCP\AppFramework\Http;
-use OCP\IURLGenerator;
 use PHPUnit\Framework\TestCase;
 use Exception;
 use OCP\Files\NotFoundException;
@@ -24,11 +23,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 
 	/** @var IRequest $requestMock */
 	private $requestMock;
-
-	/**
-	 * @var IURLGenerator
-	 */
-	private $urlGeneratorMock;
 
 	/**
 	 * @return void
@@ -44,10 +38,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 				['integration_openproject', 'client_secret'],
 				['integration_openproject', 'oauth_instance_url'],
 			)->willReturnOnConsecutiveCalls('cliendID', 'clientSecret', 'http://openproject.org');
-		$this->urlGeneratorMock = $this->getMockBuilder(IURLGenerator::class)->getMock();
-		$this->urlGeneratorMock
-			->method('getBaseUrl')
-			->willReturn('http://nextcloud.org/');
 	}
 
 	/**
@@ -78,7 +68,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 			->willReturn(['some' => 'data']);
 
 		$controller = new OpenProjectAPIController(
-			'integration_openproject', $this->requestMock, $this->configMock, $service, $this->urlGeneratorMock, 'test',
+			'integration_openproject', $this->requestMock, $this->configMock, $service, 'test',
 		);
 		$response = $controller->getNotifications();
 		$this->assertSame(Http::STATUS_OK, $response->getStatus());
@@ -92,7 +82,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 		$this->getUserValueMock('');
 		$service = $this->createMock(OpenProjectAPIService::class);
 		$controller = new OpenProjectAPIController(
-			'integration_openproject', $this->requestMock, $this->configMock, $service, $this->urlGeneratorMock, 'test'
+			'integration_openproject', $this->requestMock, $this->configMock, $service, 'test'
 		);
 		$response = $controller->getNotifications();
 		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
@@ -111,7 +101,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 			->willReturn(['error' => 'something went wrong']);
 
 		$controller = new OpenProjectAPIController(
-			'integration_openproject', $this->requestMock, $this->configMock, $service, $this->urlGeneratorMock, 'test'
+			'integration_openproject', $this->requestMock, $this->configMock, $service, 'test'
 		);
 		$response = $controller->getNotifications();
 		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
@@ -142,7 +132,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 			$this->requestMock,
 			$this->configMock,
 			$service,
-			$this->urlGeneratorMock,
 			'test'
 		);
 		$response = $controller->getOpenProjectAvatar('id', 'name');
@@ -177,7 +166,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 			)
 			->willReturn(['avatar' => 'some image data']);
 		$controller = new OpenProjectAPIController(
-			'integration_openproject', $this->requestMock, $this->configMock, $service, $this->urlGeneratorMock, 'test'
+			'integration_openproject', $this->requestMock, $this->configMock, $service, 'test'
 		);
 		$response = $controller->getOpenProjectAvatar('id', 'name');
 		$this->assertSame('some image data', $response->render());
@@ -222,7 +211,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 			->willReturn($expectedResponse);
 
 		$controller = new OpenProjectAPIController(
-			'integration_openproject', $this->requestMock, $this->configMock, $service, $this->urlGeneratorMock, 'test'
+			'integration_openproject', $this->requestMock, $this->configMock, $service, 'test'
 		);
 		$response = $controller->getSearchedWorkPackages($searchQuery, $fileId);
 		$this->assertSame(Http::STATUS_OK, $response->getStatus());
@@ -237,7 +226,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 		$this->getUserValueMock('');
 		$service = $this->createMock(OpenProjectAPIService::class);
 		$controller = new OpenProjectAPIController(
-			'integration_openproject', $this->requestMock, $this->configMock, $service, $this->urlGeneratorMock, 'test'
+			'integration_openproject', $this->requestMock, $this->configMock, $service, 'test'
 		);
 		$response = $controller->getSearchedWorkPackages('test');
 		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
@@ -256,7 +245,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 			->willReturn(['error' => 'something went wrong']);
 
 		$controller = new OpenProjectAPIController(
-			'integration_openproject', $this->requestMock, $this->configMock, $service, $this->urlGeneratorMock, 'test'
+			'integration_openproject', $this->requestMock, $this->configMock, $service, 'test'
 		);
 		$response = $controller->getSearchedWorkPackages('test');
 		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
@@ -280,7 +269,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 			]);
 
 		$controller = new OpenProjectAPIController(
-			'integration_openproject', $this->requestMock, $this->configMock, $service, $this->urlGeneratorMock, 'test'
+			'integration_openproject', $this->requestMock, $this->configMock, $service, 'test'
 		);
 		$response = $controller->getOpenProjectWorkPackageStatus('7');
 		$this->assertSame(Http::STATUS_OK, $response->getStatus());
@@ -297,7 +286,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 		$this->getUserValueMock('');
 		$service = $this->createMock(OpenProjectAPIService::class);
 		$controller = new OpenProjectAPIController(
-			'integration_openproject', $this->requestMock, $this->configMock, $service, $this->urlGeneratorMock, 'test'
+			'integration_openproject', $this->requestMock, $this->configMock, $service, 'test'
 		);
 		$response = $controller->getOpenProjectWorkPackageStatus('7');
 		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
@@ -316,7 +305,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 			->willReturn(['error' => 'something went wrong']);
 
 		$controller = new OpenProjectAPIController(
-			'integration_openproject', $this->requestMock, $this->configMock, $service, $this->urlGeneratorMock, 'test'
+			'integration_openproject', $this->requestMock, $this->configMock, $service, 'test'
 		);
 		$response = $controller->getOpenProjectWorkPackageStatus('7');
 		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
@@ -338,7 +327,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 				"color" => "#CC5DE8", "position" => 4, "isDefault" => true, "isMilestone" => false, "createdAt" => "2022-01-12T08:53:15Z", "updatedAt" => "2022-01-12T08:53:34Z"]);
 
 		$controller = new OpenProjectAPIController(
-			'integration_openproject', $this->requestMock, $this->configMock, $service, $this->urlGeneratorMock, 'test'
+			'integration_openproject', $this->requestMock, $this->configMock, $service, 'test'
 		);
 		$response = $controller->getOpenProjectWorkPackageType('3');
 		$this->assertSame(Http::STATUS_OK, $response->getStatus());
@@ -353,7 +342,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 		$this->getUserValueMock('');
 		$service = $this->createMock(OpenProjectAPIService::class);
 		$controller = new OpenProjectAPIController(
-			'integration_openproject', $this->requestMock, $this->configMock, $service, $this->urlGeneratorMock, 'test'
+			'integration_openproject', $this->requestMock, $this->configMock, $service, 'test'
 		);
 		$response = $controller->getOpenProjectWorkPackageType('3');
 		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
@@ -372,7 +361,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 			->willReturn(['error' => 'something went wrong']);
 
 		$controller = new OpenProjectAPIController(
-			'integration_openproject', $this->requestMock, $this->configMock, $service, $this->urlGeneratorMock, 'test'
+			'integration_openproject', $this->requestMock, $this->configMock, $service, 'test'
 		);
 		$response = $controller->getOpenProjectWorkPackageType('3');
 		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
@@ -399,7 +388,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 			]]);
 
 		$controller = new OpenProjectAPIController(
-			'integration_openproject', $this->requestMock, $this->configMock, $service, $this->urlGeneratorMock, 'test'
+			'integration_openproject', $this->requestMock, $this->configMock, $service, 'test'
 		);
 		$response = $controller->getWorkPackageFileLinks(7);
 		$this->assertSame(Http::STATUS_OK, $response->getStatus());
@@ -419,7 +408,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 		$this->getUserValueMock('');
 		$service = $this->createMock(OpenProjectAPIService::class);
 		$controller = new OpenProjectAPIController(
-			'integration_openproject', $this->requestMock, $this->configMock, $service, $this->urlGeneratorMock, 'test'
+			'integration_openproject', $this->requestMock, $this->configMock, $service, 'test'
 		);
 		$response = $controller->getWorkPackageFileLinks(7);
 		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
@@ -437,7 +426,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 			->method('getWorkPackageFileLinks')
 			->willThrowException(new NotFoundException('work package not found'));
 		$controller = new OpenProjectAPIController(
-			'integration_openproject', $this->requestMock, $this->configMock, $service, $this->urlGeneratorMock, 'test'
+			'integration_openproject', $this->requestMock, $this->configMock, $service, 'test'
 		);
 		$response = $controller->getWorkPackageFileLinks(7);
 		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
@@ -456,7 +445,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 			->method('getWorkPackageFileLinks')
 			->willThrowException(new Exception('something went wrong'));
 		$controller = new OpenProjectAPIController(
-			'integration_openproject', $this->requestMock, $this->configMock, $service, $this->urlGeneratorMock, 'test'
+			'integration_openproject', $this->requestMock, $this->configMock, $service, 'test'
 		);
 		$response = $controller->getWorkPackageFileLinks(7);
 		$this->assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
@@ -477,7 +466,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 			->willReturn(['success' => true]);
 
 		$controller = new OpenProjectAPIController(
-			'integration_openproject', $this->requestMock, $this->configMock, $service, $this->urlGeneratorMock, 'test'
+			'integration_openproject', $this->requestMock, $this->configMock, $service, 'test'
 		);
 		$response = $controller->deleteFileLink(7);
 		$this->assertSame(Http::STATUS_OK, $response->getStatus());
@@ -491,7 +480,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 		$this->getUserValueMock('');
 		$service = $this->createMock(OpenProjectAPIService::class);
 		$controller = new OpenProjectAPIController(
-			'integration_openproject', $this->requestMock, $this->configMock, $service, $this->urlGeneratorMock, 'test'
+			'integration_openproject', $this->requestMock, $this->configMock, $service, 'test'
 		);
 		$response = $controller->deleteFileLink(7);
 		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
@@ -509,7 +498,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 			->method('deleteFileLink')
 			->willThrowException(new NotFoundException('file not found'));
 		$controller = new OpenProjectAPIController(
-			'integration_openproject', $this->requestMock, $this->configMock, $service, $this->urlGeneratorMock, 'test'
+			'integration_openproject', $this->requestMock, $this->configMock, $service, 'test'
 		);
 		$response = $controller->deleteFileLink(7);
 		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
@@ -528,7 +517,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 			->method('deleteFileLink')
 			->willThrowException(new Exception('something went wrong'));
 		$controller = new OpenProjectAPIController(
-			'integration_openproject', $this->requestMock, $this->configMock, $service, $this->urlGeneratorMock, 'test'
+			'integration_openproject', $this->requestMock, $this->configMock, $service, 'test'
 		);
 		$response = $controller->deleteFileLink(7);
 		$this->assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());


### PR DESCRIPTION
the search and the link function could be used without or a wrong storageUrl, this is actually not needed, I'm suggesting in this PR to send the storageURL in every link and search request to OpenProject

should fix https://community.openproject.org/work_packages/41949 
In the search for listing existing  links we did not send the storageUrl as filter so also links from other storages would show up