### PR TITLE
Fix icon placements and colors for different themes

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -51,10 +51,22 @@ body[data-theme-dark] .icon-openproject {
 	filter: none !important;
 }
 
+body[data-theme-dark-highcontrast] .icon-openproject {
+	filter: none !important;
+}
+
+body[data-theme-dark-highcontrast] .icon-openproject-till-nc-25::after {
+	filter: none !important;
+}
+
 body.theme--dark .icon-close, .icon-checkmark, .icon-noConnection {
-	filter: var(--background-invert-if-dark);
+	filter: contrast(0);
 }
 
 body[data-theme-dark] .icon-close, .icon-checkmark, .icon-noConnection {
-	filter: var(--background-invert-if-dark);
+	filter: contrast(0);
+}
+
+body[data-theme-dark-highcontrast] .icon-close, .icon-checkmark, .icon-noConnection {
+	filter: contrast(0);
 }

--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -36,16 +36,17 @@
 	background-image: url(./../img/noConnection.svg);
 }
 
-body.theme--dark .icon-open-project::after {
+body.theme--dark .icon-open-project::after,
+body.theme--dark .icon-openproject,
+body[data-theme-dark] .icon-open-project::after,
+body[data-theme-dark] .icon-openproject
+{
 	filter: none;
 }
 
-body[data-theme-dark] .icon-openproject {
-	filter: none;
-}
 
-body.theme--dark .icon-openproject {
-	filter: none;
+body.theme--dark .icon-close, .icon-checkmark, .icon-noConnection {
+	filter: var(--background-invert-if-dark);
 }
 
 body[data-theme-dark] .icon-close, .icon-checkmark, .icon-noConnection {

--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -1,6 +1,6 @@
 .icon-openproject {
 	background-image: url(./../img/app.svg);
-	filter: contrast(0) brightness(0);
+	filter: contrast(0) brightness(0) !important;
 	min-width: 32px !important;
 }
 
@@ -31,19 +31,25 @@
 	background-image: url(./../img/app.svg);
 }
 
-
 .icon-noConnection {
 	background-image: url(./../img/noConnection.svg);
 }
 
-body.theme--dark .icon-open-project::after,
-body.theme--dark .icon-openproject,
-body[data-theme-dark] .icon-open-project::after,
-body[data-theme-dark] .icon-openproject
-{
-	filter: none;
+body.theme--dark .icon-open-project::after {
+	filter: none !important;
 }
 
+body.theme--dark .icon-openproject {
+	filter: none !important;
+}
+
+body[data-theme-dark] .icon-open-project::after {
+	filter: none !important;
+}
+
+body[data-theme-dark] .icon-openproject {
+	filter: none !important;
+}
 
 body.theme--dark .icon-close, .icon-checkmark, .icon-noConnection {
 	filter: var(--background-invert-if-dark);

--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -1,17 +1,53 @@
 .icon-openproject {
 	background-image: url(./../img/app.svg);
-	filter: contrast(0) brightness(0) !important;
+	filter: contrast(0) brightness(0);
 	min-width: 32px !important;
 }
+
+.icon-open-project {
+	position: relative;
+}
+
+.panel--header .icon-open-project::after {
+	left: 20px;
+	top: 22%;
+	height: 30px;
+	width: 30px;
+	background-size: 30px;
+}
+
+.panels li .icon-open-project::after {
+	left: 10%;
+	top: 15%;
+	height: 26px;
+	width: 26px;
+	background-size: 26px;
+}
+
+.icon-open-project::after {
+	content: '';
+	position: absolute;
+	filter: contrast(0) brightness(0);
+	background-image: url(./../img/app.svg);
+}
+
 
 .icon-noConnection {
 	background-image: url(./../img/noConnection.svg);
 }
 
+body.theme--dark .icon-open-project::after {
+	filter: none;
+}
+
 body[data-theme-dark] .icon-openproject {
-	filter: none !important;
+	filter: none;
+}
+
+body.theme--dark .icon-openproject {
+	filter: none;
 }
 
 body[data-theme-dark] .icon-close, .icon-checkmark, .icon-noConnection {
-	filter: var(--background-invert-if-dark) !important;
+	filter: var(--background-invert-if-dark);
 }

--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -1,31 +1,17 @@
 .icon-openproject {
 	background-image: url(./../img/app.svg);
-	filter: contrast(0) brightness(0);
+	filter: contrast(0) brightness(0) !important;
+	min-width: 32px !important;
 }
 
 .icon-noConnection {
 	background-image: url(./../img/noConnection.svg);
-	filter: contrast(0) brightness(0);
 }
 
-.icon-open-project {
-	position: relative;
+body[data-theme-dark] .icon-openproject {
+	filter: none !important;
 }
 
-.panel--header .icon-open-project::after {
-	left: 20px; top: 22%;
-}
-
-.icon-open-project::after {
-	content: '';
-	position: absolute;
-	top: 10%; left: 40%;
-	height: 30px; width: 30px;
-	background-size: 30px 30px;
-	filter: contrast(0) brightness(0);
-	background-image: url(./../img/app.svg);
-}
-
-body.theme--dark .icon-openproject, .icon-noConnection, .icon-open-project::after {
-	filter: none;
+body[data-theme-dark] .icon-close, .icon-checkmark, .icon-noConnection {
+	filter: var(--background-invert-if-dark) !important;
 }

--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -4,11 +4,11 @@
 	min-width: 32px !important;
 }
 
-.icon-open-project {
+.icon-openproject-till-nc-25 {
 	position: relative;
 }
 
-.panel--header .icon-open-project::after {
+.panel--header .icon-openproject-till-nc-25::after {
 	left: 20px;
 	top: 22%;
 	height: 30px;
@@ -16,7 +16,7 @@
 	background-size: 30px;
 }
 
-.panels li .icon-open-project::after {
+.panels li .icon-openproject-till-nc-25::after {
 	left: 10%;
 	top: 15%;
 	height: 26px;
@@ -24,7 +24,7 @@
 	background-size: 26px;
 }
 
-.icon-open-project::after {
+.icon-openproject-till-nc-25::after {
 	content: '';
 	position: absolute;
 	filter: contrast(0) brightness(0);
@@ -35,7 +35,7 @@
 	background-image: url(./../img/noConnection.svg);
 }
 
-body.theme--dark .icon-open-project::after {
+body.theme--dark .icon-openproject-till-nc-25::after {
 	filter: none !important;
 }
 
@@ -43,7 +43,7 @@ body.theme--dark .icon-openproject {
 	filter: none !important;
 }
 
-body[data-theme-dark] .icon-open-project::after {
+body[data-theme-dark] .icon-openproject-till-nc-25::after {
 	filter: none !important;
 }
 

--- a/lib/Dashboard/OpenProjectWidget.php
+++ b/lib/Dashboard/OpenProjectWidget.php
@@ -56,8 +56,7 @@ class OpenProjectWidget implements IWidget {
 		IL10N $l10n,
 		IInitialState $initialStateService,
 		IURLGenerator $url,
-		IConfig $config,
-		LoggerInterface $logger
+		IConfig $config
 	) {
 		$this->initialStateService = $initialStateService;
 		$this->l10n = $l10n;

--- a/lib/Dashboard/OpenProjectWidget.php
+++ b/lib/Dashboard/OpenProjectWidget.php
@@ -30,7 +30,6 @@ use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\Util;
-use Psr\Log\LoggerInterface;
 
 use OCA\OpenProject\AppInfo\Application;
 
@@ -53,11 +52,6 @@ class OpenProjectWidget implements IWidget {
 	 */
 	private $config;
 
-	/**
-	 * @var LoggerInterface
-	 */
-	private $logger;
-
 	public function __construct(
 		IL10N $l10n,
 		IInitialState $initialStateService,
@@ -69,7 +63,6 @@ class OpenProjectWidget implements IWidget {
 		$this->l10n = $l10n;
 		$this->url = $url;
 		$this->config = $config;
-		$this->logger = $logger;
 	}
 
 	/**

--- a/lib/Dashboard/OpenProjectWidget.php
+++ b/lib/Dashboard/OpenProjectWidget.php
@@ -30,6 +30,7 @@ use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\Util;
+use Psr\Log\LoggerInterface;
 
 use OCA\OpenProject\AppInfo\Application;
 
@@ -52,16 +53,23 @@ class OpenProjectWidget implements IWidget {
 	 */
 	private $config;
 
+	/**
+	 * @var LoggerInterface
+	 */
+	private $logger;
+
 	public function __construct(
 		IL10N $l10n,
 		IInitialState $initialStateService,
 		IURLGenerator $url,
-		IConfig $config
+		IConfig $config,
+		LoggerInterface $logger
 	) {
 		$this->initialStateService = $initialStateService;
 		$this->l10n = $l10n;
 		$this->url = $url;
 		$this->config = $config;
+		$this->logger = $logger;
 	}
 
 	/**
@@ -89,8 +97,13 @@ class OpenProjectWidget implements IWidget {
 	 * @inheritDoc
 	 */
 	public function getIconClass(): string {
+		$currentVersion = implode('.', Util::getVersion());
+
+		$this->logger->error('Current version: ' . $currentVersion, ['app' => Application::APP_ID]);
 		
-		return 'icon-open-project';
+		return version_compare($currentVersion, '25') >= 0
+			? 'icon-openproject'
+			: 'icon-open-project';
 	}
 
 	/**

--- a/lib/Dashboard/OpenProjectWidget.php
+++ b/lib/Dashboard/OpenProjectWidget.php
@@ -93,7 +93,7 @@ class OpenProjectWidget implements IWidget {
 
 		return version_compare($currentVersion, '25') >= 0
 			? 'icon-openproject'
-			: 'icon-open-project';
+			: 'icon-openproject-till-nc-25';
 	}
 
 	/**

--- a/lib/Dashboard/OpenProjectWidget.php
+++ b/lib/Dashboard/OpenProjectWidget.php
@@ -99,8 +99,6 @@ class OpenProjectWidget implements IWidget {
 	public function getIconClass(): string {
 		$currentVersion = implode('.', Util::getVersion());
 
-		$this->logger->error('Current version: ' . $currentVersion, ['app' => Application::APP_ID]);
-		
 		return version_compare($currentVersion, '25') >= 0
 			? 'icon-openproject'
 			: 'icon-open-project';

--- a/lib/Dashboard/OpenProjectWidget.php
+++ b/lib/Dashboard/OpenProjectWidget.php
@@ -89,7 +89,7 @@ class OpenProjectWidget implements IWidget {
 	 * @inheritDoc
 	 */
 	public function getIconClass(): string {
-		return 'icon-open-project';
+		return 'icon-openproject';
 	}
 
 	/**

--- a/lib/Dashboard/OpenProjectWidget.php
+++ b/lib/Dashboard/OpenProjectWidget.php
@@ -89,7 +89,8 @@ class OpenProjectWidget implements IWidget {
 	 * @inheritDoc
 	 */
 	public function getIconClass(): string {
-		return 'icon-openproject';
+		
+		return 'icon-open-project';
 	}
 
 	/**

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -122,28 +122,29 @@ export default {
 </script>
 
 <style scoped lang="scss">
-.grid-form label {
-	line-height: 38px;
-}
-
-.grid-form input {
-	width: 100%;
-}
-
-.grid-form {
-	max-width: 500px;
-	display: grid;
-	grid-template: 1fr / 1fr 1fr;
-	margin-left: 30px;
-}
-
-#openproject_prefs .icon {
-	display: inline-block;
-	width: 32px;
-}
-
-#openproject_prefs .grid-form .icon {
-	margin-bottom: -3px;
+#openproject_prefs {
+	.icon {
+		display: inline-block;
+		width: 32px;
+	}
+	.grid-form {
+		max-width: 500px;
+		display: grid;
+		grid-template: 1fr / 1fr 1fr;
+		margin-left: 30px;
+		label {
+			line-height: 38px;
+		}
+		input {
+			width: 100%;
+		}
+		.icon {
+			margin-bottom: -3px;
+		}
+	}
+	.icon-details, .icon-link, .icon-category-auth {
+		filter: var(--background-invert-if-dark);
+	}
 }
 
 .save-config-btn, .update-config-btn {

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -132,22 +132,29 @@ export default {
 		display: grid;
 		grid-template: 1fr / 1fr 1fr;
 		margin-left: 30px;
+
 		label {
 			line-height: 38px;
 		}
+
 		input {
 			width: 100%;
 		}
+
 		.icon {
 			margin-bottom: -3px;
 		}
-	}
-	.icon-details, .icon-link, .icon-category-auth {
-		filter: contrast(0);
 	}
 }
 
 .save-config-btn, .update-config-btn {
 	margin-left: 30px;
 }
+
+body.theme--dark, body[data-theme-dark], body[data-theme-dark-highcontrast] {
+	.icon-details, .icon-link, .icon-category-auth {
+		filter: contrast(0);
+	}
+}
+
 </style>

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -143,7 +143,7 @@ export default {
 		}
 	}
 	.icon-details, .icon-link, .icon-category-auth {
-		filter: var(--background-invert-if-dark);
+		filter: contrast(0);
 	}
 }
 

--- a/src/components/OAuthConnectButton.vue
+++ b/src/components/OAuthConnectButton.vue
@@ -93,7 +93,7 @@ export default {
 	}
 }
 
-body[data-theme-dark], body.theme--dark {
+body[data-theme-dark], body[data-theme-dark-highcontrast] body.theme--dark {
 	.oauth-connect--message {
 		color: #cfcfcf;
 	}

--- a/src/components/OAuthConnectButton.vue
+++ b/src/components/OAuthConnectButton.vue
@@ -93,7 +93,7 @@ export default {
 	}
 }
 
-body[data-theme-dark], body[data-theme-dark-highcontrast] body.theme--dark {
+body[data-theme-dark], body[data-theme-dark-highcontrast], body.theme--dark {
 	.oauth-connect--message {
 		color: #cfcfcf;
 	}

--- a/src/components/OAuthConnectButton.vue
+++ b/src/components/OAuthConnectButton.vue
@@ -93,7 +93,7 @@ export default {
 	}
 }
 
-body[data-theme-dark] {
+body[data-theme-dark], body.theme--dark {
 	.oauth-connect--message {
 		color: #cfcfcf;
 	}

--- a/src/components/OAuthConnectButton.vue
+++ b/src/components/OAuthConnectButton.vue
@@ -87,9 +87,15 @@ export default {
 		font-size: 1rem;
 		text-align: center;
 		font-weight: 400;
-		color: #878787;
+		color: #333333;
 		padding: 0px 18px;
 		line-height: 1.4rem;
+	}
+}
+
+body[data-theme-dark] {
+	.oauth-connect--message {
+		color: #cfcfcf;
 	}
 }
 </style>

--- a/src/components/settings/SettingsTitle.vue
+++ b/src/components/settings/SettingsTitle.vue
@@ -1,5 +1,5 @@
 <template>
-	<h2>
+	<h2 class="settings-title">
 		<div class="icon-openproject" />
 		<span>{{ title }}</span>
 	</h2>
@@ -19,15 +19,13 @@ export default {
 <style lang="scss" scoped>
 @import '../../../css/dashboard.css';
 
-.icon-openproject {
-	background-size: cover;
-	height: 23px;
-	width: 23px;
-}
-
-h2 {
+.settings-title {
 	display: flex;
 	align-items: center;
+	.icon-openproject {
+		height: 32px;
+		background-size: cover;
+	}
 	span {
 		padding-left: 10px;
 	}

--- a/src/components/settings/SettingsTitle.vue
+++ b/src/components/settings/SettingsTitle.vue
@@ -30,4 +30,12 @@ export default {
 		padding-left: 10px;
 	}
 }
+
+body[data-theme-dark-highcontrast], body[data-theme-dark], body.theme--dark {
+	.settings-title {
+		.icon-openproject {
+			filter: none !important;
+		}
+	}
+}
 </style>

--- a/src/components/tab/EmptyContent.vue
+++ b/src/components/tab/EmptyContent.vue
@@ -102,6 +102,7 @@ export default {
 		img {
 			height: 50px;
 			width: 50px;
+			filter: var(--background-invert-if-dark);
 		}
 	}
 	&--message {
@@ -127,6 +128,12 @@ export default {
 		display: flex;
 		align-items: center;
 		justify-content: center;
+	}
+}
+
+body[data-theme-dark] {
+	.empty-content--message--title {
+		color: #cfcfcf;
 	}
 }
 </style>

--- a/src/components/tab/EmptyContent.vue
+++ b/src/components/tab/EmptyContent.vue
@@ -131,9 +131,11 @@ export default {
 	}
 }
 
-body[data-theme-dark] {
-	.empty-content--message--title {
-		color: #cfcfcf;
-	}
+body.theme--dark .empty-content--message--title {
+	color: #cfcfcf;
+}
+
+body[data-theme-dark] .empty-content--message--title {
+	color: #cfcfcf;
 }
 </style>

--- a/src/components/tab/EmptyContent.vue
+++ b/src/components/tab/EmptyContent.vue
@@ -131,11 +131,9 @@ export default {
 	}
 }
 
-body.theme--dark .empty-content--message--title {
-	color: #cfcfcf;
-}
-
-body[data-theme-dark] .empty-content--message--title {
-	color: #cfcfcf;
+body.theme--dark, body[data-theme-dark] {
+	.empty-content--message--title {
+		color: #cfcfcf;
+	}
 }
 </style>

--- a/src/components/tab/EmptyContent.vue
+++ b/src/components/tab/EmptyContent.vue
@@ -131,7 +131,7 @@ export default {
 	}
 }
 
-body.theme--dark, body[data-theme-dark] {
+body.theme--dark, body[data-theme-dark], body[data-theme-dark-highcontrast] {
 	.empty-content--message--title {
 		color: #cfcfcf;
 	}

--- a/src/views/ProjectsTab.vue
+++ b/src/views/ProjectsTab.vue
@@ -310,7 +310,7 @@ export default {
 	animation: fade-in 3s 1;
 }
 
-body.theme--dark, body[data-theme-dark] {
+body.theme--dark, body[data-theme-dark], body[data-theme-dark-highcontrast] {
 	.linked-workpackages--workpackage--unlink {
 		filter: invert(100%);
 	}

--- a/src/views/ProjectsTab.vue
+++ b/src/views/ProjectsTab.vue
@@ -310,11 +310,9 @@ export default {
 	animation: fade-in 3s 1;
 }
 
-body.theme--dark .linked-workpackages--workpackage--unlink {
-	filter: invert(100%);
-}
-
-body[data-theme-dark] .linked-workpackages--workpackage--unlink {
-	filter: invert(100%);
+body.theme--dark, body[data-theme-dark] {
+	.linked-workpackages--workpackage--unlink {
+		filter: invert(100%);
+	}
 }
 </style>

--- a/src/views/ProjectsTab.vue
+++ b/src/views/ProjectsTab.vue
@@ -313,4 +313,8 @@ export default {
 body.theme--dark .linked-workpackages--workpackage--unlink {
 	filter: invert(100%);
 }
+
+body[data-theme-dark] .linked-workpackages--workpackage--unlink {
+	filter: invert(100%);
+}
 </style>


### PR DESCRIPTION
## Description
Recently there has been some design, theme related updates in the NC server. `body.theme--dark` has been dropped to now use `body[data-theme-dark]`

this PR should fix:
- placement and colors of the op logo in the dashboard widget
- the color of the op logo in the sidebar tab
- the color and size of the op logo in the settings title
- the color of the label icons for the admin settings page
- the text colors for empty content view

## Related
- [OP#42270] should fix https://community.openproject.org/projects/nextcloud-integration/work_packages/42270
- [OP#42475] should fix https://community.openproject.org/projects/nextcloud-integration/work_packages/42475

Signed-off-by: Kiran Parajuli <kiranparajuli589@gmail.com>