### PR TITLE
update github action packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-
 
       - name: Read package.json node and npm engines version
-        uses: skjnldsv/read-package-engines-version-actions@v1.1
+        uses: skjnldsv/read-package-engines-version-actions@v1.2
         id: versions
         with:
           fallbackNode: '^14'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
       - name: Cache PHP dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}


### PR DESCRIPTION
manly to fix CI errors like
`Error: Can't use 'tar -xzf' extract archive file: /home/runner/work/_actions/_temp_4ee0518e-3de3-46ec-ba57-e6f2f1e0c587/8e211d25-6f5d-46fc-82eb-2d3937132f46.tar.gz. return code: 2.`
which I believe come from the v2 of the cache package