### PR TITLE
[#42634] do not use speaker icon for the notification items in the dashboard widget

### DIFF
--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -72,7 +72,7 @@ export default {
 					targetUrl: this.getNotificationTarget(n),
 					avatarUrl: this.getAuthorAvatarUrl(n),
 					avatarUsername: this.getAuthorShortName(n) + 'z',
-					overlayIconUrl: this.getNotificationTypeImage(n),
+					overlayIconUrl: false,
 					mainText: this.getTargetTitle(n),
 					subText: this.getSubline(n),
 				}
@@ -233,9 +233,6 @@ export default {
 		},
 		getNotificationContent(n) {
 			return ''
-		},
-		getNotificationTypeImage(n) {
-			return generateUrl('/svg/core/actions/sound?color=' + this.themingColor)
 		},
 		getSubline(n) {
 			return n._links.project.title + ' - ' + t('integration_openproject', n.reason)


### PR DESCRIPTION
### Description
- do not use the speaker icon at all for the notification items in the dashboard widget

in the widget item component, there is a check for the icon URL if it's truthy. Ref: https://github.com/nextcloud/nextcloud-vue-dashboard/blob/fd9246f2e3102dd0b33ac1e90975a42f518354b6/src/DashboardWidgetItem.vue#L39

we set is as `false` so that it is never rendered on the browser

### Related
- https://community.openproject.org/work_packages/42634

Signed-off-by: Kiran Parajuli <kiranparajuli589@gmail.com>