### PR TITLE
Fix the misplaced route

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -22,10 +22,10 @@ return [
 		['name' => 'openProjectAPI#getWorkPackageFileLinks', 'url' => '/work-packages/{id}/file-links', 'verb' => 'GET'],
 		['name' => 'openProjectAPI#getOpenProjectWorkPackageStatus', 'url' => '/statuses/{id}', 'verb' => 'GET'],
 		['name' => 'openProjectAPI#getOpenProjectWorkPackageType', 'url' => '/types/{id}', 'verb' => 'GET'],
+		['name' => 'openProjectAPI#deleteFileLink', 'url' => '/file-links/{id}', 'verb' => 'DELETE'],
 	],
 	'ocs' => [
 		['name' => 'files#getFileInfo', 'url' => '/fileinfo/{fileId}', 'verb' => 'GET'],
 		['name' => 'files#getFilesInfo', 'url' => '/filesinfo', 'verb' => 'POST'],
-		['name' => 'openProjectAPI#deleteFileLink', 'url' => '/file-links/{id}', 'verb' => 'DELETE'],
 	]
 ];


### PR DESCRIPTION
The endpoint for `deleting` a link should be inside `routes` but PR https://github.com/nextcloud/integration_openproject/pull/67/files#diff-6301937af1cc1575e9e18ecd27c4a51f0d3cf9ce12e59a14709f626dfa3ef952 misplaced it 

This PR fixes that. This fixes the unlinking of the work package which wasn't working before.