### PR TITLE
Replace the unlink button to actions component

### DIFF
--- a/src/views/ProjectsTab.vue
+++ b/src/views/ProjectsTab.vue
@@ -39,8 +39,13 @@
 						:workpackage="workpackage"
 						class="linked-workpackages--workpackage--item"
 						@click.native="routeToTheWorkPackage(workpackage.id, workpackage.projectId)" />
-					<div class="linked-workpackages--workpackage--unlink icon-noConnection"
-						@click="unlink(workpackage.id, fileInfo.id)" />
+					<Actions>
+						<ActionButton class="linked-workpackages--workpackage--unlinkactionbutton"
+							icon="icon-noConnection"
+							@click="unlink(workpackage.id, fileInfo.id)">
+							Unlink WorkPackage
+						</ActionButton>
+					</Actions>
 				</div>
 				<div :class="{ 'workpackage-seperator': index !== filterWorkpackagesByFileId.length-1 }" />
 			</div>
@@ -55,6 +60,8 @@
 <script>
 import EmptyContent from '../components/tab/EmptyContent'
 import WorkPackage from '../components/tab/WorkPackage'
+import Actions from '@nextcloud/vue/dist/Components/Actions'
+import ActionButton from '@nextcloud/vue/dist/Components/ActionButton'
 import axios from '@nextcloud/axios'
 import { generateUrl } from '@nextcloud/router'
 import { showSuccess, showError } from '@nextcloud/dialogs'
@@ -70,6 +77,8 @@ export default {
 		EmptyContent,
 		SearchInput,
 		WorkPackage,
+		Actions,
+		ActionButton,
 	},
 	data: () => ({
 		error: '',
@@ -290,13 +299,8 @@ export default {
 		&--item {
 			border: none;
 		}
-		&--unlink {
-			position: absolute;
-			top: 12px;
-			right: 14px;
-			height: 15px;
-			width: 18px;
-			align-items: center;
+		&--unlinkactionbutton {
+			margin: 4px;
 			filter: contrast(0) brightness(0);
 			visibility: hidden;
 		}
@@ -306,7 +310,7 @@ export default {
 		background-color: var(--color-background-dark);
 	}
 
-	.linked-workpackages:hover .linked-workpackages--workpackage--unlink {
+	.linked-workpackages:hover .linked-workpackages--workpackage--unlinkactionbutton {
 		visibility: visible;
 		cursor: pointer;
 	}
@@ -334,7 +338,7 @@ export default {
 }
 
 body.theme--dark, body[data-theme-dark], body[data-theme-dark-highcontrast] {
-	.linked-workpackages--workpackage--unlink {
+	.linked-workpackages--workpackage--unlinkactionbutton {
 		filter: invert(100%);
 	}
 }

--- a/tests/jest/views/ProjectsTab.spec.js
+++ b/tests/jest/views/ProjectsTab.spec.js
@@ -31,7 +31,7 @@ describe('ProjectsTab.vue Test', () => {
 	const existingRelationSelector = '.existing-relations'
 	const searchInputStubSelector = 'searchinput-stub'
 	const linkedWorkpackageSelector = '.workpackage'
-	const workPackageUnlinkSelector = '.linked-workpackages--workpackage--unlink'
+	const workPackageUnlinkSelector = '.linked-workpackages--workpackage--unlinkactionbutton'
 
 	beforeEach(() => {
 		// eslint-disable-next-line no-import-assign

--- a/tests/jest/views/__snapshots__/ProjectsTab.spec.js.snap
+++ b/tests/jest/views/__snapshots__/ProjectsTab.spec.js.snap
@@ -35,8 +35,10 @@ exports[`ProjectsTab.vue Test fetchWorkpackages adds every work-package only onc
             </div>
           </div>
         </div>
-      </div>
-      <div class="linked-workpackages--workpackage--unlink icon-noConnection"></div>
+      </div> <button data-v-68f2cb4a="" rel="noreferrer noopener" class="action-item action-item--single icon-noConnection linked-workpackages--workpackage--unlinkactionbutton undefined has-tooltip" aria-label="" icon="icon-noConnection" data-original-title="">
+        <!----> <span data-v-68f2cb4a="" aria-hidden="true" hidden="hidden"><li data-v-71ea20d2="" class="action linked-workpackages--workpackage--unlinkactionbutton" data-v-68f2cb4a=""><button data-v-71ea20d2="" aria-label="" type="button" class="action-button focusable"><span data-v-71ea20d2="" class="action-button__icon icon-noConnection"></span> <span data-v-71ea20d2="" class="action-button__text">Unlink WorkPackage</span>
+        <!---->
+      </button></li></span></button>
     </div>
     <div class=""></div>
   </div>
@@ -95,8 +97,10 @@ exports[`ProjectsTab.vue Test fetchWorkpackages shows the linked workpackages 1`
             </div>
           </div>
         </div>
-      </div>
-      <div class="linked-workpackages--workpackage--unlink icon-noConnection"></div>
+      </div> <button data-v-68f2cb4a="" rel="noreferrer noopener" class="action-item action-item--single icon-noConnection linked-workpackages--workpackage--unlinkactionbutton undefined has-tooltip" aria-label="" icon="icon-noConnection" data-original-title="">
+        <!----> <span data-v-68f2cb4a="" aria-hidden="true" hidden="hidden"><li data-v-71ea20d2="" class="action linked-workpackages--workpackage--unlinkactionbutton" data-v-68f2cb4a=""><button data-v-71ea20d2="" aria-label="" type="button" class="action-button focusable"><span data-v-71ea20d2="" class="action-button__icon icon-noConnection"></span> <span data-v-71ea20d2="" class="action-button__text">Unlink WorkPackage</span>
+        <!---->
+      </button></li></span></button>
     </div>
     <div class="workpackage-seperator"></div>
   </div>
@@ -130,8 +134,10 @@ exports[`ProjectsTab.vue Test fetchWorkpackages shows the linked workpackages 1`
             </div>
           </div>
         </div>
-      </div>
-      <div class="linked-workpackages--workpackage--unlink icon-noConnection"></div>
+      </div> <button data-v-68f2cb4a="" rel="noreferrer noopener" class="action-item action-item--single icon-noConnection linked-workpackages--workpackage--unlinkactionbutton undefined has-tooltip" aria-label="" icon="icon-noConnection" data-original-title="">
+        <!----> <span data-v-68f2cb4a="" aria-hidden="true" hidden="hidden"><li data-v-71ea20d2="" class="action linked-workpackages--workpackage--unlinkactionbutton" data-v-68f2cb4a=""><button data-v-71ea20d2="" aria-label="" type="button" class="action-button focusable"><span data-v-71ea20d2="" class="action-button__icon icon-noConnection"></span> <span data-v-71ea20d2="" class="action-button__text">Unlink WorkPackage</span>
+        <!---->
+      </button></li></span></button>
     </div>
     <div class=""></div>
   </div>
@@ -173,8 +179,10 @@ exports[`ProjectsTab.vue Test fetchWorkpackages shows the linked workpackages 2`
             </div>
           </div>
         </div>
-      </div>
-      <div class="linked-workpackages--workpackage--unlink icon-noConnection"></div>
+      </div> <button data-v-68f2cb4a="" rel="noreferrer noopener" class="action-item action-item--single icon-noConnection linked-workpackages--workpackage--unlinkactionbutton undefined has-tooltip" aria-label="" icon="icon-noConnection" data-original-title="">
+        <!----> <span data-v-68f2cb4a="" aria-hidden="true" hidden="hidden"><li data-v-71ea20d2="" class="action linked-workpackages--workpackage--unlinkactionbutton" data-v-68f2cb4a=""><button data-v-71ea20d2="" aria-label="" type="button" class="action-button focusable"><span data-v-71ea20d2="" class="action-button__icon icon-noConnection"></span> <span data-v-71ea20d2="" class="action-button__text">Unlink WorkPackage</span>
+        <!---->
+      </button></li></span></button>
     </div>
     <div class="workpackage-seperator"></div>
   </div>
@@ -208,8 +216,10 @@ exports[`ProjectsTab.vue Test fetchWorkpackages shows the linked workpackages 2`
             </div>
           </div>
         </div>
-      </div>
-      <div class="linked-workpackages--workpackage--unlink icon-noConnection"></div>
+      </div> <button data-v-68f2cb4a="" rel="noreferrer noopener" class="action-item action-item--single icon-noConnection linked-workpackages--workpackage--unlinkactionbutton undefined has-tooltip" aria-label="" icon="icon-noConnection" data-original-title="">
+        <!----> <span data-v-68f2cb4a="" aria-hidden="true" hidden="hidden"><li data-v-71ea20d2="" class="action linked-workpackages--workpackage--unlinkactionbutton" data-v-68f2cb4a=""><button data-v-71ea20d2="" aria-label="" type="button" class="action-button focusable"><span data-v-71ea20d2="" class="action-button__icon icon-noConnection"></span> <span data-v-71ea20d2="" class="action-button__text">Unlink WorkPackage</span>
+        <!---->
+      </button></li></span></button>
     </div>
     <div class=""></div>
   </div>
@@ -251,8 +261,10 @@ exports[`ProjectsTab.vue Test onSave shows the just linked workpackage 1`] = `
             </div>
           </div>
         </div>
-      </div>
-      <div class="linked-workpackages--workpackage--unlink icon-noConnection"></div>
+      </div> <button data-v-68f2cb4a="" rel="noreferrer noopener" class="action-item action-item--single icon-noConnection linked-workpackages--workpackage--unlinkactionbutton undefined has-tooltip" aria-label="" icon="icon-noConnection" data-original-title="">
+        <!----> <span data-v-68f2cb4a="" aria-hidden="true" hidden="hidden"><li data-v-71ea20d2="" class="action linked-workpackages--workpackage--unlinkactionbutton" data-v-68f2cb4a=""><button data-v-71ea20d2="" aria-label="" type="button" class="action-button focusable"><span data-v-71ea20d2="" class="action-button__icon icon-noConnection"></span> <span data-v-71ea20d2="" class="action-button__text">Unlink WorkPackage</span>
+        <!---->
+      </button></li></span></button>
     </div>
     <div class=""></div>
   </div>


### PR DESCRIPTION
### Description

This PR changes(replaces) the unlink work package button (used div previously) with the help of action button (nexcloud component). 

OP#42134 https://community.openproject.org/projects/nextcloud-integration/work_packages/42134/activity