### PR TITLE
OP#42140 only addd to searchlist when in loading state

### DIFF
--- a/src/components/tab/SearchInput.vue
+++ b/src/components/tab/SearchInput.vue
@@ -165,11 +165,14 @@ export default {
 		async processWorkPackages(workPackages) {
 			for (let workPackage of workPackages) {
 				try {
-					workPackage = await workpackageHelper.getAdditionalMetaData(workPackage)
-					const alreadyLinked = this.linkedWorkPackages.some(el => el.id === workPackage.id)
-					const alreadyInSearchResults = this.searchResults.some(el => el.id === workPackage.id)
-					if (!alreadyInSearchResults && !alreadyLinked) {
-						this.searchResults.push(workPackage)
+					if (this.isStateLoading) {
+						workPackage = await workpackageHelper.getAdditionalMetaData(workPackage)
+						const alreadyLinked = this.linkedWorkPackages.some(el => el.id === workPackage.id)
+						const alreadyInSearchResults = this.searchResults.some(el => el.id === workPackage.id)
+						// check the state again, it might have changed in between
+						if (!alreadyInSearchResults && !alreadyLinked && this.isStateLoading) {
+							this.searchResults.push(workPackage)
+						}
 					}
 				} catch (e) {
 					console.error('could not process workpackage data')

--- a/tests/jest/components/tab/SearchInput.spec.js
+++ b/tests/jest/components/tab/SearchInput.spec.js
@@ -334,6 +334,32 @@ describe('SearchInput.vue tests', () => {
 				)
 				axiosSpy.mockRestore()
 			})
+			it.each(
+				[STATE.NO_TOKEN, STATE.ERROR, STATE.OK]
+			)(
+				'should only add work packages to the list in loading state',
+				async (state) => {
+					wrapper = mountSearchInput({})
+					const axiosSpy = jest.spyOn(axios, 'get')
+						.mockImplementationOnce(() => Promise.resolve({
+							status: 200,
+							data: workPackageSearchReqResponse,
+						}))
+					// any other requests e.g. for types and statuses
+						.mockImplementation(() => Promise.resolve(
+							{ status: 200, data: [] })
+						)
+
+					const inputField = wrapper.find(inputSelector)
+					await inputField.setValue('anything longer than 3 char')
+					await wrapper.setData({ state })
+					for (let i = 0; i < 9; i++) {
+						await localVue.nextTick()
+					}
+
+					expect(wrapper.vm.searchResults).toMatchObject([])
+					axiosSpy.mockRestore()
+				})
 		})
 
 		describe('loading icon', () => {


### PR DESCRIPTION
fixes https://community.openproject.org/projects/nextcloud-integration/work_packages/42140

when a link gets created the state switches from `loading` to `ok` and the list of workpackages in the search gets cleaned, but if some requests were outstanding workpackages would be kept on added to the list and it would not be cleaned correctly.

This PR makes sure workpackages are not processed and the searchlist is not extended while the state is anything else than `loading`