### PR TITLE
fix php tests

### DIFF
--- a/tests/lib/Controller/ConfigControllerTest.php
+++ b/tests/lib/Controller/ConfigControllerTest.php
@@ -334,8 +334,9 @@ class ConfigControllerTest extends TestCase {
 		$count = 0;
 		$function = function (IUser $user) use (&$count) {
 			$count++;
+			return null;
 		};
-		$userManager->callForAllUsers($function, '', true);
+		$userManager->callForAllUsers($function);
 		$this->assertSame(1, $count, 'Expected to have only 1 user in the dB before this test');
 		$user1 = $userManager->createUser('test101', 'test101');
 		$configMock = $this->getMockBuilder(IConfig::class)->getMock();

--- a/tests/lib/Service/OpenProjectAPIServiceCheckNotificationsTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceCheckNotificationsTest.php
@@ -79,11 +79,15 @@ class OpenProjectAPIServiceCheckNotificationsTest extends TestCase {
 				[$this->anything(), 'integration_openproject', 'token'],
 				[$this->anything(), 'integration_openproject', 'notification_enabled'],
 				[$this->anything(), 'integration_openproject', 'last_notification_check'],
+				[$this->anything(), 'integration_openproject', 'token'],
+				[$this->anything(), 'integration_openproject', 'refresh_token'],
 			)
 			->willReturnOnConsecutiveCalls(
 				'123456',
 				'1',
-				$lastNotificationCheck
+				$lastNotificationCheck,
+				'123456',
+				'refresh-token',
 			);
 
 		$configMock


### PR DESCRIPTION
1. phpstan tests started to fail with PHP 8, complaining about missing return of `callForAllUsers` callback
2. more mocks needed for the notification tests, that must have happened with merging multiple PRs where each would pass CI by itself but together not