### PR TITLE
highlight & focus the OP instance input on invalid input

### DIFF
--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -14,7 +14,9 @@
 				{{ t('integration_openproject', 'OpenProject instance address') }}
 			</label>
 			<input id="openproject-oauth-instance"
+				ref="openproject-oauth-instance-input"
 				v-model="state.oauth_instance_url"
+				:class="{ error: !isOpenProjectInstanceValid }"
 				type="text"
 				:placeholder="t('integration_openproject', 'OpenProject address')">
 			<label for="openproject-client-id">
@@ -74,6 +76,7 @@ export default {
 			isAdminConfigOk: loadState('integration_openproject', 'admin-config-status'),
 			redirect_uri: window.location.protocol + '//' + window.location.host + generateUrl('/apps/integration_openproject/oauth-redirect'),
 			loadingState: STATE.OK,
+			isOpenProjectInstanceValid: true,
 		}
 	},
 	computed: {
@@ -135,6 +138,8 @@ export default {
 					t('integration_openproject', 'No OpenProject detected at the URL')
 				)
 				this.loadingState = STATE.OK
+				this.isOpenProjectInstanceValid = false
+				this.$refs['openproject-oauth-instance-input'].focus()
 				return
 			}
 			if (this.isAdminConfigOk) {
@@ -143,6 +148,7 @@ export default {
 				await this.saveOptions()
 			}
 			this.loadingState = STATE.OK
+			this.isOpenProjectInstanceValid = true
 		},
 	},
 }
@@ -171,6 +177,10 @@ export default {
 		.icon {
 			margin-bottom: -3px;
 		}
+	}
+	.error {
+		color: var(--color-error);
+		border-color: var(--color-error);
 	}
 }
 

--- a/tests/jest/components/AdminSettings.spec.js
+++ b/tests/jest/components/AdminSettings.spec.js
@@ -185,6 +185,7 @@ describe('AdminSettings', () => {
 				(name, buttonSelector, isAdminConfigOk) => {
 					let axiosSpyIsValidOPInstance
 					let saveConfigButton
+					let inputField
 					beforeEach(async () => {
 						axiosSpyIsValidOPInstance = jest.spyOn(axios, 'post')
 							.mockImplementationOnce(() => Promise.resolve({ data: false }))
@@ -193,7 +194,7 @@ describe('AdminSettings', () => {
 							isAdminConfigOk,
 						})
 						saveConfigButton = wrapper.find(buttonSelector)
-						const inputField = wrapper.find(selectors.oauthInstance)
+						inputField = wrapper.find(selectors.oauthInstance)
 						await inputField.setValue('http://no-openproject-here.org')
 
 					})
@@ -208,6 +209,20 @@ describe('AdminSettings', () => {
 						await localVue.nextTick()
 						expect(showErrorSpy).toBeCalledTimes(1)
 						showErrorSpy.mockRestore()
+					})
+					it('should focus the input field', async () => {
+						await saveConfigButton.trigger('click')
+						await localVue.nextTick()
+						try {
+							expect(inputField.element).toBe(document.activeElement)
+						} catch (e) {
+							throw new Error('input field not in focus')
+						}
+					})
+					it('should set the error class for the input field', async () => {
+						await saveConfigButton.trigger('click')
+						await localVue.nextTick()
+						expect(inputField.attributes().class).toContain('error')
 					})
 				})
 			describe('valid OpenProject instance', () => {
@@ -247,6 +262,7 @@ describe('AdminSettings', () => {
 function getWrapper(data = {}) {
 	return shallowMount(AdminSettings, {
 		localVue,
+		attachTo: document.body,
 		mocks: {
 			t: (app, msg) => msg,
 			generateUrl() {


### PR DESCRIPTION
if the openproject URL is not valid the input field gets marked red and receives the focus
![image](https://user-images.githubusercontent.com/2425577/171607741-bc856c43-96d3-419e-9f34-9ca9ef27b3bd.png)

fixes https://community.openproject.org/projects/nextcloud-integration/work_packages/42727