### PR TITLE
OP#41271 remember new refresh_token after refreshing oauth token

### DIFF
--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -434,6 +434,12 @@ class OpenProjectAPIService {
 					'grant_type' => 'refresh_token',
 					'refresh_token' => $refreshToken,
 				], 'POST');
+				if (isset($result['refresh_token'])) {
+					$refreshToken = $result['refresh_token'];
+					$this->config->setUserValue(
+						$userId, Application::APP_ID, 'refresh_token', $refreshToken
+					);
+				}
 				if (isset($result['access_token'])) {
 					$accessToken = $result['access_token'];
 					$this->config->setUserValue($userId, Application::APP_ID, 'token', $accessToken);


### PR DESCRIPTION
part of https://community.openproject.org/projects/nextcloud-integration/work_packages/41271

when refreshing the oauth token, open project not only sends back a new token but also a new refresh-token, that also needs to be remembered, otherwise the second refresh would fail.

Signed-off-by: Artur Neumann <artur@jankaritech.com>

CC @Kharonus
