### PR TITLE
OP#42613 cache colors of statuses and types

### DIFF
--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -113,21 +113,7 @@ class OpenProjectAPIService {
 		$this->storage = $storage;
 		$this->urlGenerator = $urlGenerator;
 
-		$this->setupCache($cacheFactory);
-	}
-
-	/**
-	 * @param ICacheFactory $cacheFactory
-	 * @return void
-	 */
-	public function setupCache($cacheFactory) {
-		if ($cacheFactory->isAvailable()) {
-			if ($cacheFactory->isLocalCacheAvailable()) {
-				$this->cache = $cacheFactory->createLocal();
-			} else {
-				$this->cache = $cacheFactory->createDistributed();
-			}
-		}
+		$this->cache = $cacheFactory->createDistributed();
 	}
 
 	/**
@@ -557,22 +543,20 @@ class OpenProjectAPIService {
 	 * @return string[]
 	 */
 	public function getOpenProjectWorkPackageStatus(string $userId, string $statusId): array {
-		if ($this->cache instanceof ICache) {
-			$result = $this->cache->get(Application::APP_ID . '/statuses/' . $statusId);
-			if ($result !== null) {
-				return $result;
-			}
+		$result = $this->cache->get(Application::APP_ID . '/statuses/' . $statusId);
+		if ($result !== null) {
+			return $result;
 		}
 		$result = $this->request($userId, 'statuses/' . $statusId);
 		if (!isset($result['id'])) {
 			return ['error' => 'Malformed response'];
-		} elseif ($this->cache instanceof ICache) {
-			$this->cache->set(
+		}
+
+		$this->cache->set(
 				Application::APP_ID . '/statuses/' . $statusId,
 				$result,
 				CACHE_TTL
-			);
-		}
+		);
 		return $result;
 	}
 
@@ -584,22 +568,19 @@ class OpenProjectAPIService {
 	 * @return string[]
 	 */
 	public function getOpenProjectWorkPackageType(string $userId, string $typeId): array {
-		if ($this->cache instanceof ICache) {
-			$result = $this->cache->get(Application::APP_ID . '/types/' . $typeId);
-			if ($result !== null) {
-				return $result;
-			}
+		$result = $this->cache->get(Application::APP_ID . '/types/' . $typeId);
+		if ($result !== null) {
+			return $result;
 		}
 		$result = $this->request($userId, 'types/' . $typeId);
 		if (!isset($result['id'])) {
 			return ['error' => 'Malformed response'];
-		} elseif ($this->cache instanceof ICache) {
-			$this->cache->set(
-				Application::APP_ID . '/types/' . $typeId,
-				$result,
-				CACHE_TTL
-			);
 		}
+		$this->cache->set(
+			Application::APP_ID . '/types/' . $typeId,
+			$result,
+			CACHE_TTL
+		);
 
 		return $result;
 	}

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -113,6 +113,14 @@ class OpenProjectAPIService {
 		$this->storage = $storage;
 		$this->urlGenerator = $urlGenerator;
 
+		$this->setupCache($cacheFactory);
+	}
+
+	/**
+	 * @param ICacheFactory $cacheFactory
+	 * @return void
+	 */
+	public function setupCache($cacheFactory) {
 		if ($cacheFactory->isAvailable()) {
 			if ($cacheFactory->isLocalCacheAvailable()) {
 				$this->cache = $cacheFactory->createLocal();

--- a/tests/lib/Service/OpenProjectAPIServiceCheckNotificationsTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceCheckNotificationsTest.php
@@ -166,6 +166,7 @@ class OpenProjectAPIServiceCheckNotificationsTest extends TestCase {
 			$clientService,
 			$this->createMock(\OCP\Files\IRootFolder::class),
 			$this->createMock(\OCP\IURLGenerator::class),
+			$this->createMock(\OCP\ICacheFactory::class),
 		);
 
 		$service->checkNotifications();

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -256,7 +256,8 @@ class OpenProjectAPIServiceTest extends TestCase {
 			$this->createMock(\OCP\Notification\IManager::class),
 			$clientService,
 			$storageMock,
-			$urlGeneratorMock
+			$urlGeneratorMock,
+			$this->createMock(\OCP\ICacheFactory::class),
 		);
 	}
 
@@ -1146,6 +1147,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 			$clientService,
 			$this->createMock(\OCP\Files\IRootFolder::class),
 			$this->createMock(\OCP\IURLGenerator::class),
+			$this->createMock(\OCP\ICacheFactory::class),
 		);
 
 		$response = $service->request('', '', []);


### PR DESCRIPTION
needs memory caching to be configured in NC, see https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/caching_configuration.html

In case local or distributed cache is available the code will cache the responses for the status & type requests for 1h

@eneiluj I would need your suggestion here. Is that the way the caching should be implemented? I tried with APCu, memcached and Redis in those cases it seems to work