### PR TITLE
add confirm dialog for admin config update action

### DIFF
--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -134,18 +134,12 @@ class ConfigController extends Controller {
 		foreach ($values as $key => $value) {
 			$this->config->setAppValue(Application::APP_ID, $key, trim($value));
 		}
-		$configStatus = OpenProjectAPIService::isAdminConfigOk($this->config);
 		// if the admin config is not ok, we clear every existing user information
-		if (!$configStatus) {
-			$this->userManager->callForAllUsers(function (IUser $user) {
-				$this->clearUserInfo($user->getUID());
-			});
-			return new DataResponse([
-				"status" => false
-			]);
-		}
+		$this->userManager->callForAllUsers(function (IUser $user) {
+			$this->clearUserInfo($user->getUID());
+		});
 		return new DataResponse([
-			"status" => true
+			"status" => OpenProjectAPIService::isAdminConfigOk($this->config)
 		]);
 	}
 

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -82,7 +82,7 @@ class ConfigController extends Controller {
 	 * @param string|null $userId
 	 * @return void
 	 */
-	private function clearUserInfo(string $userId = null) {
+	public function clearUserInfo(string $userId = null) {
 		if ($userId === null) {
 			$userId = $this->userId;
 		}

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -15,6 +15,8 @@ use OCP\IURLGenerator;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserManager;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\RedirectResponse;
@@ -34,6 +36,10 @@ class ConfigController extends Controller {
 	 * @var IURLGenerator
 	 */
 	private $urlGenerator;
+	/**
+	 * @var IUserManager
+	 */
+	private $userManager;
 	/**
 	 * @var IL10N
 	 */
@@ -57,6 +63,7 @@ class ConfigController extends Controller {
 								IRequest $request,
 								IConfig $config,
 								IURLGenerator $urlGenerator,
+								IUserManager $userManager,
 								IL10N $l,
 								OpenProjectAPIService $openprojectAPIService,
 								LoggerInterface $logger,
@@ -64,10 +71,27 @@ class ConfigController extends Controller {
 		parent::__construct($appName, $request);
 		$this->config = $config;
 		$this->urlGenerator = $urlGenerator;
+		$this->userManager = $userManager;
 		$this->l = $l;
 		$this->openprojectAPIService = $openprojectAPIService;
 		$this->logger = $logger;
 		$this->userId = $userId;
+	}
+
+	/**
+	 * @param string|null $userId
+	 * @return void
+	 */
+	private function clearUserInfo(string $userId = null) {
+		if ($userId === null) {
+			$userId = $this->userId;
+		}
+		$this->config->deleteUserValue($userId, Application::APP_ID, 'token');
+		$this->config->deleteUserValue($userId, Application::APP_ID, 'login');
+		$this->config->deleteUserValue($userId, Application::APP_ID, 'user_id');
+		$this->config->deleteUserValue($userId, Application::APP_ID, 'user_name');
+		$this->config->deleteUserValue($userId, Application::APP_ID, 'refresh_token');
+		$this->config->deleteUserValue($userId, Application::APP_ID, 'last_notification_check');
 	}
 
 	/**
@@ -87,12 +111,7 @@ class ConfigController extends Controller {
 			if ($values['token'] && $values['token'] !== '') {
 				$result = $this->storeUserInfo();
 			} else {
-				$this->config->deleteUserValue($this->userId, Application::APP_ID, 'token');
-				$this->config->deleteUserValue($this->userId, Application::APP_ID, 'login');
-				$this->config->deleteUserValue($this->userId, Application::APP_ID, 'user_id');
-				$this->config->deleteUserValue($this->userId, Application::APP_ID, 'user_name');
-				$this->config->deleteUserValue($this->userId, Application::APP_ID, 'refresh_token');
-				$this->config->deleteUserValue($this->userId, Application::APP_ID, 'last_notification_check');
+				$this->clearUserInfo();
 				$result = [
 					'user_name' => '',
 				];
@@ -116,17 +135,12 @@ class ConfigController extends Controller {
 			$this->config->setAppValue(Application::APP_ID, $key, trim($value));
 		}
 		$configStatus = $this->openprojectAPIService->isAdminConfigOk($this->config);
-		if ($configStatus) {
-			return new DataResponse([
-				'status' => true,
-			]);
-		} else {
-			return new DataResponse(
-				[
-					'users' => 'here'
-				]
-			);
+		if (!$configStatus) {
+			$this->userManager->callForAllUsers(function (IUser $user) {
+				$this->clearUserInfo($user->getUID());
+			});
 		}
+		return new DataResponse(1);
 	}
 
 	/**

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -134,7 +134,7 @@ class ConfigController extends Controller {
 		foreach ($values as $key => $value) {
 			$this->config->setAppValue(Application::APP_ID, $key, trim($value));
 		}
-		$configStatus = $this->openprojectAPIService->isAdminConfigOk($this->config);
+		$configStatus = OpenProjectAPIService::isAdminConfigOk($this->config);
 		// if the admin config is not ok, we clear every existing user information
 		if (!$configStatus) {
 			$this->userManager->callForAllUsers(function (IUser $user) {

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -135,6 +135,7 @@ class ConfigController extends Controller {
 			$this->config->setAppValue(Application::APP_ID, $key, trim($value));
 		}
 		$configStatus = $this->openprojectAPIService->isAdminConfigOk($this->config);
+		// if the admin config is not ok, we clear every existing user information
 		if (!$configStatus) {
 			$this->userManager->callForAllUsers(function (IUser $user) {
 				$this->clearUserInfo($user->getUID());

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -115,7 +115,18 @@ class ConfigController extends Controller {
 		foreach ($values as $key => $value) {
 			$this->config->setAppValue(Application::APP_ID, $key, trim($value));
 		}
-		return new DataResponse(1);
+		$configStatus = $this->openprojectAPIService->isAdminConfigOk($this->config);
+		if ($configStatus) {
+			return new DataResponse([
+				'status' => true,
+			]);
+		} else {
+			return new DataResponse(
+				[
+					'users' => 'here'
+				]
+			);
+		}
 	}
 
 	/**

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -140,8 +140,13 @@ class ConfigController extends Controller {
 			$this->userManager->callForAllUsers(function (IUser $user) {
 				$this->clearUserInfo($user->getUID());
 			});
+			return new DataResponse([
+				"status" => false
+			]);
 		}
-		return new DataResponse(1);
+		return new DataResponse([
+			"status" => true
+		]);
 	}
 
 	/**

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -134,7 +134,6 @@ class ConfigController extends Controller {
 		foreach ($values as $key => $value) {
 			$this->config->setAppValue(Application::APP_ID, $key, trim($value));
 		}
-		// if the admin config is not ok, we clear every existing user information
 		$this->userManager->callForAllUsers(function (IUser $user) {
 			$this->clearUserInfo($user->getUID());
 		});

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -7,6 +7,7 @@ use OCP\AppFramework\Services\IInitialState;
 use OCP\IConfig;
 use OCP\Settings\ISettings;
 
+use OCA\OpenProject\Service\OpenProjectAPIService;
 use OCA\OpenProject\AppInfo\Application;
 
 class Admin implements ISettings {
@@ -39,7 +40,12 @@ class Admin implements ISettings {
 			'client_secret' => $clientSecret,
 			'oauth_instance_url' => $oauthUrl,
 		];
+
+		$adminConfigStatus = OpenProjectAPIService::isAdminConfigOk($this->config);
+
 		$this->initialStateService->provideInitialState('admin-config', $adminConfig);
+		$this->initialStateService->provideInitialState('admin-config-status', $adminConfigStatus);
+
 		return new TemplateResponse(Application::APP_ID, 'adminSettings');
 	}
 

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -78,8 +78,8 @@ export default {
 			OC.dialogs.confirmDestructive(
 				t(
 					'integration_openproject',
-					'Are you sure you want to update the admin settings?'
-					+ ' After saving, every connected users must need to re-connect to the Openproject instance.'
+					'Are you sure you want to update the Oauth settings for OpenProject?'
+					+ ' After saving, all connected users will have to re-connect to the OpenProject instance.'
 				),
 				t('integration_openproject', 'Confirm Update'),
 				{

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -78,13 +78,13 @@ export default {
 			OC.dialogs.confirmDestructive(
 				t(
 					'integration_openproject',
-					'Are you sure you want to update the Oauth settings for OpenProject?'
-					+ ' After saving, all connected users will have to re-connect to the OpenProject instance.'
+					'Are you sure you want to replace the OpenProject OAuth client details?'
+					+ ' Every currently connected user will need to re-authorize this Nextcloud instance to have access to their OpenProject account.'
 				),
-				t('integration_openproject', 'Confirm Update'),
+				t('integration_openproject', 'Replace OpenProject OAuth client details'),
 				{
 					type: OC.dialogs.YES_NO_BUTTONS,
-					confirm: t('integration_openproject', 'Update'),
+					confirm: t('integration_openproject', 'Replace'),
 					confirmClasses: 'error',
 					cancel: t('integration_openproject', 'Cancel'),
 				},

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -52,6 +52,7 @@ import { delay } from '../utils'
 import { showSuccess, showError } from '@nextcloud/dialogs'
 import '@nextcloud/dialogs/styles/toast.scss'
 import SettingsTitle from '../components/settings/SettingsTitle'
+import { translate as t } from '@nextcloud/l10n'
 
 export default {
 	name: 'AdminSettings',
@@ -72,8 +73,27 @@ export default {
 		onInput() {
 			const that = this
 			delay(() => {
-				that.saveOptions()
-			}, 2000)()
+				OC.dialogs.confirmDestructive(
+					t(
+						'integration_openproject',
+						'Are you sure you want to update the admin settings?'
+								+ ' After saving, every connected users must need to re-connect to the Openproject instance.'
+					),
+					t('integration_openproject', 'Confirm Update'),
+					{
+						type: OC.dialogs.YES_NO_BUTTONS,
+						confirm: t('integration_openproject', 'Update'),
+						confirmClasses: 'error',
+						cancel: t('integration_openproject', 'Cancel'),
+					},
+					(result) => {
+						if (result) {
+							that.saveOptions()
+						}
+					},
+					true
+				)
+			}, 1000)()
 		},
 		saveOptions() {
 			const req = {

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -145,6 +145,7 @@ export default {
 #openproject_prefs .grid-form .icon {
 	margin-bottom: -3px;
 }
+
 .save-config-btn, .update-config-btn {
 	margin-left: 30px;
 }

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -66,6 +66,7 @@ export default {
 			state: loadState('integration_openproject', 'admin-config'),
 			// to prevent some browsers to fill fields with remembered passwords
 			readonly: true,
+			isAdminConfigOk: loadState('integration_openproject', 'admin-config-status'),
 			redirect_uri: window.location.protocol + '//' + window.location.host + generateUrl('/apps/integration_openproject/oauth-redirect'),
 		}
 	},
@@ -73,26 +74,28 @@ export default {
 		onInput() {
 			const that = this
 			delay(() => {
-				OC.dialogs.confirmDestructive(
-					t(
-						'integration_openproject',
-						'Are you sure you want to update the admin settings?'
-								+ ' After saving, every connected users must need to re-connect to the Openproject instance.'
-					),
-					t('integration_openproject', 'Confirm Update'),
-					{
-						type: OC.dialogs.YES_NO_BUTTONS,
-						confirm: t('integration_openproject', 'Update'),
-						confirmClasses: 'error',
-						cancel: t('integration_openproject', 'Cancel'),
-					},
-					(result) => {
-						if (result) {
-							that.saveOptions()
-						}
-					},
-					true
-				)
+				if (that.isAdminConfigOk) {
+					OC.dialogs.confirmDestructive(
+						t(
+							'integration_openproject',
+							'Are you sure you want to update the admin settings?'
+							+ ' After saving, every connected users must need to re-connect to the Openproject instance.'
+						),
+						t('integration_openproject', 'Confirm Update'),
+						{
+							type: OC.dialogs.YES_NO_BUTTONS,
+							confirm: t('integration_openproject', 'Update'),
+							confirmClasses: 'error',
+							cancel: t('integration_openproject', 'Cancel'),
+						},
+						(result) => {
+							if (result) {
+								that.saveOptions()
+							}
+						},
+						true
+					)
+				} else that.saveOptions()
 			}, 1000)()
 		},
 		saveOptions() {
@@ -106,6 +109,8 @@ export default {
 			const url = generateUrl('/apps/integration_openproject/admin-config')
 			axios.put(url, req)
 				.then((response) => {
+					// after successfully saving the admin credentials, the admin config status needs to be updated
+					this.isAdminConfigOk = response.data.status === true
 					showSuccess(t('integration_openproject', 'OpenProject admin options saved'))
 				})
 				.catch((error) => {

--- a/tests/jest/components/AdminSettings.spec.js
+++ b/tests/jest/components/AdminSettings.spec.js
@@ -1,8 +1,20 @@
 /* jshint esversion: 8 */
 
+import axios from '@nextcloud/axios'
 import { createLocalVue, shallowMount } from '@vue/test-utils'
 import AdminSettings from '../../../src/components/AdminSettings'
 import * as initialState from '@nextcloud/initial-state'
+
+jest.mock('@nextcloud/axios')
+jest.mock('@nextcloud/l10n', () => ({
+	translate: jest.fn((app, msg) => msg),
+	getLanguage: jest.fn(() => ''),
+}))
+jest.mock('@nextcloud/dialogs', () => ({
+	getLanguage: jest.fn(() => ''),
+	showError: jest.fn(),
+	showSuccess: jest.fn(),
+}))
 
 const localVue = createLocalVue()
 
@@ -17,6 +29,8 @@ const selectors = {
 	oauthInstance: '#openproject-oauth-instance',
 	oauthClientId: '#openproject-client-id',
 	oauthClientSecret: '#openproject-client-secret',
+	saveConfigButton: '.save-config-btn',
+	updateConfigButton: '.update-config-btn',
 }
 
 // eslint-disable-next-line no-import-assign
@@ -47,67 +61,94 @@ describe('AdminSettings', () => {
 			expect(inputField.attributes().readonly).toBeFalsy()
 		})
 	})
-	describe('on input event', () => {
+	describe('form submit', () => {
 		beforeEach(() => {
 			jest.clearAllMocks()
 		})
-		it.each([
-			selectors.oauthInstance,
-			selectors.oauthClientId,
-			selectors.oauthClientId,
-		])('should call "onInput" method', async (inputSelector) => {
-			const onInputSpy = jest.spyOn(AdminSettings.methods, 'onInput')
-				.mockImplementationOnce(() => {
+		describe('when the admin config status is not ok beforehand', () => {
+			let wrapper, confirmSpy
+			beforeEach(() => {
+				confirmSpy = jest.spyOn(global.OC.dialogs, 'confirmDestructive')
+				wrapper = getWrapper({
+					isAdminConfigOk: false,
 				})
-			const wrapper = getWrapper()
-			const inputField = wrapper.find(inputSelector)
-
-			await inputField.trigger('input')
-
-			expect(onInputSpy).toHaveBeenCalledTimes(1)
-		})
-		it('should not asks for confirmation if admin config status is not ok beforehand', async () => {
-			jest.useFakeTimers()
-			const confirmSpy = jest.spyOn(global.OC.dialogs, 'confirmDestructive')
-			const wrapper = getWrapper({
-				isAdminConfigOk: false,
 			})
-			const inputField = wrapper.find(selectors.oauthClientId)
-			await inputField.setValue('test')
-
-			jest.runAllTimers()
-
-			expect(confirmSpy).toBeCalledTimes(0)
-		})
-		it('should ask for confirmation if admin config status is ok beforehand', async () => {
-			jest.useFakeTimers()
-			const confirmSpy = jest.spyOn(global.OC.dialogs, 'confirmDestructive')
-			const wrapper = getWrapper({
-				isAdminConfigOk: true,
+			it('should show the save button', async () => {
+				expect(wrapper.find(selectors.saveConfigButton)).toMatchSnapshot()
+				expect(wrapper.find(selectors.updateConfigButton).exists()).toBeFalsy()
 			})
-			const inputField = wrapper.find(selectors.oauthClientId)
-			await inputField.setValue('test')
+			it('should not trigger confirm dialog on save', async () => {
+				const saveConfigButton = wrapper.find(selectors.saveConfigButton)
+				const inputField = wrapper.find(selectors.oauthClientId)
+				await inputField.setValue('test')
+				await saveConfigButton.trigger('click')
+				expect(confirmSpy).toBeCalledTimes(0)
+			})
+		})
+		describe('when the admin config status is ok beforehand', () => {
+			let wrapper, confirmSpy
+			beforeEach(() => {
+				confirmSpy = jest.spyOn(global.OC.dialogs, 'confirmDestructive')
+				wrapper = getWrapper({
+					isAdminConfigOk: true,
+				})
+			})
+			it('should show the save button', async () => {
+				expect(wrapper.find(selectors.updateConfigButton)).toMatchSnapshot()
+				expect(wrapper.find(selectors.saveConfigButton).exists()).toBeFalsy()
+			})
+			it('should trigger confirm dialog on save', async () => {
+				const updateConfigButton = wrapper.find(selectors.updateConfigButton)
+				const inputField = wrapper.find(selectors.oauthClientId)
+				await inputField.setValue('test')
+				await updateConfigButton.trigger('click')
 
-			jest.runAllTimers()
-
-			expect(confirmSpy).toBeCalledTimes(1)
-
-			const expectedDialogMessage = 'Are you sure you want to update the admin settings? After saving, every connected users must need to re-connect to the Openproject instance.'
-			const expectedDialogTitle = 'Confirm Update'
-			const expectedButtonSet = {
-				confirm: 'Update',
-				cancel: 'Cancel',
-				confirmClasses: 'error',
-				type: 70,
-			}
-
-			expect(confirmSpy).toHaveBeenCalledWith(
-				expectedDialogMessage,
-				expectedDialogTitle,
-				expectedButtonSet,
-				expect.any(Function),
-				true
-			)
+				const expectedDialogMessage = 'Are you sure you want to update the admin settings?'
+				  + ' After saving, every connected users must need to re-connect to the Openproject instance.'
+				const expectedDialogTitle = 'Confirm Update'
+				const expectedButtonSet = {
+					confirm: 'Update',
+					cancel: 'Cancel',
+					confirmClasses: 'error',
+					type: 70,
+				}
+				expect(confirmSpy).toBeCalledTimes(1)
+				expect(confirmSpy).toHaveBeenCalledWith(
+					expectedDialogMessage,
+					expectedDialogTitle,
+					expectedButtonSet,
+					expect.any(Function),
+					true
+				)
+			})
+		})
+		describe('on saveOptions', () => {
+			it.each([
+				{ initaialComponentStatus: true, responseStatus: false, finalComponentStatus: false },
+				{ initaialComponentStatus: false, responseStatus: true, finalComponentStatus: true },
+			])('should update the admin config status as provided by the update response', async ({
+				initaialComponentStatus,
+				responseStatus,
+				finalComponentStatus,
+			}) => {
+				const axiosSpy = jest.spyOn(axios, 'put')
+					.mockImplementationOnce(() => Promise.resolve({
+						data: {
+							status: responseStatus,
+						},
+					}))
+				const wrapper = getWrapper({
+					isAdminConfigOk: initaialComponentStatus,
+					state: {
+						client_id: 'some-id',
+						client_secret: 'some-secret',
+						oauth_instance_url: 'some-url',
+					},
+				})
+				await wrapper.vm.saveOptions()
+				expect(axiosSpy).toHaveBeenCalledTimes(1)
+				expect(wrapper.vm.isAdminConfigOk).toBe(finalComponentStatus)
+			})
 		})
 	})
 })

--- a/tests/jest/components/AdminSettings.spec.js
+++ b/tests/jest/components/AdminSettings.spec.js
@@ -66,10 +66,53 @@ describe('AdminSettings', () => {
 
 			expect(onInputSpy).toHaveBeenCalledTimes(1)
 		})
+		it('should not asks for confirmation if admin config status is not ok beforehand', async () => {
+			jest.useFakeTimers()
+			const confirmSpy = jest.spyOn(global.OC.dialogs, 'confirmDestructive')
+			const wrapper = getWrapper({
+				isAdminConfigOk: false,
+			})
+			const inputField = wrapper.find(selectors.oauthClientId)
+			await inputField.setValue('test')
+
+			jest.runAllTimers()
+
+			expect(confirmSpy).toBeCalledTimes(0)
+		})
+		it('should ask for confirmation if admin config status is ok beforehand', async () => {
+			jest.useFakeTimers()
+			const confirmSpy = jest.spyOn(global.OC.dialogs, 'confirmDestructive')
+			const wrapper = getWrapper({
+				isAdminConfigOk: true,
+			})
+			const inputField = wrapper.find(selectors.oauthClientId)
+			await inputField.setValue('test')
+
+			jest.runAllTimers()
+
+			expect(confirmSpy).toBeCalledTimes(1)
+
+			const expectedDialogMessage = 'Are you sure you want to update the admin settings? After saving, every connected users must need to re-connect to the Openproject instance.'
+			const expectedDialogTitle = 'Confirm Update'
+			const expectedButtonSet = {
+				confirm: 'Update',
+				cancel: 'Cancel',
+				confirmClasses: 'error',
+				type: 70,
+			}
+
+			expect(confirmSpy).toHaveBeenCalledWith(
+				expectedDialogMessage,
+				expectedDialogTitle,
+				expectedButtonSet,
+				expect.any(Function),
+				true
+			)
+		})
 	})
 })
 
-function getWrapper() {
+function getWrapper(data = {}) {
 	return shallowMount(AdminSettings, {
 		localVue,
 		mocks: {
@@ -77,6 +120,11 @@ function getWrapper() {
 			generateUrl() {
 				return '/'
 			},
+		},
+		data() {
+			return {
+				...data,
+			}
 		},
 	})
 }

--- a/tests/jest/components/AdminSettings.spec.js
+++ b/tests/jest/components/AdminSettings.spec.js
@@ -65,7 +65,7 @@ describe('AdminSettings', () => {
 		beforeEach(() => {
 			jest.clearAllMocks()
 		})
-		describe('when the admin config status is not ok beforehand', () => {
+		describe('when the admin config is not complete', () => {
 			let wrapper, confirmSpy
 			beforeEach(() => {
 				confirmSpy = jest.spyOn(global.OC.dialogs, 'confirmDestructive')
@@ -85,7 +85,7 @@ describe('AdminSettings', () => {
 				expect(confirmSpy).toBeCalledTimes(0)
 			})
 		})
-		describe('when the admin config status is ok beforehand', () => {
+		describe('when the admin config status is complete', () => {
 			let wrapper, confirmSpy
 			beforeEach(() => {
 				confirmSpy = jest.spyOn(global.OC.dialogs, 'confirmDestructive')
@@ -93,18 +93,18 @@ describe('AdminSettings', () => {
 					isAdminConfigOk: true,
 				})
 			})
-			it('should show the save button', async () => {
+			it('should show the update button', async () => {
 				expect(wrapper.find(selectors.updateConfigButton)).toMatchSnapshot()
 				expect(wrapper.find(selectors.saveConfigButton).exists()).toBeFalsy()
 			})
-			it('should trigger confirm dialog on save', async () => {
+			it('should trigger confirm dialog on update', async () => {
 				const updateConfigButton = wrapper.find(selectors.updateConfigButton)
 				const inputField = wrapper.find(selectors.oauthClientId)
 				await inputField.setValue('test')
 				await updateConfigButton.trigger('click')
 
-				const expectedDialogMessage = 'Are you sure you want to update the admin settings?'
-				  + ' After saving, every connected users must need to re-connect to the Openproject instance.'
+				const expectedDialogMessage = 'Are you sure you want to update the Oauth settings for OpenProject?'
+				  + ' After saving, all connected users will have to re-connect to the OpenProject instance.'
 				const expectedDialogTitle = 'Confirm Update'
 				const expectedButtonSet = {
 					confirm: 'Update',

--- a/tests/jest/components/AdminSettings.spec.js
+++ b/tests/jest/components/AdminSettings.spec.js
@@ -6,6 +6,13 @@ import * as initialState from '@nextcloud/initial-state'
 
 const localVue = createLocalVue()
 
+global.OC = {
+	dialogs: {
+		confirmDestructive: jest.fn(),
+		YES_NO_BUTTONS: 70,
+	},
+}
+
 const selectors = {
 	oauthInstance: '#openproject-oauth-instance',
 	oauthClientId: '#openproject-client-id',
@@ -26,7 +33,7 @@ describe('AdminSettings', () => {
 		it.each([
 			selectors.oauthClientId,
 			selectors.oauthClientSecret,
-		])('should have on readonly attribute after the input is focused', async (inputSelector) => {
+		])('should not have readonly attribute after the input is focused', async (inputSelector) => {
 			const wrapper = getWrapper()
 			const inputField = wrapper.find(inputSelector)
 			expect(inputField.attributes().readonly).toBeTruthy()

--- a/tests/jest/components/AdminSettings.spec.js
+++ b/tests/jest/components/AdminSettings.spec.js
@@ -103,11 +103,11 @@ describe('AdminSettings', () => {
 				await inputField.setValue('test')
 				await updateConfigButton.trigger('click')
 
-				const expectedDialogMessage = 'Are you sure you want to update the Oauth settings for OpenProject?'
-				  + ' After saving, all connected users will have to re-connect to the OpenProject instance.'
-				const expectedDialogTitle = 'Confirm Update'
+				const expectedDialogMessage = 'Are you sure you want to replace the OpenProject OAuth client details?'
+				+ ' Every currently connected user will need to re-authorize this Nextcloud instance to have access to their OpenProject account.'
+				const expectedDialogTitle = 'Replace OpenProject OAuth client details'
 				const expectedButtonSet = {
-					confirm: 'Update',
+					confirm: 'Replace',
 					cancel: 'Cancel',
 					confirmClasses: 'error',
 					type: 70,

--- a/tests/jest/components/__snapshots__/AdminSettings.spec.js.snap
+++ b/tests/jest/components/__snapshots__/AdminSettings.spec.js.snap
@@ -1,5 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AdminSettings form submit when the admin config status is not ok beforehand should show the save button 1`] = `<button class="save-config-btn">Save</button>`;
+exports[`AdminSettings form submit when the admin config status is not ok beforehand should show the save button 1`] = `
+<button class="save-config-btn">
+  Save
+</button>
+`;
 
-exports[`AdminSettings form submit when the admin config status is ok beforehand should show the save button 1`] = `<button class="update-config-btn">Update</button>`;
+exports[`AdminSettings form submit when the admin config status is ok beforehand should show the save button 1`] = `
+<button class="update-config-btn">
+  Update
+</button>
+`;

--- a/tests/jest/components/__snapshots__/AdminSettings.spec.js.snap
+++ b/tests/jest/components/__snapshots__/AdminSettings.spec.js.snap
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AdminSettings form submit when the admin config status is not ok beforehand should show the save button 1`] = `
+exports[`AdminSettings form submit when the admin config is not complete should show the save button 1`] = `
 <button class="save-config-btn">
   Save
 </button>
 `;
 
-exports[`AdminSettings form submit when the admin config status is ok beforehand should show the save button 1`] = `
+exports[`AdminSettings form submit when the admin config status is complete should show the update button 1`] = `
 <button class="update-config-btn">
   Update
 </button>

--- a/tests/jest/components/__snapshots__/AdminSettings.spec.js.snap
+++ b/tests/jest/components/__snapshots__/AdminSettings.spec.js.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AdminSettings form submit when the admin config status is not ok beforehand should show the save button 1`] = `<button class="save-config-btn">Save</button>`;
+
+exports[`AdminSettings form submit when the admin config status is ok beforehand should show the save button 1`] = `<button class="update-config-btn">Update</button>`;

--- a/tests/lib/Controller/ConfigControllerTest.php
+++ b/tests/lib/Controller/ConfigControllerTest.php
@@ -7,6 +7,7 @@ use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IURLGenerator;
+use OCP\IUserManager;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
@@ -16,6 +17,11 @@ class ConfigControllerTest extends TestCase {
 	 * @var IL10N
 	 */
 	private $l;
+
+	/**
+	 * @var IUserManager
+	 */
+	private $userManager;
 
 	/**
 	 * @var ConfigController
@@ -82,12 +88,13 @@ class ConfigControllerTest extends TestCase {
 			->willReturnCallback(function ($string, $args) {
 				return vsprintf($string, $args);
 			});
-
+		$this->userManager = $this->createMock(IUserManager::class);
 		$this->configController = new ConfigController(
 			'integration_openproject',
 			$this->createMock(IRequest::class),
 			$this->getConfigMock(str_repeat("A", 128), str_repeat("S", 50)),
 			$this->createMock(IURLGenerator::class),
+			$this->userManager,
 			$this->l,
 			$apiServiceMock,
 			$this->createMock(LoggerInterface::class),
@@ -147,6 +154,7 @@ class ConfigControllerTest extends TestCase {
 			$this->createMock(IRequest::class),
 			$this->getConfigMock($codeVerifier, str_repeat("S", 50)),
 			$this->createMock(IURLGenerator::class),
+			$this->createMock(IUserManager::class),
 			$this->l,
 			$this->createMock(OpenProjectAPIService::class),
 			$loggerMock,
@@ -202,6 +210,7 @@ class ConfigControllerTest extends TestCase {
 			$this->createMock(IRequest::class),
 			$this->getConfigMock(str_repeat("A", 128), $clientSecret),
 			$this->createMock(IURLGenerator::class),
+			$this->createMock(IUserManager::class),
 			$this->l,
 			$this->createMock(OpenProjectAPIService::class),
 			$loggerMock,
@@ -278,6 +287,7 @@ class ConfigControllerTest extends TestCase {
 			$this->createMock(IRequest::class),
 			$this->getConfigMock(str_repeat("A", 128), str_repeat("S", 50)),
 			$this->createMock(IURLGenerator::class),
+			$this->createMock(IUserManager::class),
 			$this->l,
 			$apiServiceMock,
 			$this->createMock(LoggerInterface::class),
@@ -285,5 +295,28 @@ class ConfigControllerTest extends TestCase {
 		);
 		$result = $configController->oauthRedirect('code', 'randomString');
 		$this->assertSame($expectedRedirect, $result->getRedirectURL());
+	}
+
+	public function testSetAdminConfigForCaseAdminConfigStatusNotOk() {
+		$apiServiceMock = $this->getMockBuilder(OpenProjectAPIService::class)
+			->disableOriginalConstructor()
+			->getMock();
+
+		$apiServiceMock
+			->method('isAdminConfigOk')
+			->willReturn(false);
+		$configController = new ConfigController(
+			'integration_openproject',
+			$this->createMock(IRequest::class),
+			$this->getConfigMock(str_repeat("A", 128), str_repeat("S", 50)),
+			$this->createMock(IURLGenerator::class),
+			$this->createMock(IUserManager::class),
+			$this->l,
+			$apiServiceMock,
+			$this->createMock(LoggerInterface::class),
+			'testUser'
+		);
+		$result = $configController->setAdminConfig([]);
+
 	}
 }

--- a/tests/lib/Controller/ConfigControllerTest.php
+++ b/tests/lib/Controller/ConfigControllerTest.php
@@ -91,9 +91,6 @@ class ConfigControllerTest extends TestCase {
 			});
 		$this->userManager = $this->createMock(IUserManager::class);
 
-
-
-
 		$this->configController = new ConfigController(
 			'integration_openproject',
 			$this->createMock(IRequest::class),
@@ -309,25 +306,11 @@ class ConfigControllerTest extends TestCase {
 		$manager = \OC::$server->getUserManager();
 		$count = 0;
 		$function = function (IUser $user) use (&$count) {
-			var_dump("-------------------------------");
-			var_dump($user->getUID());
-			var_dump("-------------------------------");
 			$count++;
 		};
 		$manager->callForAllUsers($function, '', true);
-		$countBefore = $count;
-
-		try {
-			$user1 = $manager->createUser('test1', 'test1');
-		} catch (\InvalidArgumentException $e) {
-			echo "\nuser 'test1' already exists.\nwill be deleted and re-created";
-			$user1 = $manager->get('test1');
-			$user1->delete();
-			$user1 = $manager->createUser('test1', 'test1');
-		}
-		// expect only 2 users (admin and our test user)
-		$this->assertSame(2, $countBefore + 1);
-
+		$this->assertSame(1, $count, 'Expected to have only 1 user in the dB before this test');
+		$user1 = $manager->createUser('test11', 'test11');
 
 		$configMock = $this->getMockBuilder(IConfig::class)->getMock();
 		$configMock
@@ -338,6 +321,7 @@ class ConfigControllerTest extends TestCase {
 				['integration_openproject', 'oauth_instance_url']
 			)
 			->willReturnOnConsecutiveCalls('$client_id', '', 'http://openproject.com');
+
 
 		$configMock
 			->expects($this->exactly(12))
@@ -369,11 +353,11 @@ class ConfigControllerTest extends TestCase {
 			$this->l,
 			$apiService,
 			$this->createMock(LoggerInterface::class),
-			'test1'
+			'test11'
 		);
 		$result = $configController->setAdminConfig([]);
 		$this->assertSame(
-			1,
+			["status" => false],
 			$result->getData()
 		);
 		$user1->delete();
@@ -404,12 +388,11 @@ class ConfigControllerTest extends TestCase {
 
 		$manager = \OC::$server->getUserManager();
 		try {
-			$user1 = $manager->createUser('test1', 'test1');
+			$user1 = $manager->createUser('test11', 'test11');
 		} catch (\InvalidArgumentException $e) {
-			echo "'test1' user already exists.\ndeleting and recreating for test...";
-			$user1 = $manager->get('test1');
+			$user1 = $manager->get('test11');
 			$user1->delete();
-			$user1 = $manager->createUser('test1', 'test1');
+			$user1 = $manager->createUser('test11', 'test11');
 		}
 		$configMock
 			->expects($this->never())
@@ -434,7 +417,7 @@ class ConfigControllerTest extends TestCase {
 			'oauth_instance_url' => 'http://openproject.com',
 		]);
 		$this->assertSame(
-			1,
+			["status" => true],
 			$result->getData()
 		);
 		$user1->delete();

--- a/tests/lib/Controller/ConfigControllerTest.php
+++ b/tests/lib/Controller/ConfigControllerTest.php
@@ -298,25 +298,33 @@ class ConfigControllerTest extends TestCase {
 	}
 
 	public function testSetAdminConfigForCaseAdminConfigStatusNotOk() {
-		$apiServiceMock = $this->getMockBuilder(OpenProjectAPIService::class)
+		$configMock = $this->getMockBuilder(IConfig::class)->getMock();
+		$configMock
+			->method('getAppValue')
+			->withConsecutive(
+				['integration_openproject', 'client_id'],
+				['integration_openproject', 'client_secret'],
+				['integration_openproject', 'oauth_instance_url'],
+			)
+			->willReturnOnConsecutiveCalls('$client_id', '', 'http://openproject.com');
+		$apiService = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
 			->getMock();
-
-		$apiServiceMock
-			->method('isAdminConfigOk')
-			->willReturn(false);
 		$configController = new ConfigController(
 			'integration_openproject',
 			$this->createMock(IRequest::class),
-			$this->getConfigMock(str_repeat("A", 128), str_repeat("S", 50)),
+			$configMock,
 			$this->createMock(IURLGenerator::class),
 			$this->createMock(IUserManager::class),
 			$this->l,
-			$apiServiceMock,
+			$apiService,
 			$this->createMock(LoggerInterface::class),
 			'testUser'
 		);
 		$result = $configController->setAdminConfig([]);
-
+		$this->assertSame(
+			1,
+			$result->getData()
+		);
 	}
 }

--- a/tests/lib/Controller/ConfigControllerTest.php
+++ b/tests/lib/Controller/ConfigControllerTest.php
@@ -379,6 +379,9 @@ class ConfigControllerTest extends TestCase {
 		$user1->delete();
 	}
 
+	/**
+	 * @return void
+	 */
 	public function testSetAdminConfigForCaseAdminConfigStatusOk() {
 		$configMock = $this->getMockBuilder(IConfig::class)->getMock();
 		$configMock


### PR DESCRIPTION
#### Description
- implement confirm dialog to update admin credentials
- delete user prefs. if updated admin config is not ok
- added button to submit the form

#### Related
- [OP#42273] part of https://community.openproject.org/projects/nextcloud-integration/work_packages/42273