### PR TITLE
OP#41503 only show WP belonging to this file (async cases)

### DIFF
--- a/src/components/tab/SearchInput.vue
+++ b/src/components/tab/SearchInput.vue
@@ -169,6 +169,7 @@ export default {
 			for (let workPackage of workPackages) {
 				try {
 					if (this.isStateLoading) {
+						workPackage.fileId = this.fileInfo.id
 						workPackage = await workpackageHelper.getAdditionalMetaData(workPackage)
 						const alreadyLinked = this.linkedWorkPackages.some(el => el.id === workPackage.id)
 						const alreadyInSearchResults = this.searchResults.some(el => el.id === workPackage.id)

--- a/src/components/tab/SearchInput.vue
+++ b/src/components/tab/SearchInput.vue
@@ -3,7 +3,7 @@
 		<Multiselect ref="workPackageMultiSelect"
 			class="searchInput"
 			:placeholder="placeholder"
-			:options="searchResults"
+			:options="filterSearchResultsByFileId"
 			:user-select="true"
 			label="displayName"
 			track-by="id"
@@ -81,6 +81,15 @@ export default {
 			}
 			return ''
 		},
+		filterSearchResultsByFileId() {
+			return this.searchResults.filter(wp => {
+				if (wp.fileId === undefined || wp.fileId === '') {
+					console.error('work-package data does not contain a fileId')
+					return false
+				}
+				return wp.fileId === this.fileInfo.id
+			})
+		},
 	},
 	watch: {
 		fileInfo(oldFile, newFile) {
@@ -116,7 +125,7 @@ export default {
 			if (query) {
 				this.resetState()
 				if (query.length <= SEARCH_CHAR_LIMIT) return
-				await this.debounceMakeSearchRequest(query)
+				await this.debounceMakeSearchRequest(query, this.fileInfo.id)
 			}
 		},
 		debounceMakeSearchRequest: debounce(function(...args) {
@@ -148,7 +157,7 @@ export default {
 				)
 			}
 		},
-		async makeSearchRequest(search) {
+		async makeSearchRequest(search, fileId) {
 			this.state = STATE.LOADING
 			const url = generateUrl('/apps/integration_openproject/work-packages')
 			const req = {}
@@ -162,14 +171,14 @@ export default {
 				response = e.response
 			}
 			this.checkForErrorCode(response.status)
-			if (response.status === 200) await this.processWorkPackages(response.data)
+			if (response.status === 200) await this.processWorkPackages(response.data, fileId)
 			if (this.isStateLoading) this.state = STATE.OK
 		},
-		async processWorkPackages(workPackages) {
+		async processWorkPackages(workPackages, fileId) {
 			for (let workPackage of workPackages) {
 				try {
 					if (this.isStateLoading) {
-						workPackage.fileId = this.fileInfo.id
+						workPackage.fileId = fileId
 						workPackage = await workpackageHelper.getAdditionalMetaData(workPackage)
 						const alreadyLinked = this.linkedWorkPackages.some(el => el.id === workPackage.id)
 						const alreadyInSearchResults = this.searchResults.some(el => el.id === workPackage.id)

--- a/src/utils/workpackageHelper.js
+++ b/src/utils/workpackageHelper.js
@@ -60,6 +60,7 @@ export const workpackageHelper = {
 			statusCol: statusColor,
 			typeCol: typeColor,
 			picture: avatarUrl,
+			fileId: workPackage.fileId,
 		}
 	},
 }

--- a/src/utils/workpackageHelper.js
+++ b/src/utils/workpackageHelper.js
@@ -34,6 +34,8 @@ export const workpackageHelper = {
 			|| workPackage._links.status.title === ''
 			|| typeof workPackage._links.type.title !== 'string'
 			|| workPackage._links.type.title === ''
+			|| typeof workPackage.fileId !== 'number'
+			|| workPackage.fileId <= 0
 		) {
 			throw new Error('missing data in workpackage object')
 		}

--- a/src/views/ProjectsTab.vue
+++ b/src/views/ProjectsTab.vue
@@ -84,7 +84,13 @@ export default {
 			return this.state === STATE.LOADING
 		},
 		filterWorkpackagesByFileId() {
-			return this.workpackages.filter(wp => wp.fileId === this.fileInfo.id)
+			return this.workpackages.filter(wp => {
+				if (wp.fileId === undefined || wp.fileId === '') {
+					console.error('work-package data does not contain a fileId')
+					return false
+				}
+				return wp.fileId === this.fileInfo.id
+			})
 		},
 	},
 	methods: {

--- a/src/views/ProjectsTab.vue
+++ b/src/views/ProjectsTab.vue
@@ -197,7 +197,7 @@ export default {
 			}
 			return linkId
 		},
-		worpackageAlreadyInList(workPackage) {
+		workpackageAlreadyInList(workPackage) {
 			return this.workpackages.some(
 				elem => elem.id === workPackage.id && elem.fileId === workPackage.fileId,
 			)
@@ -216,11 +216,11 @@ export default {
 							workPackage.fileId = fileId
 							// if the WP is already in the list, because the user switched quickly between files
 							// don't even try to fetch all the additional meta data
-							if (!this.worpackageAlreadyInList(workPackage)) {
+							if (!this.workpackageAlreadyInList(workPackage)) {
 								workPackage = await workpackageHelper.getAdditionalMetaData(workPackage)
 								// check again, the WP might have been added by an outstanding request
 								// from another file
-								if (!this.worpackageAlreadyInList(workPackage)) {
+								if (!this.workpackageAlreadyInList(workPackage)) {
 									this.workpackages.push(workPackage)
 								}
 							}

--- a/tests/jest/components/tab/SearchInput.spec.js
+++ b/tests/jest/components/tab/SearchInput.spec.js
@@ -7,6 +7,7 @@ import SearchInput from '../../../../src/components/tab/SearchInput'
 import workPackagesSearchResponse from '../../fixtures/workPackagesSearchResponse.json'
 import workPackagesSearchResponseNoAssignee from '../../fixtures/workPackagesSearchResponseNoAssignee.json'
 import workPackageSearchReqResponse from '../../fixtures/workPackageSearchReqResponse.json'
+import workPackageObjectsInSearchResults from '../../fixtures/workPackageObjectsInSearchResults.json'
 import { STATE } from '../../../../src/utils'
 
 jest.mock('@nextcloud/axios')
@@ -176,6 +177,7 @@ describe('SearchInput.vue tests', () => {
 			})
 			it('should display correct options list of search results', async () => {
 				await wrapper.setData({
+					fileInfo: { id: 1234 },
 					searchResults: workPackagesSearchResponse,
 				})
 				const multiSelectContent = wrapper.find(multiSelectContentSelector)
@@ -195,7 +197,8 @@ describe('SearchInput.vue tests', () => {
 			})
 			it('should only use the options from the latest search response', async () => {
 				await wrapper.setData({
-					searchResults: workPackageSearchReqResponse,
+					fileInfo: { id: 111 },
+					searchResults: workPackageObjectsInSearchResults,
 				})
 				expect(wrapper.findAll(workPackageStubSelector).length).toBe(3)
 				const axiosSpy = jest.spyOn(axios, 'get')
@@ -219,13 +222,15 @@ describe('SearchInput.vue tests', () => {
 				axiosSpy.mockRestore()
 			})
 			it('should not display work packages that are already linked', async () => {
-				wrapper = mountSearchInput({},
+				wrapper = mountSearchInput({ id: 111 },
 					[
 						{
+							fileId: 111,
 							id: 1,
 							subject: 'One',
 						},
 						{
+							fileId: 111,
 							id: 13,
 							subject: 'Write a software',
 						},
@@ -233,7 +238,7 @@ describe('SearchInput.vue tests', () => {
 				const axiosSpy = jest.spyOn(axios, 'get')
 					.mockImplementationOnce(() => Promise.resolve({
 						status: 200,
-						data: workPackageSearchReqResponse,
+						data: workPackageObjectsInSearchResults,
 					}))
 					// any other requests e.g. for types and statuses
 					.mockImplementation(() => Promise.resolve(
@@ -288,7 +293,9 @@ describe('SearchInput.vue tests', () => {
 						{ status: 200, data: [] })
 					)
 				await wrapper.setData({
+					fileInfo: { id: 111 },
 					searchResults: [{
+						fileId: 111,
 						id: 2,
 						subject: 'Organize open source conference',
 					}],
@@ -388,6 +395,7 @@ describe('SearchInput.vue tests', () => {
 				await inputField.setValue('orga')
 				await wrapper.setData({
 					searchResults: [{
+						fileId: 111,
 						id: 999,
 					}],
 				})
@@ -400,7 +408,7 @@ describe('SearchInput.vue tests', () => {
 				await multiselectItem.trigger('click')
 				const savedEvent = wrapper.emitted('saved')
 				expect(savedEvent).toHaveLength(1)
-				expect(savedEvent[0]).toEqual([{ id: 999 }])
+				expect(savedEvent[0]).toEqual([{ fileId: 111, id: 999 }])
 			})
 			it('should send a request to link file to workpackage', async () => {
 				const postSpy = jest.spyOn(axios, 'post')

--- a/tests/jest/components/tab/__snapshots__/SearchInput.spec.js.snap
+++ b/tests/jest/components/tab/__snapshots__/SearchInput.spec.js.snap
@@ -22,6 +22,7 @@ exports[`SearchInput.vue tests work packages multiselect search list should disp
 Object {
   "workpackage": Object {
     "assignee": "test",
+    "fileId": 1234,
     "id": "1",
     "picture": "/server/index.php/apps/integration_openproject/avatar?userId=1&userName=System",
     "project": "test",

--- a/tests/jest/components/tab/__snapshots__/SearchInput.spec.js.snap
+++ b/tests/jest/components/tab/__snapshots__/SearchInput.spec.js.snap
@@ -49,6 +49,7 @@ exports[`SearchInput.vue tests work packages multiselect search list should only
 Object {
   "workpackage": Object {
     "assignee": "some assignee",
+    "fileId": undefined,
     "id": 1,
     "picture": "http://localhost/apps/integration_openproject/avatar?userId=&userName=some assignee",
     "project": "some project",

--- a/tests/jest/components/tab/__snapshots__/SearchInput.spec.js.snap
+++ b/tests/jest/components/tab/__snapshots__/SearchInput.spec.js.snap
@@ -50,7 +50,7 @@ exports[`SearchInput.vue tests work packages multiselect search list should only
 Object {
   "workpackage": Object {
     "assignee": "some assignee",
-    "fileId": undefined,
+    "fileId": 111,
     "id": 1,
     "picture": "http://localhost/apps/integration_openproject/avatar?userId=&userName=some assignee",
     "project": "some project",

--- a/tests/jest/fixtures/workPackageObjectsInSearchResults.json
+++ b/tests/jest/fixtures/workPackageObjectsInSearchResults.json
@@ -1,0 +1,579 @@
+[{
+	"fileId": 111,
+	"derivedStartDate": "2022-01-15",
+	"derivedDueDate": "2022-03-08",
+	"_type": "WorkPackage",
+	"id": 2,
+	"lockVersion": 0,
+	"subject": "Organize open source conference",
+	"description": {
+		"format": "markdown",
+		"raw": null,
+		"html": ""
+	},
+	"scheduleManually": false,
+	"startDate": "2022-01-15",
+	"dueDate": "2022-03-26",
+	"estimatedTime": null,
+	"derivedEstimatedTime": null,
+	"percentageDone": 0,
+	"createdAt": "2022-01-12T08:53:29Z",
+	"updatedAt": "2022-01-12T08:53:29Z",
+	"_links": {
+		"attachments": {
+			"href": "/api/v3/work_packages/2/attachments"
+		},
+		"addAttachment": {
+			"href": "/api/v3/work_packages/2/attachments",
+			"method": "post"
+		},
+		"self": {
+			"href": "/api/v3/work_packages/2",
+			"title": "Organize open source conference"
+		},
+		"update": {
+			"href": "/api/v3/work_packages/2/form",
+			"method": "post"
+		},
+		"schema": {
+			"href": "/api/v3/work_packages/schemas/1-3"
+		},
+		"updateImmediately": {
+			"href": "/api/v3/work_packages/2",
+			"method": "patch"
+		},
+		"delete": {
+			"href": "/api/v3/work_packages/2",
+			"method": "delete"
+		},
+		"move": {
+			"href": "/work_packages/2/move/new",
+			"type": "text/html",
+			"title": "Move Organize open source conference"
+		},
+		"copy": {
+			"href": "/work_packages/2/copy",
+			"title": "Copy Organize open source conference"
+		},
+		"pdf": {
+			"href": "/work_packages/2.pdf",
+			"type": "application/pdf",
+			"title": "Export as PDF"
+		},
+		"atom": {
+			"href": "/work_packages/2.atom",
+			"type": "application/rss+xml",
+			"title": "Atom feed"
+		},
+		"availableRelationCandidates": {
+			"href": "/api/v3/work_packages/2/available_relation_candidates",
+			"title": "Potential work packages to relate to"
+		},
+		"customFields": {
+			"href": "/projects/demo-project/settings/custom_fields",
+			"type": "text/html",
+			"title": "Custom fields"
+		},
+		"configureForm": {
+			"href": "/types/3/edit?tab=form_configuration",
+			"type": "text/html",
+			"title": "Configure form"
+		},
+		"activities": {
+			"href": "/api/v3/work_packages/2/activities"
+		},
+		"availableWatchers": {
+			"href": "/api/v3/work_packages/2/available_watchers"
+		},
+		"relations": {
+			"href": "/api/v3/work_packages/2/relations"
+		},
+		"revisions": {
+			"href": "/api/v3/work_packages/2/revisions"
+		},
+		"watchers": {
+			"href": "/api/v3/work_packages/2/watchers"
+		},
+		"addWatcher": {
+			"href": "/api/v3/work_packages/2/watchers",
+			"method": "post",
+			"payload": {
+				"user": {
+					"href": "/api/v3/users/{user_id}"
+				}
+			},
+			"templated": true
+		},
+		"removeWatcher": {
+			"href": "/api/v3/work_packages/2/watchers/{user_id}",
+			"method": "delete",
+			"templated": true
+		},
+		"addRelation": {
+			"href": "/api/v3/work_packages/2/relations",
+			"method": "post",
+			"title": "Add relation"
+		},
+		"addChild": {
+			"href": "/api/v3/projects/demo-project/work_packages",
+			"method": "post",
+			"title": "Add child of Organize open source conference"
+		},
+		"changeParent": {
+			"href": "/api/v3/work_packages/2",
+			"method": "patch",
+			"title": "Change parent of Organize open source conference"
+		},
+		"addComment": {
+			"href": "/api/v3/work_packages/2/activities",
+			"method": "post",
+			"title": "Add comment"
+		},
+		"previewMarkup": {
+			"href": "/api/v3/render/markdown?context=/api/v3/work_packages/2",
+			"method": "post"
+		},
+		"category": {
+			"href": null
+		},
+		"type": {
+			"href": "/api/v3/types/3",
+			"title": "Phase"
+		},
+		"priority": {
+			"href": "/api/v3/priorities/8",
+			"title": "Normal"
+		},
+		"project": {
+			"href": "/api/v3/projects/1",
+			"title": "Demo project"
+		},
+		"status": {
+			"href": "/api/v3/statuses/7",
+			"title": "In progress"
+		},
+		"author": {
+			"href": "/api/v3/users/1"
+		},
+		"responsible": {
+			"href": null
+		},
+		"assignee": {
+			"href": "/api/v3/users/1",
+			"title": "System"
+		},
+		"version": {
+			"href": null
+		},
+		"github_pull_requests": {
+			"href": "/api/v3/work_packages/2/github_pull_requests",
+			"title": "GitHub pull requests"
+		},
+		"watch": {
+			"href": "/api/v3/work_packages/2/watchers",
+			"method": "post",
+			"payload": {
+				"user": {
+					"href": "/api/v3/users/3"
+				}
+			}
+		},
+		"children": [
+			{
+				"href": "/api/v3/work_packages/3",
+				"title": "Set date and location of conference"
+			},
+			{
+				"href": "/api/v3/work_packages/4",
+				"title": "Setup conference website"
+			},
+			{
+				"href": "/api/v3/work_packages/5",
+				"title": "Invite attendees to conference"
+			}
+		],
+		"ancestors": [],
+		"parent": {
+			"href": null,
+			"title": null
+		},
+		"customActions": []
+	}
+},
+{
+	"fileId": 111,
+	"derivedStartDate": "2021-01-15",
+	"derivedDueDate": "2022-01-08",
+	"_type": "WorkPackage",
+	"id": 13,
+	"lockVersion": 0,
+	"subject": "Write a software",
+	"description": {
+		"format": "markdown",
+		"raw": null,
+		"html": ""
+	},
+	"scheduleManually": false,
+	"startDate": "2022-01-15",
+	"dueDate": "2022-03-26",
+	"estimatedTime": null,
+	"derivedEstimatedTime": null,
+	"percentageDone": 0,
+	"createdAt": "2021-01-12T08:53:29Z",
+	"updatedAt": "2021-01-12T08:53:29Z",
+	"_links": {
+		"attachments": {
+			"href": "/api/v3/work_packages/13/attachments"
+		},
+		"addAttachment": {
+			"href": "/api/v3/work_packages/13/attachments",
+			"method": "post"
+		},
+		"self": {
+			"href": "/api/v3/work_packages/13",
+			"title": "Write a software"
+		},
+		"update": {
+			"href": "/api/v3/work_packages/13/form",
+			"method": "post"
+		},
+		"schema": {
+			"href": "/api/v3/work_packages/schemas/1-3"
+		},
+		"updateImmediately": {
+			"href": "/api/v3/work_packages/13",
+			"method": "patch"
+		},
+		"delete": {
+			"href": "/api/v3/work_packages/13",
+			"method": "delete"
+		},
+		"move": {
+			"href": "/work_packages/13/move/new",
+			"type": "text/html",
+			"title": "Move Write a software"
+		},
+		"copy": {
+			"href": "/work_packages/13/copy",
+			"title": "Copy Write a software"
+		},
+		"pdf": {
+			"href": "/work_packages/13.pdf",
+			"type": "application/pdf",
+			"title": "Export as PDF"
+		},
+		"atom": {
+			"href": "/work_packages/13.atom",
+			"type": "application/rss+xml",
+			"title": "Atom feed"
+		},
+		"availableRelationCandidates": {
+			"href": "/api/v3/work_packages/13/available_relation_candidates",
+			"title": "Potential work packages to relate to"
+		},
+		"customFields": {
+			"href": "/projects/demo-project/settings/custom_fields",
+			"type": "text/html",
+			"title": "Custom fields"
+		},
+		"configureForm": {
+			"href": "/types/3/edit?tab=form_configuration",
+			"type": "text/html",
+			"title": "Configure form"
+		},
+		"activities": {
+			"href": "/api/v3/work_packages/13/activities"
+		},
+		"availableWatchers": {
+			"href": "/api/v3/work_packages/13/available_watchers"
+		},
+		"relations": {
+			"href": "/api/v3/work_packages/13/relations"
+		},
+		"revisions": {
+			"href": "/api/v3/work_packages/13/revisions"
+		},
+		"watchers": {
+			"href": "/api/v3/work_packages/13/watchers"
+		},
+		"addWatcher": {
+			"href": "/api/v3/work_packages/13/watchers",
+			"method": "post",
+			"payload": {
+				"user": {
+					"href": "/api/v3/users/{user_id}"
+				}
+			},
+			"templated": true
+		},
+		"removeWatcher": {
+			"href": "/api/v3/work_packages/13/watchers/{user_id}",
+			"method": "delete",
+			"templated": true
+		},
+		"addRelation": {
+			"href": "/api/v3/work_packages/13/relations",
+			"method": "post",
+			"title": "Add relation"
+		},
+		"addChild": {
+			"href": "/api/v3/projects/demo-project/work_packages",
+			"method": "post",
+			"title": "Add child of Write a software"
+		},
+		"changeParent": {
+			"href": "/api/v3/work_packages/13",
+			"method": "patch",
+			"title": "Change parent of Write a software"
+		},
+		"addComment": {
+			"href": "/api/v3/work_packages/13/activities",
+			"method": "post",
+			"title": "Add comment"
+		},
+		"previewMarkup": {
+			"href": "/api/v3/render/markdown?context=/api/v3/work_packages/13",
+			"method": "post"
+		},
+		"category": {
+			"href": null
+		},
+		"type": {
+			"href": "/api/v3/types/3",
+			"title": "Phase"
+		},
+		"priority": {
+			"href": "/api/v3/priorities/8",
+			"title": "Normal"
+		},
+		"project": {
+			"href": "/api/v3/projects/1",
+			"title": "Demo project"
+		},
+		"status": {
+			"href": "/api/v3/statuses/7",
+			"title": "In progress"
+		},
+		"author": {
+			"href": "/api/v3/users/1"
+		},
+		"responsible": {
+			"href": null
+		},
+		"assignee": {
+			"href": "/api/v3/users/1",
+			"title": "System"
+		},
+		"version": {
+			"href": null
+		},
+		"github_pull_requests": {
+			"href": "/api/v3/work_packages/13/github_pull_requests",
+			"title": "GitHub pull requests"
+		},
+		"watch": {
+			"href": "/api/v3/work_packages/13/watchers",
+			"method": "post",
+			"payload": {
+				"user": {
+					"href": "/api/v3/users/3"
+				}
+			}
+		},
+		"ancestors": [],
+		"parent": {
+			"href": null,
+			"title": null
+		},
+		"customActions": []
+	}
+},
+	{
+		"fileId": 111,
+		"derivedStartDate": "2021-01-15",
+		"derivedDueDate": "2022-01-08",
+		"_type": "WorkPackage",
+		"id": 5,
+		"lockVersion": 0,
+		"subject": "Create a website",
+		"description": {
+			"format": "markdown",
+			"raw": null,
+			"html": ""
+		},
+		"scheduleManually": false,
+		"startDate": "2022-01-15",
+		"dueDate": "2022-03-26",
+		"estimatedTime": null,
+		"derivedEstimatedTime": null,
+		"percentageDone": 0,
+		"createdAt": "2021-01-12T08:53:29Z",
+		"updatedAt": "2021-01-12T08:53:29Z",
+		"_links": {
+			"attachments": {
+				"href": "/api/v3/work_packages/5/attachments"
+			},
+			"addAttachment": {
+				"href": "/api/v3/work_packages/5/attachments",
+				"method": "post"
+			},
+			"self": {
+				"href": "/api/v3/work_packages/5",
+				"title": "Create a website"
+			},
+			"update": {
+				"href": "/api/v3/work_packages/5/form",
+				"method": "post"
+			},
+			"schema": {
+				"href": "/api/v3/work_packages/schemas/1-3"
+			},
+			"updateImmediately": {
+				"href": "/api/v3/work_packages/5",
+				"method": "patch"
+			},
+			"delete": {
+				"href": "/api/v3/work_packages/5",
+				"method": "delete"
+			},
+			"move": {
+				"href": "/work_packages/5/move/new",
+				"type": "text/html",
+				"title": "Move Create a website"
+			},
+			"copy": {
+				"href": "/work_packages/5/copy",
+				"title": "Copy Create a website"
+			},
+			"pdf": {
+				"href": "/work_packages/5.pdf",
+				"type": "application/pdf",
+				"title": "Export as PDF"
+			},
+			"atom": {
+				"href": "/work_packages/5.atom",
+				"type": "application/rss+xml",
+				"title": "Atom feed"
+			},
+			"availableRelationCandidates": {
+				"href": "/api/v3/work_packages/5/available_relation_candidates",
+				"title": "Potential work packages to relate to"
+			},
+			"customFields": {
+				"href": "/projects/demo-project/settings/custom_fields",
+				"type": "text/html",
+				"title": "Custom fields"
+			},
+			"configureForm": {
+				"href": "/types/3/edit?tab=form_configuration",
+				"type": "text/html",
+				"title": "Configure form"
+			},
+			"activities": {
+				"href": "/api/v3/work_packages/5/activities"
+			},
+			"availableWatchers": {
+				"href": "/api/v3/work_packages/5/available_watchers"
+			},
+			"relations": {
+				"href": "/api/v3/work_packages/5/relations"
+			},
+			"revisions": {
+				"href": "/api/v3/work_packages/5/revisions"
+			},
+			"watchers": {
+				"href": "/api/v3/work_packages/5/watchers"
+			},
+			"addWatcher": {
+				"href": "/api/v3/work_packages/5/watchers",
+				"method": "post",
+				"payload": {
+					"user": {
+						"href": "/api/v3/users/{user_id}"
+					}
+				},
+				"templated": true
+			},
+			"removeWatcher": {
+				"href": "/api/v3/work_packages/5/watchers/{user_id}",
+				"method": "delete",
+				"templated": true
+			},
+			"addRelation": {
+				"href": "/api/v3/work_packages/5/relations",
+				"method": "post",
+				"title": "Add relation"
+			},
+			"addChild": {
+				"href": "/api/v3/projects/demo-project/work_packages",
+				"method": "post",
+				"title": "Add child of Create a website"
+			},
+			"changeParent": {
+				"href": "/api/v3/work_packages/5",
+				"method": "patch",
+				"title": "Change parent of Create a website"
+			},
+			"addComment": {
+				"href": "/api/v3/work_packages/5/activities",
+				"method": "post",
+				"title": "Add comment"
+			},
+			"previewMarkup": {
+				"href": "/api/v3/render/markdown?context=/api/v3/work_packages/5",
+				"method": "post"
+			},
+			"category": {
+				"href": null
+			},
+			"type": {
+				"href": "/api/v3/types/3",
+				"title": "Phase"
+			},
+			"priority": {
+				"href": "/api/v3/priorities/8",
+				"title": "Normal"
+			},
+			"project": {
+				"href": "/api/v3/projects/1",
+				"title": "Demo project"
+			},
+			"status": {
+				"href": "/api/v3/statuses/7",
+				"title": "In progress"
+			},
+			"author": {
+				"href": "/api/v3/users/1"
+			},
+			"responsible": {
+				"href": null
+			},
+			"assignee": {
+				"href": "/api/v3/users/1",
+				"title": "System"
+			},
+			"version": {
+				"href": null
+			},
+			"github_pull_requests": {
+				"href": "/api/v3/work_packages/5/github_pull_requests",
+				"title": "GitHub pull requests"
+			},
+			"watch": {
+				"href": "/api/v3/work_packages/5/watchers",
+				"method": "post",
+				"payload": {
+					"user": {
+						"href": "/api/v3/users/3"
+					}
+				}
+			},
+			"ancestors": [],
+			"parent": {
+				"href": null,
+				"title": null
+			},
+			"customActions": []
+		}
+	}
+]

--- a/tests/jest/fixtures/workPackagesSearchResponse.json
+++ b/tests/jest/fixtures/workPackagesSearchResponse.json
@@ -1,5 +1,6 @@
 [
     {
+        "fileId": 1234,
         "id" : "1",
         "subject" : "Organize work-packages",
         "project" : "test",

--- a/tests/jest/views/ProjectsTab.spec.js
+++ b/tests/jest/views/ProjectsTab.spec.js
@@ -306,6 +306,65 @@ describe('ProjectsTab.vue Test', () => {
 			expect(workPackages.exists()).toBeTruthy()
 			expect(workPackages).toMatchSnapshot()
 		})
+		it('adds every work-package only once', async () => {
+			// this can happen if multiple replies arrive at the same time
+			// when the user switches between files while results still loading
+			wrapper = mountWrapper()
+			const axiosGetSpy = jest.spyOn(axios, 'get')
+				.mockImplementationOnce(() => Promise.resolve({
+					status: 200,
+					data: [{
+						id: 123,
+						subject: 'my task',
+						_links: {
+							status: {
+								href: '/api/v3/statuses/12',
+								title: 'open',
+							},
+							type: {
+								href: '/api/v3/types/6',
+								title: 'Task',
+							},
+							assignee: {
+								href: '/api/v3/users/1',
+								title: 'Bal Bahadur Pun',
+							},
+							project: { title: 'a big project' },
+						},
+					},
+					{
+						id: 123,
+						subject: 'my task',
+						_links: {
+							status: {
+								href: '/api/v3/statuses/12',
+								title: 'open',
+							},
+							type: {
+								href: '/api/v3/types/6',
+								title: 'Task',
+							},
+							assignee: {
+								href: '/api/v3/users/1',
+								title: 'Bal Bahadur Pun',
+							},
+							project: { title: 'a big project' },
+						},
+					}],
+				}))
+				.mockImplementation(() => Promise.resolve({
+					status: 200,
+					data: [],
+				}))
+			await wrapper.vm.update({ id: 2222 })
+			expect(axiosGetSpy).toBeCalledWith(
+				'http://localhost/apps/integration_openproject/work-packages?fileId=2222',
+				{}
+			)
+			expect(wrapper.vm.state).toBe(STATE.OK)
+			const workPackages = wrapper.find(workPackagesSelector)
+			expect(workPackages).toMatchSnapshot()
+		})
 	})
 	describe('onSave', () => {
 		it('shows the just linked workpackage', async () => {

--- a/tests/jest/views/ProjectsTab.spec.js
+++ b/tests/jest/views/ProjectsTab.spec.js
@@ -310,6 +310,10 @@ describe('ProjectsTab.vue Test', () => {
 	describe('onSave', () => {
 		it('shows the just linked workpackage', async () => {
 			wrapper = mountWrapper()
+			await wrapper.setData({
+				fileInfo: { id: 1234 },
+			})
+			await localVue.nextTick()
 			await wrapper.vm.onSaved(workPackagesSearchResponse[0])
 			const workPackages = wrapper.find(workPackagesSelector)
 			expect(wrapper.find(existingRelationSelector).exists()).toBeTruthy()
@@ -328,6 +332,7 @@ describe('ProjectsTab.vue Test', () => {
 			wrapper = mountWrapper()
 			await wrapper.setData({
 				workpackages: workPackagesSearchResponse,
+				fileInfo: { id: 1234 },
 			})
 			await localVue.nextTick()
 			await wrapper.find(linkedWorkpackageSelector).trigger('click')
@@ -343,6 +348,7 @@ describe('ProjectsTab.vue Test', () => {
 			wrapper = mountWrapper()
 			await wrapper.setData({
 				workpackages: workPackagesSearchResponse,
+				fileInfo: { id: 1234 },
 			})
 			await localVue.nextTick()
 			await expect(wrapper.find(workPackageUnlinkSelector).exists()).toBeTruthy()

--- a/tests/jest/views/__snapshots__/ProjectsTab.spec.js.snap
+++ b/tests/jest/views/__snapshots__/ProjectsTab.spec.js.snap
@@ -7,7 +7,7 @@ exports[`ProjectsTab.vue Test fetchWorkpackages adds every work-package only onc
   </div>
   <div class="linked-workpackages">
     <div class="linked-workpackages--workpackage">
-      <div class="workpackage linked-workpackages--workpackage--item">
+      <div class="workpackage linked-workpackages--workpackage--item" id="workpackage-123">
         <div class="row">
           <div class="row__status">
             <div class="row__status__title">

--- a/tests/jest/views/__snapshots__/ProjectsTab.spec.js.snap
+++ b/tests/jest/views/__snapshots__/ProjectsTab.spec.js.snap
@@ -1,5 +1,48 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ProjectsTab.vue Test fetchWorkpackages adds every work-package only once 1`] = `
+<div class="" id="openproject-linked-workpackages">
+  <div class="existing-relations">
+    integration_openproject
+  </div>
+  <div class="linked-workpackages">
+    <div class="linked-workpackages--workpackage">
+      <div class="workpackage linked-workpackages--workpackage--item">
+        <div class="row">
+          <div class="row__status">
+            <div class="row__status__title">
+              open
+            </div>
+          </div>
+          <div class="row__workpackage">
+            #123 - a big project
+          </div>
+        </div>
+        <div class="row">
+          <div class="row__subject"><span class="row__subject__type">
+				Task
+			</span>
+            my task
+          </div>
+        </div>
+        <div class="row">
+          <div class="row__assignee">
+            <div class="row__assignee__avatar">
+              <avatar-stub size="23" url="http://localhost/apps/integration_openproject/avatar?userId=1&amp;userName=Bal Bahadur Pun" user="Bal Bahadur Pun" display-name="Bal Bahadur Pun" class="item-avatar"></avatar-stub>
+            </div>
+            <div class="row__assignee__assignee">
+              Bal Bahadur Pun
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="linked-workpackages--workpackage--unlink icon-noConnection"></div>
+    </div>
+    <div class=""></div>
+  </div>
+</div>
+`;
+
 exports[`ProjectsTab.vue Test fetchWorkpackages sets the "connection-error" state if the request url is not valid 1`] = `
 <div class="projects">
   <!---->


### PR DESCRIPTION
switching between files while the list is still loading might add data from an other file to the current view, see https://community.openproject.org/projects/nextcloud-integration/work_packages/41503

To protect from that this PR:
1. checks is a WP already exists in the list (by comparing the fileId and the WPid)
2. filters the workpackages to show by the fileId of the file currently in view

manual test-cases
| test | expected outcome  | result |
| --- | --- | --- |
| 1. link file1 to WP-A, WP-B, WP-C 2. link file2 to WP-D, WP-E 3. quickly switch between the files | WP list is correct, no extra WP listed | :heavy_check_mark: |
| 1. link file1 to WP-A, WP-B, WP-C 2. link file2 to WP-C, WP-D 3. quickly switch between the files | WP list is correct, no extra WP listed, WP-C is shown in both files | :heavy_check_mark: |
| 1. link file1 to WP-A, WP-B, WP-C 2. don't link file2 to any WP 3. quickly switch between the files, ending on file2 | WP list is empty, no links message shown | :heavy_check_mark: |
| 1. link file1 to WP-A, WP-B, WP-C 2. link file2 to WP-D, WP-E 3. quickly switch between the files | WP order is the same as in the case when the user would have waited for the complete loading  | :x: |

ToDo:
- [ ] ~~hardening existing unit tests (e.g. without `workPackage.fileId = this.fileInfo.id` in `processWorkPackages` adding WP would not work, but no test failed)~~ integration or better e2e tests needed for that
- [ ] ~~write tests for the cases above~~ I couldn't achieve it, maybe a case for manual testing
- [ ] discuss if we do some "local" sorting for the last case

@kiranparajuli589 @SwikritiT @eneiluj putting this to draft for now, but happy to hear your input