### PR TITLE
[OP#41678] use notifications API to fetch OP notifications

### DIFF
--- a/lib/Controller/OpenProjectAPIController.php
+++ b/lib/Controller/OpenProjectAPIController.php
@@ -110,14 +110,13 @@ class OpenProjectAPIController extends Controller {
 	 * get notifications list
 	 * @NoAdminRequired
 	 *
-	 * @param ?string $since
 	 * @return DataResponse
 	 */
-	public function getNotifications(?string $since = null): DataResponse {
+	public function getNotifications(): DataResponse {
 		if ($this->accessToken === '' || !OpenProjectAPIService::validateOpenProjectURL($this->openprojectUrl)) {
 			return new DataResponse('', Http::STATUS_BAD_REQUEST);
 		}
-		$result = $this->openprojectAPIService->getNotifications($this->userId, $since, 7);
+		$result = $this->openprojectAPIService->getNotifications($this->userId);
 		if (!isset($result['error'])) {
 			$response = new DataResponse($result);
 		} else {

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -101,7 +101,7 @@ class Notifier implements INotifier {
 				->setParsedMessage('--')
 				->setLink($p['link'] ?? '')
 				->setRichMessage(
-					$l->n('You have %s notification in {instance}', 'You have %s notifications in {instance}', $nbNotifications, [$nbNotifications]),
+					$l->n('You have %s new notification in {instance}', 'You have %s new notifications in {instance}', $nbNotifications, [$nbNotifications]),
 					[
 						'instance' => $richSubjectInstance,
 					]

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -149,7 +149,6 @@ class OpenProjectAPIService {
 						'link' => self::sanitizeUrl($openprojectUrl . '/notifications')
 					]);
 				}
-
 			}
 		}
 	}

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -125,7 +125,7 @@ class OpenProjectAPIService {
 		$notificationEnabled = ($this->config->getUserValue($userId, Application::APP_ID, 'notification_enabled', '0') === '1');
 		if ($accessToken && $notificationEnabled) {
 			$lastNotificationCheck = $this->config->getUserValue($userId, Application::APP_ID, 'last_notification_check');
-			$lastNotificationCheck = $lastNotificationCheck === '' ? 0 : $lastNotificationCheck;
+			$lastNotificationCheck = $lastNotificationCheck === '' ? 0 : (int)$lastNotificationCheck;
 			$newLastNotificationCheck = time();
 			$openprojectUrl = $this->config->getAppValue(Application::APP_ID, 'oauth_instance_url');
 			$notifications = $this->getNotifications($userId);
@@ -134,7 +134,7 @@ class OpenProjectAPIService {
 					$userId,
 					Application::APP_ID,
 					'last_notification_check',
-					$newLastNotificationCheck
+					"$newLastNotificationCheck"
 				);
 				$nbRelevantNotifications = 0;
 				foreach ($notifications as $n) {
@@ -204,7 +204,15 @@ class OpenProjectAPIService {
 	 * @return array<mixed>
 	 */
 	public function getNotifications(string $userId): array {
-		$result = $this->request($userId, 'notifications');
+		$filters[] = [
+			'readIAN' =>
+				['operator' => '=', 'values' => ['f']]
+		];
+
+		$params = [
+			'filters' => \Safe\json_encode($filters),
+		];
+		$result = $this->request($userId, 'notifications', $params);
 		if (isset($result['error'])) {
 			return $result;
 		} elseif (!isset($result['_embedded']['elements'])) {

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -129,7 +129,7 @@ class OpenProjectAPIService {
 			if (!isset($notifications['error']) && count($notifications) > 0) {
 				$this->sendNCNotification($userId, 'new_open_tickets', [
 					'nbNotifications' => count($notifications),
-					'link' => $openprojectUrl
+					'link' => self::sanitizeUrl($openprojectUrl . '/notifications')
 				]);
 			}
 		}
@@ -694,5 +694,20 @@ class OpenProjectAPIService {
 		} else {
 			return self::validateOpenProjectURL($oauthInstanceUrl);
 		}
+	}
+
+	/**
+	 * makes sure the URL has no extra slashes
+	 */
+	public static function sanitizeUrl(
+		string $url, bool $trailingSlash = false
+	): string {
+		if ($trailingSlash === true) {
+			$url = $url . "/";
+		} else {
+			$url = \rtrim($url, "/");
+		}
+		$url = \preg_replace("/([^:]\/)\/+/", '$1', $url);
+		return $url;
 	}
 }

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -138,8 +138,8 @@ class OpenProjectAPIService {
 				);
 				$nbRelevantNotifications = 0;
 				foreach ($notifications as $n) {
-					$updatedAt = new DateTime($n['createdAt']);
-					if ($updatedAt->getTimestamp() > $lastNotificationCheck) {
+					$createdAt = new DateTime($n['createdAt']);
+					if ($createdAt->getTimestamp() > $lastNotificationCheck) {
 						$nbRelevantNotifications++;
 					}
 				}

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -138,11 +138,10 @@ class OpenProjectAPIService {
 				);
 				$nbRelevantNotifications = 0;
 				foreach ($notifications as $n) {
-					$updatedAt = new DateTime($n['updatedAt']);
+					$updatedAt = new DateTime($n['createdAt']);
 					if ($updatedAt->getTimestamp() > $lastNotificationCheck) {
 						$nbRelevantNotifications++;
 					}
-
 				}
 				if ($nbRelevantNotifications > 0) {
 					$this->sendNCNotification($userId, 'new_open_tickets', [

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -178,8 +178,9 @@ class OpenProjectAPIService {
 		$notification->setApp(Application::APP_ID)
 			->setUser($userId)
 			->setDateTime(new DateTime())
-			->setObject('dum', 'dum')
-			->setSubject($subject, $params);
+			->setObject('dum', 'dum');
+
+		$notification->setSubject($subject, $params);
 
 		$manager->notify($notification);
 	}

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -238,7 +238,7 @@ export default {
 			return generateUrl('/svg/core/actions/sound?color=' + this.themingColor)
 		},
 		getSubline(n) {
-			return n._links.project.title
+			return n._links.project.title + ' - ' + t('integration_openproject', n.reason)
 		},
 		getTargetTitle(n) {
 			return n._links.resource.title

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -199,37 +199,31 @@ export default {
 			return notifications
 		},
 		getNotificationTarget(n) {
-			const projectId = n._links?.project?.href
-				? n._links.project.href.replace(/.*\//, '')
+			const wpId = n._links?.resource?.href
+				? n._links.resource.href.replace(/.*\//, '')
 				: null
-			return projectId
-				? this.openprojectUrl + '/projects/' + projectId + '/work_packages/' + n.id
+			return wpId
+				? this.openprojectUrl + '/notifications/details/' + wpId + '/activity/'
 				: ''
 		},
 		getUniqueKey(n) {
 			return n.id + ':' + n.updatedAt
 		},
 		getAuthorShortName(n) {
-			return n._links?.assignee?.title
-				? n._links.assignee.title
-				: n._links?.author?.title
-					? n._links.author.title
-					: undefined
+			return n._links?.actor?.title
+				? n._links.actor.title
+				: undefined
 		},
 		getAuthorFullName(n) {
 			return n.firstname + ' ' + n.lastname
 		},
 		getAuthorAvatarUrl(n) {
-			const userId = n._links?.assignee?.href
-				? n._links.assignee.href.replace(/.*\//, '')
-				: n._links?.author?.href
-					? n._links.author.href.replace(/.*\//, '')
-					: null
-			const userName = n._links?.assignee?.title
-				? n._links.assignee.title
-				: n._links?.author?.title
-					? n._links.author.title
-					: null
+			const userId = n._links?.actor?.href
+				? n._links.actor.href.replace(/.*\//, '')
+				: null
+			const userName = n._links?.actor?.title
+				? n._links.actor.title
+				: null
 			return userId
 				? generateUrl('/apps/integration_openproject/avatar?') + encodeURIComponent('userId') + '=' + userId + '&' + encodeURIComponent('userName') + '=' + userName
 				: ''
@@ -244,16 +238,10 @@ export default {
 			return generateUrl('/svg/core/actions/sound?color=' + this.themingColor)
 		},
 		getSubline(n) {
-			const description = n.description?.raw
-				? n.description.raw
-				: ''
-			const status = n._links?.status?.title
-				? '[' + n._links.status.title + '] '
-				: ''
-			return status + description
+			return n._links.project.title
 		},
 		getTargetTitle(n) {
-			return n.subject
+			return n._links.resource.title
 		},
 		getFormattedDate(n) {
 			return moment(n.updated_at).format('LLL')

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -63,7 +63,7 @@ export default {
 			return this.state === STATE.LOADING
 		},
 		showMoreUrl() {
-			return this.openprojectUrl + '/projects'
+			return this.openprojectUrl + '/notifications'
 		},
 		items() {
 			return this.notifications.map((n) => {

--- a/tests/lib/Service/OpenProjectAPIServiceCheckNotificationsTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceCheckNotificationsTest.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * Nextcloud - OpenProject
+ *
+ *
+ * @author Artur Neumann <artur@jankaritech.com>
+ * @copyright Artur Neumann 2022
+ */
+
+namespace OCA\OpenProject\Service;
+
+use OCP\Http\Client\IResponse;
+use OCP\IConfig;
+use OCP\IUserManager;
+use OCP\Notification\IManager;
+use OCP\Notification\INotification;
+use PHPUnit\Framework\TestCase;
+
+class OpenProjectAPIServiceCheckNotificationsTest extends TestCase {
+	/**
+	 * @var string
+	 */
+	private $oPNotificationAPIResponse = '
+					{
+					  "_type": "Collection",
+					  "_embedded": {
+						"elements": [
+						  {
+							"_type": "Notification",
+							"id": 21,
+							"reason": "commented",
+							"createdAt": "2022-05-11T10:10:10Z"
+						  },
+						  {
+							"_type": "Notification",
+							"id": 22,
+							"reason": "commented",
+							"createdAt": "2022-05-12T10:10:10Z"
+						  },
+						  {
+							"_type": "Notification",
+							"id": 23,
+							"reason": "commented",
+							"createdAt": "2022-05-13T10:10:10Z"
+						  },
+						  {
+							"_type": "Notification",
+							"id": 25,
+							"reason": "commented",
+							"createdAt": "2022-05-14T10:10:10Z"
+						  }
+						]
+					  }
+					}';
+
+	/**
+	 * @return array<mixed>
+	 */
+	public function checkNotificationDataProvider(): array {
+		return [
+			[ '', 4, true ], // last_notification_check was not set yet
+			[ '1652132430', 4, true ], // all notifications are were created after the last_notification_check
+			[ '1652350210', 2, true ], // some notifications were created after and some befor the last_notification_check
+			[ '1652605230', 0, false] // all notifications are older that last_notification_check
+		];
+	}
+	/**
+	 * @dataProvider checkNotificationDataProvider
+	 */
+	public function testCheckNotifications(
+		string $lastNotificationCheck,
+		int    $countOfReportedOPNotifications,
+		bool   $nextCloudNotificationFired
+	): void {
+		$configMock = $this->getMockBuilder(IConfig::class)->getMock();
+		$configMock
+			->method('getUserValue')
+			->withConsecutive(
+				[$this->anything(), 'integration_openproject', 'token'],
+				[$this->anything(), 'integration_openproject', 'notification_enabled'],
+				[$this->anything(), 'integration_openproject', 'last_notification_check'],
+			)
+			->willReturnOnConsecutiveCalls(
+				'123456',
+				'1',
+				$lastNotificationCheck
+			);
+
+		$configMock
+			->expects($this->once())
+			->method('setUserValue')
+			->with(
+				$this->anything(),
+				'integration_openproject',
+				'last_notification_check',
+				$this->anything()
+			);
+
+		$configMock
+			->method('getAppValue')
+			->withConsecutive(
+				['integration_openproject', 'oauth_instance_url'],
+				['integration_openproject', 'client_id'],
+				['integration_openproject', 'client_secret'],
+				['integration_openproject', 'oauth_instance_url'],
+				['integration_openproject', 'client_id'],
+				['integration_openproject', 'oauth_instance_url'],
+			)->willReturnOnConsecutiveCalls(
+				'https://openproject',
+				'clientID',
+				'SECRET',
+				'https://openproject',
+				'clientID',
+				'https://openproject'
+			);
+
+		$response = $this->getMockBuilder(IResponse::class)->getMock();
+		$response->method('getBody')->willReturn($this->oPNotificationAPIResponse);
+		$ocClient = $this->getMockBuilder('\OCP\Http\Client\IClient')->getMock();
+		$ocClient->method('get')->willReturn($response);
+		$clientService = $this->getMockBuilder('\OCP\Http\Client\IClientService')->getMock();
+		$clientService->method('newClient')->willReturn($ocClient);
+
+		$notificationManagerMock = $this->getMockBuilder(IManager::class)->getMock();
+
+		if ($nextCloudNotificationFired) {
+			$notificationMock = $this->getMockBuilder(INotification::class)
+				->getMock();
+
+			$notificationMock
+				->expects($this->once())
+				->method('setSubject')
+				->with(
+					'new_open_tickets',
+					[
+						'nbNotifications' => $countOfReportedOPNotifications,
+						'link' => 'https://openproject/notifications'
+					]
+				);
+
+			$notificationManagerMock
+				->expects($this->once())
+				->method('createNotification')
+				->willReturn($notificationMock);
+
+			$notificationManagerMock
+				->expects($this->once())
+				->method('notify');
+		} else {
+			$notificationManagerMock
+				->expects($this->never())
+				->method('notify');
+		}
+		$service = new OpenProjectAPIService(
+			'integration_openproject',
+			\OC::$server->get(IUserManager::class),
+			$this->createMock(\OCP\IAvatarManager::class),
+			$this->createMock(\Psr\Log\LoggerInterface::class),
+			$this->createMock(\OCP\IL10N::class),
+			$configMock,
+			$notificationManagerMock,
+			$clientService,
+			$this->createMock(\OCP\Files\IRootFolder::class),
+			$this->createMock(\OCP\IURLGenerator::class),
+		);
+
+		$service->checkNotifications();
+	}
+}

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -67,6 +67,11 @@ class OpenProjectAPIServiceTest extends TestCase {
 	/**
 	 * @var string
 	 */
+	private $notificationsPath = '/api/v3/notifications';
+
+	/**
+	 * @var string
+	 */
 	private $fileLinksPath = '/api/v3/file_links';
 
 	/**
@@ -485,10 +490,8 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$consumerRequest = new ConsumerRequest();
 		$consumerRequest
 			->setMethod('GET')
-			->setPath($this->workPackagesPath)
-			->setHeaders(["Authorization" => "Bearer 1234567890"])
-			->addQueryParameter('filters', '[{"status":{"operator":"!","values":["14"]}}]')
-			->addQueryParameter('sortBy', '[["updatedAt", "desc"]]');
+			->setPath($this->notificationsPath)
+			->setHeaders(["Authorization" => "Bearer 1234567890"]);
 
 		$providerResponse = new ProviderResponse();
 		$providerResponse
@@ -497,7 +500,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 			->setBody(["_embedded" => ["elements" => [['some' => 'data']]]]);
 
 		$this->builder
-			->uponReceiving('a GET request to /work_packages with filter and sorting')
+			->uponReceiving('a GET request to /notifications')
 			->with($consumerRequest)
 			->willRespondWith($providerResponse);
 
@@ -526,7 +529,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$service = $this->getServiceMock();
 		$service->method('request')
 			->willReturn($response);
-		$result = $service->getNotifications('', '');
+		$result = $service->getNotifications('');
 		$this->assertSame(["error" => "Malformed response"], $result);
 	}
 
@@ -537,38 +540,8 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$service = $this->getServiceMock();
 		$service->method('request')
 			->willReturn(['error' => 'my error']);
-		$result = $service->getNotifications('', '');
+		$result = $service->getNotifications('');
 		$this->assertSame(["error" => "my error"], $result);
-	}
-
-	/**
-	 * @return void
-	 */
-	public function testGetNotificationsFilters() {
-		$service = $this->getServiceMock(['request', 'now']);
-		$service->method('now')
-			->willReturn("2022-01-27T08:15:48Z");
-		$service->expects($this->once())
-			->method('request')
-			->with(
-				'user', 'work_packages',
-				[
-					'filters' => '[{"updatedAt":{"operator":"<>d","values":["2022-01-01T12:01:01Z","2022-01-27T08:15:48Z"]}},{"status":{"operator":"!","values":["14"]}}]',
-					'sortBy' => '[["updatedAt", "desc"]]'
-				]);
-
-		$service->getNotifications('user', '2022-01-01T12:01:01Z');
-	}
-
-	/**
-	 * @return void
-	 */
-	public function testGetNotificationsLimit() {
-		$service = $this->getServiceMock();
-		$service->method('request')
-			->willReturn(["_embedded" => ["elements" => [['id' => 1], ['id' => 2], ['id' => 3]]]]);
-		$result = $service->getNotifications('', '', 2);
-		$this->assertSame([['id' => 1], ['id' => 2]], $result);
 	}
 
 	/**

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -491,6 +491,10 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$consumerRequest
 			->setMethod('GET')
 			->setPath($this->notificationsPath)
+			->setQuery("filters=" . \Safe\json_encode([[
+					'readIAN' =>
+						['operator' => '=', 'values' => ['f']]
+				]]))
 			->setHeaders(["Authorization" => "Bearer 1234567890"]);
 
 		$providerResponse = new ProviderResponse();

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -492,9 +492,9 @@ class OpenProjectAPIServiceTest extends TestCase {
 			->setMethod('GET')
 			->setPath($this->notificationsPath)
 			->setQuery("filters=" . \Safe\json_encode([[
-					'readIAN' =>
-						['operator' => '=', 'values' => ['f']]
-				]]))
+				'readIAN' =>
+					['operator' => '=', 'values' => ['f']]
+			]]))
 			->setHeaders(["Authorization" => "Bearer 1234567890"]);
 
 		$providerResponse = new ProviderResponse();


### PR DESCRIPTION
use the notification API to fetch notifications from OpenProject (for dashboard and for the NC notifications)

please note for the notifications to work you need to install and enable the notifications NC app https://github.com/nextcloud/notifications and also enable `Enable notifications for activity in my work packages` in the openproject_integration personal settings

dashboard view
![image](https://user-images.githubusercontent.com/2425577/168549042-6c93bb27-8116-424b-be14-add4aea3a727.png)

notifications view
![image](https://user-images.githubusercontent.com/2425577/168549166-f5dc4004-8ab5-4976-b87b-a198a6844567.png)

The count of notifications in the notifications view is the count of NEW notifications since the last check. Dismissing notifications on NC side will NOT have any effect on the OP notifications

fixes https://community.openproject.org/projects/nextcloud-integration/work_packages/41678