### PR TITLE
[OP#42614] check if an OpenProject server replies on the URL given in the admin settings

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -23,6 +23,7 @@ return [
 		['name' => 'openProjectAPI#getOpenProjectWorkPackageStatus', 'url' => '/statuses/{id}', 'verb' => 'GET'],
 		['name' => 'openProjectAPI#getOpenProjectWorkPackageType', 'url' => '/types/{id}', 'verb' => 'GET'],
 		['name' => 'openProjectAPI#deleteFileLink', 'url' => '/file-links/{id}', 'verb' => 'DELETE'],
+		['name' => 'openProjectAPI#isValidOpenProjectInstance', 'url' => '/is-valid-op-instance', 'verb' => 'POST'],
 	],
 	'ocs' => [
 		['name' => 'files#getFileInfo', 'url' => '/fileinfo/{fileId}', 'verb' => 'GET'],

--- a/lib/Controller/OpenProjectAPIController.php
+++ b/lib/Controller/OpenProjectAPIController.php
@@ -283,6 +283,9 @@ class OpenProjectAPIController extends Controller {
 	 * @return DataResponse
 	 */
 	public function isValidOpenProjectInstance(string $url): DataResponse {
+		if ($this->openprojectAPIService::validateURL($url) !== true) {
+			return new DataResponse(false);
+		}
 		try {
 			$response = $this->openprojectAPIService->rawRequest('', $url, '');
 			$body = (string) $response->getBody();

--- a/lib/Controller/OpenProjectAPIController.php
+++ b/lib/Controller/OpenProjectAPIController.php
@@ -98,7 +98,7 @@ class OpenProjectAPIController extends Controller {
 	 * @return DataResponse
 	 */
 	public function getNotifications(): DataResponse {
-		if ($this->accessToken === '' || !OpenProjectAPIService::validateOpenProjectURL($this->openprojectUrl)) {
+		if ($this->accessToken === '' || !OpenProjectAPIService::validateURL($this->openprojectUrl)) {
 			return new DataResponse('', Http::STATUS_BAD_REQUEST);
 		}
 		$result = $this->openprojectAPIService->getNotifications($this->userId);
@@ -121,7 +121,7 @@ class OpenProjectAPIController extends Controller {
 	 * @return DataResponse
 	 */
 	public function getSearchedWorkPackages(?string $searchQuery = null, ?int $fileId = null): DataResponse {
-		if ($this->accessToken === '' || !OpenProjectAPIService::validateOpenProjectURL($this->openprojectUrl)) {
+		if ($this->accessToken === '' || !OpenProjectAPIService::validateURL($this->openprojectUrl)) {
 			return new DataResponse(
 				'invalid open project configuration', Http::STATUS_UNAUTHORIZED
 			);
@@ -153,7 +153,7 @@ class OpenProjectAPIController extends Controller {
 	 * @return DataResponse
 	 */
 	public function linkWorkPackageToFile(int $workpackageId, int $fileId, string $fileName) {
-		if ($this->accessToken === '' || !OpenProjectAPIService::validateOpenProjectURL($this->openprojectUrl)) {
+		if ($this->accessToken === '' || !OpenProjectAPIService::validateURL($this->openprojectUrl)) {
 			return new DataResponse('', Http::STATUS_BAD_REQUEST);
 		}
 
@@ -180,7 +180,7 @@ class OpenProjectAPIController extends Controller {
 	 * @return DataResponse
 	 */
 	public function getWorkPackageFileLinks(int $id): DataResponse {
-		if ($this->accessToken === '' || !OpenProjectAPIService::validateOpenProjectURL($this->openprojectUrl)) {
+		if ($this->accessToken === '' || !OpenProjectAPIService::validateURL($this->openprojectUrl)) {
 			return new DataResponse('', Http::STATUS_BAD_REQUEST);
 		}
 
@@ -205,7 +205,7 @@ class OpenProjectAPIController extends Controller {
 	 * @return DataResponse
 	 */
 	public function deleteFileLink(int $id): DataResponse {
-		if ($this->accessToken === '' || !OpenProjectAPIService::validateOpenProjectURL($this->openprojectUrl)) {
+		if ($this->accessToken === '' || !OpenProjectAPIService::validateURL($this->openprojectUrl)) {
 			return new DataResponse('', Http::STATUS_BAD_REQUEST);
 		}
 
@@ -234,7 +234,7 @@ class OpenProjectAPIController extends Controller {
 	 * @return DataResponse
 	 */
 	public function getOpenProjectWorkPackageStatus(string $id): DataResponse {
-		if ($this->accessToken === '' || !OpenProjectAPIService::validateOpenProjectURL($this->openprojectUrl)) {
+		if ($this->accessToken === '' || !OpenProjectAPIService::validateURL($this->openprojectUrl)) {
 			return new DataResponse('', Http::STATUS_BAD_REQUEST);
 		}
 		$result = $this->openprojectAPIService->getOpenProjectWorkPackageStatus(
@@ -258,7 +258,7 @@ class OpenProjectAPIController extends Controller {
 	 * @return DataResponse
 	 */
 	public function getOpenProjectWorkPackageType(string $id): DataResponse {
-		if ($this->accessToken === '' || !OpenProjectAPIService::validateOpenProjectURL($this->openprojectUrl)) {
+		if ($this->accessToken === '' || !OpenProjectAPIService::validateURL($this->openprojectUrl)) {
 			return new DataResponse('', Http::STATUS_BAD_REQUEST);
 		}
 		$result = $this->openprojectAPIService->getOpenProjectWorkPackageType(

--- a/lib/Controller/OpenProjectAPIController.php
+++ b/lib/Controller/OpenProjectAPIController.php
@@ -293,7 +293,7 @@ class OpenProjectAPIController extends Controller {
 			if (
 				$decodedBody &&
 				isset($decodedBody['_type']) &&
-				isset ($decodedBody['instanceName']) &&
+				isset($decodedBody['instanceName']) &&
 				$decodedBody['_type'] === 'Root' &&
 				$decodedBody['instanceName'] !== ''
 			) {
@@ -306,7 +306,7 @@ class OpenProjectAPIController extends Controller {
 			if (
 				$decodedBody &&
 				isset($decodedBody['_type']) &&
-				isset ($decodedBody['errorIdentifier']) &&
+				isset($decodedBody['errorIdentifier']) &&
 				$decodedBody['_type'] === 'Error' &&
 				$decodedBody['errorIdentifier'] !== ''
 			) {
@@ -316,6 +316,5 @@ class OpenProjectAPIController extends Controller {
 			return new DataResponse(false);
 		}
 		return new DataResponse(false);
-
 	}
 }

--- a/lib/Controller/OpenProjectAPIController.php
+++ b/lib/Controller/OpenProjectAPIController.php
@@ -277,7 +277,6 @@ class OpenProjectAPIController extends Controller {
 	 * check if there is a OpenProject behind a certain URL
 	 *
 	 * @NoAdminRequired
-	 * @NoCSRFRequired
 	 *
 	 * @param string $url
 	 *

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -345,7 +345,7 @@ class OpenProjectAPIService {
 	 * @param string $method
 	 * @return array{error: string} | IResponse
 	 */
-	private function rawRequest(string $accessToken, string $openprojectUrl,
+	public function rawRequest(string $accessToken, string $openprojectUrl,
 							   string $endPoint, array $params = [], string $method = 'GET') {
 		$url = $openprojectUrl . '/api/v3/' . $endPoint;
 		$options = [

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -408,7 +408,7 @@ class OpenProjectAPIService {
 		$clientID = $this->config->getAppValue(Application::APP_ID, 'client_id');
 		$clientSecret = $this->config->getAppValue(Application::APP_ID, 'client_secret');
 		$openprojectUrl = $this->config->getAppValue(Application::APP_ID, 'oauth_instance_url');
-		if (!$openprojectUrl || !OpenProjectAPIService::validateOpenProjectURL($openprojectUrl)) {
+		if (!$openprojectUrl || !OpenProjectAPIService::validateURL($openprojectUrl)) {
 			return ['error' => 'OpenProject URL is invalid', 'statusCode' => 500];
 		}
 		try {
@@ -519,9 +519,9 @@ class OpenProjectAPIService {
 		}
 	}
 
-	public static function validateOpenProjectURL(string $openprojectUrl): bool {
-		return filter_var($openprojectUrl, FILTER_VALIDATE_URL) &&
-			preg_match('/^https?/', $openprojectUrl);
+	public static function validateURL(string $url): bool {
+		return filter_var($url, FILTER_VALIDATE_URL) &&
+			preg_match('/^https?/', $url);
 	}
 
 	/**
@@ -723,7 +723,7 @@ class OpenProjectAPIService {
 		if (!$checkIfConfigIsSet) {
 			return false;
 		} else {
-			return self::validateOpenProjectURL($oauthInstanceUrl);
+			return self::validateURL($oauthInstanceUrl);
 		}
 	}
 

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -38,11 +38,13 @@
 				:placeholder="t('integration_openproject', 'Client secret of the OAuth app in OpenProject')"
 				@focus="readonly = false">
 		</div>
-		<button v-if="!isAdminConfigOk" class="save-config-btn" @click="saveOptions">
+		<button v-if="!isAdminConfigOk" class="save-config-btn" @click="validateOpenProjectInstance">
 			Save
+			<div v-if="isLoading" class="icon-loading" />
 		</button>
-		<button v-else class="update-config-btn" @click="updateForm">
+		<button v-else class="update-config-btn" @click="validateOpenProjectInstance">
 			Update
+			<div v-if="isLoading" class="icon-loading" />
 		</button>
 	</div>
 </template>
@@ -55,6 +57,7 @@ import { showSuccess, showError } from '@nextcloud/dialogs'
 import '@nextcloud/dialogs/styles/toast.scss'
 import SettingsTitle from '../components/settings/SettingsTitle'
 import { translate as t } from '@nextcloud/l10n'
+import { STATE } from '../utils'
 
 export default {
 	name: 'AdminSettings',
@@ -70,11 +73,16 @@ export default {
 			readonly: true,
 			isAdminConfigOk: loadState('integration_openproject', 'admin-config-status'),
 			redirect_uri: window.location.protocol + '//' + window.location.host + generateUrl('/apps/integration_openproject/oauth-redirect'),
+			loadingState: STATE.OK,
 		}
+	},
+	computed: {
+		isLoading() {
+			return this.loadingState === STATE.LOADING
+		},
 	},
 	methods: {
 		updateForm() {
-			this.validateOpenProjectInstance()
 			const that = this
 			OC.dialogs.confirmDestructive(
 				t(
@@ -98,7 +106,6 @@ export default {
 			)
 		},
 		async saveOptions() {
-			this.validateOpenProjectInstance()
 			const req = {
 				values: {
 					client_id: this.state.client_id,
@@ -120,14 +127,22 @@ export default {
 			}
 		},
 		async validateOpenProjectInstance() {
+			this.loadingState = STATE.LOADING
 			const url = generateUrl('/apps/integration_openproject/is-valid-op-instance')
 			const response = await axios.post(url, { url: this.state.oauth_instance_url })
 			if (response.data !== true) {
 				showError(
 					t('integration_openproject', 'No OpenProject detected at the URL')
 				)
-				throw Error()
+				this.loadingState = STATE.OK
+				return
 			}
+			if (this.isAdminConfigOk) {
+				this.updateForm()
+			} else {
+				await this.saveOptions()
+			}
+			this.loadingState = STATE.OK
 		},
 	},
 }
@@ -169,4 +184,13 @@ body.theme--dark, body[data-theme-dark], body[data-theme-dark-highcontrast] {
 	}
 }
 
+.icon-loading {
+	min-height: 0;
+}
+
+.icon-loading:after {
+	height: 14px;
+	width: 14px;
+	top: 0;
+}
 </style>

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -74,6 +74,7 @@ export default {
 	},
 	methods: {
 		updateForm() {
+			this.validateOpenProjectInstance()
 			const that = this
 			OC.dialogs.confirmDestructive(
 				t(
@@ -97,6 +98,7 @@ export default {
 			)
 		},
 		async saveOptions() {
+			this.validateOpenProjectInstance()
 			const req = {
 				values: {
 					client_id: this.state.client_id,
@@ -115,6 +117,16 @@ export default {
 				showError(
 					t('integration_openproject', 'Failed to save OpenProject admin options')
 				)
+			}
+		},
+		async validateOpenProjectInstance() {
+			const url = generateUrl('/apps/integration_openproject/is-valid-op-instance')
+			const response = await axios.post(url, { url: this.state.oauth_instance_url })
+			if (response.data !== true) {
+				showError(
+					t('integration_openproject', 'No OpenProject detected at the URL')
+				)
+				throw Error()
 			}
 		},
 	},

--- a/tests/jest/components/AdminSettings.spec.js
+++ b/tests/jest/components/AdminSettings.spec.js
@@ -98,6 +98,9 @@ describe('AdminSettings', () => {
 				expect(wrapper.find(selectors.saveConfigButton).exists()).toBeFalsy()
 			})
 			it('should trigger confirm dialog on update', async () => {
+				axios.post.mockImplementationOnce(() =>
+					Promise.resolve({ data: true }),
+				)
 				const updateConfigButton = wrapper.find(selectors.updateConfigButton)
 				const inputField = wrapper.find(selectors.oauthClientId)
 				await inputField.setValue('test')

--- a/tests/jest/components/AdminSettings.spec.js
+++ b/tests/jest/components/AdminSettings.spec.js
@@ -4,6 +4,8 @@ import axios from '@nextcloud/axios'
 import { createLocalVue, shallowMount } from '@vue/test-utils'
 import AdminSettings from '../../../src/components/AdminSettings'
 import * as initialState from '@nextcloud/initial-state'
+import { STATE } from '../../../src/utils'
+import * as dialogs from '@nextcloud/dialogs'
 
 jest.mock('@nextcloud/axios')
 jest.mock('@nextcloud/l10n', () => ({
@@ -151,6 +153,92 @@ describe('AdminSettings', () => {
 				await wrapper.vm.saveOptions()
 				expect(axiosSpy).toHaveBeenCalledTimes(1)
 				expect(wrapper.vm.isAdminConfigOk).toBe(finalComponentStatus)
+			})
+		})
+		describe('check whether OpenProject instance address is valid', () => {
+			let axiosSpySaveAdminConfig
+			beforeEach(() => {
+				axiosSpySaveAdminConfig = jest.spyOn(axios, 'put')
+					.mockImplementation(() => Promise.resolve({
+						data: {},
+					}))
+			})
+			it('should show the loading indicator while loading for the update button', () => {
+				const wrapper = getWrapper({
+					loadingState: STATE.LOADING,
+					isAdminConfigOk: true,
+				})
+				expect(wrapper.find(selectors.updateConfigButton)).toMatchSnapshot()
+			})
+			it('should show the loading indicator while loading for the save button', () => {
+				const wrapper = getWrapper({
+					loadingState: STATE.LOADING,
+					isAdminConfigOk: false,
+				})
+				expect(wrapper.find(selectors.saveConfigButton)).toMatchSnapshot()
+			})
+
+			describe.each([
+				['incomplete config', selectors.saveConfigButton, false],
+				['complete config', selectors.updateConfigButton, true],
+			])('invalid OpenProject instance with %s',
+				(name, buttonSelector, isAdminConfigOk) => {
+					let axiosSpyIsValidOPInstance
+					let saveConfigButton
+					beforeEach(async () => {
+						axiosSpyIsValidOPInstance = jest.spyOn(axios, 'post')
+							.mockImplementationOnce(() => Promise.resolve({ data: false }))
+
+						const wrapper = getWrapper({
+							isAdminConfigOk,
+						})
+						saveConfigButton = wrapper.find(buttonSelector)
+						const inputField = wrapper.find(selectors.oauthInstance)
+						await inputField.setValue('http://no-openproject-here.org')
+
+					})
+					it('should not save the config', async function() {
+						await saveConfigButton.trigger('click')
+						expect(axiosSpyIsValidOPInstance).toHaveBeenCalledTimes(1)
+						expect(axiosSpySaveAdminConfig).toHaveBeenCalledTimes(0)
+					})
+					it('should show an error message', async () => {
+						const showErrorSpy = jest.spyOn(dialogs, 'showError')
+						await saveConfigButton.trigger('click')
+						await localVue.nextTick()
+						expect(showErrorSpy).toBeCalledTimes(1)
+						showErrorSpy.mockRestore()
+					})
+				})
+			describe('valid OpenProject instance', () => {
+				let axiosSpyIsValidOPInstance
+				beforeEach(() => {
+					axiosSpyIsValidOPInstance = jest.spyOn(axios, 'post')
+						.mockImplementationOnce(() => Promise.resolve({ data: true }))
+				})
+				it('should save the config in case it was incomplete before', async function() {
+					const wrapper = getWrapper({
+						isAdminConfigOk: false,
+					})
+					const saveConfigButton = wrapper.find(selectors.saveConfigButton)
+					const inputField = wrapper.find(selectors.oauthInstance)
+					await inputField.setValue('http://openproject.org')
+					await saveConfigButton.trigger('click')
+					expect(axiosSpyIsValidOPInstance).toHaveBeenCalledTimes(1)
+					expect(axiosSpySaveAdminConfig).toHaveBeenCalledTimes(1)
+				})
+				it('should show the confirmation dialog in case the config was complete before', async () => {
+					const confirmSpy = jest.spyOn(global.OC.dialogs, 'confirmDestructive')
+					const wrapper = getWrapper({
+						isAdminConfigOk: true,
+					})
+					const updateConfigButton = wrapper.find(selectors.updateConfigButton)
+					const inputField = wrapper.find(selectors.oauthInstance)
+					await inputField.setValue('http://openproject.org')
+					await updateConfigButton.trigger('click')
+					expect(axiosSpyIsValidOPInstance).toHaveBeenCalledTimes(1)
+					expect(confirmSpy).toBeCalledTimes(1)
+				})
 			})
 		})
 	})

--- a/tests/jest/components/__snapshots__/AdminSettings.spec.js.snap
+++ b/tests/jest/components/__snapshots__/AdminSettings.spec.js.snap
@@ -1,13 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`AdminSettings form submit check whether OpenProject instance address is valid should show the loading indicator while loading for the save button 1`] = `
+<button class="save-config-btn">
+  Save
+  <div class="icon-loading"></div>
+</button>
+`;
+
+exports[`AdminSettings form submit check whether OpenProject instance address is valid should show the loading indicator while loading for the update button 1`] = `
+<button class="update-config-btn">
+  Update
+  <div class="icon-loading"></div>
+</button>
+`;
+
 exports[`AdminSettings form submit when the admin config is not complete should show the save button 1`] = `
 <button class="save-config-btn">
   Save
+  <!---->
 </button>
 `;
 
 exports[`AdminSettings form submit when the admin config status is complete should show the update button 1`] = `
 <button class="update-config-btn">
   Update
+  <!---->
 </button>
 `;

--- a/tests/lib/Controller/OpenProjectAPIControllerTest.php
+++ b/tests/lib/Controller/OpenProjectAPIControllerTest.php
@@ -517,6 +517,9 @@ class OpenProjectAPIControllerTest extends TestCase {
 		$this->assertSame('something went wrong', $response->getData());
 	}
 
+	/**
+	 * @return array<mixed>
+	 */
 	public function isValidOpenProjectInstanceDataProvider() {
 		return [
 			['{"_type":"Root","instanceName":"OpenProject"}', true],
@@ -551,7 +554,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 
 
 	/**
-	 * @return array<Exception, bool>
+	 * @return array<mixed>
 	 */
 	public function isValidOpenProjectInstanceExpectionDataProvider() {
 		$requestMock = $this->getMockBuilder('\Psr\Http\Message\RequestInterface')->getMock();

--- a/tests/lib/Controller/OpenProjectAPIControllerTest.php
+++ b/tests/lib/Controller/OpenProjectAPIControllerTest.php
@@ -628,6 +628,9 @@ class OpenProjectAPIControllerTest extends TestCase {
 		$this->assertSame($expectedResult, $result->getData());
 	}
 
+	/**
+	 * @return array<int, array<int, string>>
+	 */
 	public function isValidOpenProjectInstanceInvalidUrlDataProvider() {
 		return [
 			[ '123' ],
@@ -637,7 +640,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 		];
 	}
 	/**
-	 * @param $url
 	 * @dataProvider isValidOpenProjectInstanceInvalidUrlDataProvider
 	 * @return void
 	 */

--- a/tests/lib/Controller/OpenProjectAPIControllerTest.php
+++ b/tests/lib/Controller/OpenProjectAPIControllerTest.php
@@ -611,7 +611,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 	 * @param bool $expectedResult
 	 * @return void
 	 */
-	public function testIsValidOpenProjectInstancePrivateInstance(
+	public function testIsValidOpenProjectInstanceException(
 		$thrownException, bool $expectedResult
 	): void {
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
@@ -626,5 +626,30 @@ class OpenProjectAPIControllerTest extends TestCase {
 		);
 		$result = $controller->isValidOpenProjectInstance('http://openproject.org');
 		$this->assertSame($expectedResult, $result->getData());
+	}
+
+	public function isValidOpenProjectInstanceInvalidUrlDataProvider() {
+		return [
+			[ '123' ],
+			[ 'htt://something' ],
+			[ '' ],
+			[ 'ftp://something.org ']
+		];
+	}
+	/**
+	 * @param $url
+	 * @dataProvider isValidOpenProjectInstanceInvalidUrlDataProvider
+	 * @return void
+	 */
+	public function testIsValidOpenProjectInstanceInvalidUrl(string $url): void {
+		$service = $this->getMockBuilder(OpenProjectAPIService::class)
+			->disableOriginalConstructor()
+			->onlyMethods([])
+			->getMock();
+		$controller = new OpenProjectAPIController(
+			'integration_openproject', $this->requestMock, $this->configMock, $service, 'test'
+		);
+		$result = $controller->isValidOpenProjectInstance($url);
+		$this->assertFalse($result->getData());
 	}
 }

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -305,7 +305,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 	 * @return void
 	 */
 	public function testValidateOpenProjectURL(string $url, bool $expected) {
-		$result = OpenProjectAPIService::validateOpenProjectURL($url);
+		$result = OpenProjectAPIService::validateURL($url);
 		$this->assertSame($expected, $result);
 	}
 


### PR DESCRIPTION
before accepting an OpenProject instance URL, check if there is an OpenProject server actually listening on that URL

checks are done similar to https://github.com/opf/openproject-revit-add-in/blob/master/src/OpenProject.Browser/WebViewIntegration/OpenProjectInstanceValidator.cs#L19 
- `_type` must `Root` or `Error`
- in case of `Root` (public instance) -> `instanceName` has to be set
- in case of `Error` (private instance) -> `errorIdentifier` has to be set

fixes https://community.openproject.org/projects/nextcloud-integration/work_packages/42614