### PR TITLE
Do not show search input unless the projects tab is completely loaded

### DIFF
--- a/src/views/ProjectsTab.vue
+++ b/src/views/ProjectsTab.vue
@@ -22,7 +22,7 @@
 
 <template>
 	<div class="projects">
-		<SearchInput v-if="!!requestUrl"
+		<SearchInput v-if="!!requestUrl && !isLoading"
 			:file-info="fileInfo"
 			:linked-work-packages="workpackages"
 			@saved="onSaved" />
@@ -73,7 +73,7 @@ export default {
 	data: () => ({
 		error: '',
 		fileInfo: {},
-		state: 'loading',
+		state: STATE.LOADING,
 		workpackages: [],
 		requestUrl: loadState('integration_openproject', 'request-url'),
 		color: null,

--- a/tests/jest/views/ProjectsTab.spec.js
+++ b/tests/jest/views/ProjectsTab.spec.js
@@ -45,9 +45,18 @@ describe('ProjectsTab.vue Test', () => {
 			})
 			expect(wrapper.find(searchInputStubSelector).exists()).toBeFalsy()
 		})
-		it('should exist if the request url is valid', async () => {
+		it('should not exist if the wrapper is in "loading" state', async () => {
+			await wrapper.setData({
+				requestUrl: true,
+				state: STATE.LOADING,
+			})
+			expect(wrapper.find(searchInputStubSelector).exists()).toBeFalsy()
+		})
+		it('should exist if the request url is valid and wrapper is not "loading"', async () => {
 			await wrapper.setData({
 				requestUrl: 'https://open.project/',
+				state: STATE.OK,
+
 			})
 			expect(wrapper.find(searchInputStubSelector).exists()).toBeTruthy()
 		})


### PR DESCRIPTION
### Description
We check for the request-url, before showing the search input the users. If it is not valid, it is kept hidden, but if the url is valid, the input is shown early even if the projects tab is still loading fetching for the linked work packages.

With this PR, the search input is shown only if the the request URL is valid and the projects tab state is not loading.

### Related
https://community.openproject.org/projects/nextcloud-integration/work_packages/41496

Signed-off-by: Kiran Parajuli <kiranparajuli589@gmail.com>