### PR TITLE
OP#42613 cache colors of types and statuses in the frontedn

### DIFF
--- a/src/utils/workpackageHelper.js
+++ b/src/utils/workpackageHelper.js
@@ -1,7 +1,14 @@
 import { generateUrl } from '@nextcloud/router'
 import axios from '@nextcloud/axios'
 
+let cachedStatusColors = {}
+let cachedTypeColors = {}
 export const workpackageHelper = {
+	// to allow the unit tests, to clear the cache
+	clearCache() {
+		cachedStatusColors = {}
+		cachedTypeColors = {}
+	},
 	async getColorAttributes(path, id) {
 		const url = generateUrl(path + id)
 		let response
@@ -49,8 +56,22 @@ export const workpackageHelper = {
 			+ '=' + userId
 			+ '&' + encodeURIComponent('userName')
 			+ '=' + userName
-		const statusColor = await this.getColorAttributes('/apps/integration_openproject/statuses/', statusId)
-		const typeColor = await this.getColorAttributes('/apps/integration_openproject/types/', typeId)
+		let statusColor
+		if (cachedStatusColors[statusId] === undefined) {
+			statusColor = await this.getColorAttributes('/apps/integration_openproject/statuses/', statusId)
+			cachedStatusColors[statusId] = statusColor
+		} else {
+			statusColor = cachedStatusColors[statusId]
+		}
+
+		let typeColor
+		if (cachedTypeColors[typeId] === undefined) {
+			typeColor = await this.getColorAttributes('/apps/integration_openproject/types/', typeId)
+			cachedTypeColors[typeId] = typeColor
+		} else {
+			typeColor = cachedTypeColors[typeId]
+		}
+
 		return {
 			id: workPackage.id,
 			subject: workPackage.subject,

--- a/tests/jest/views/ProjectsTab.spec.js
+++ b/tests/jest/views/ProjectsTab.spec.js
@@ -6,6 +6,7 @@ import axios from '@nextcloud/axios'
 import * as initialState from '@nextcloud/initial-state'
 import { STATE } from '../../../src/utils'
 import workPackagesSearchResponse from '../fixtures/workPackagesSearchResponse.json'
+import { workpackageHelper } from '../../../src/utils/workpackageHelper'
 
 jest.mock('@nextcloud/dialogs')
 jest.mock('@nextcloud/l10n', () => ({
@@ -98,6 +99,11 @@ describe('ProjectsTab.vue Test', () => {
 		})
 	})
 	describe('fetchWorkpackages', () => {
+		let axiosGetSpy = jest.fn()
+		beforeEach(() => {
+			axiosGetSpy.mockRestore()
+			workpackageHelper.clearCache()
+		})
 		it.each([
 			{ HTTPStatus: 400, AppState: STATE.FAILED_FETCHING_WORKPACKAGES },
 			{ HTTPStatus: 401, AppState: STATE.NO_TOKEN },
@@ -240,7 +246,7 @@ describe('ProjectsTab.vue Test', () => {
 			{ statusColor: { }, typeColor: { } },
 		])('shows the linked workpackages', async (testCase) => {
 			wrapper = mountWrapper()
-			const axiosGetSpy = jest.spyOn(axios, 'get')
+			axiosGetSpy = jest.spyOn(axios, 'get')
 				.mockImplementationOnce(() => Promise.resolve({
 					status: 200,
 					data: [{
@@ -289,6 +295,12 @@ describe('ProjectsTab.vue Test', () => {
 				.mockImplementationOnce(() => Promise.resolve(
 					{ status: 200, data: testCase.typeColor })
 				)
+				.mockImplementationOnce(() => Promise.resolve(
+					{ status: 200, data: testCase.statusColor })
+				)
+				.mockImplementationOnce(() => Promise.resolve(
+					{ status: 200, data: testCase.typeColor })
+				)
 			await wrapper.vm.update({ id: 789 })
 			expect(axiosGetSpy).toBeCalledWith(
 				'http://localhost/apps/integration_openproject/work-packages?fileId=789',
@@ -310,7 +322,7 @@ describe('ProjectsTab.vue Test', () => {
 			// this can happen if multiple replies arrive at the same time
 			// when the user switches between files while results still loading
 			wrapper = mountWrapper()
-			const axiosGetSpy = jest.spyOn(axios, 'get')
+			axiosGetSpy = jest.spyOn(axios, 'get')
 				.mockImplementationOnce(() => Promise.resolve({
 					status: 200,
 					data: [{
@@ -364,6 +376,68 @@ describe('ProjectsTab.vue Test', () => {
 			expect(wrapper.vm.state).toBe(STATE.OK)
 			const workPackages = wrapper.find(workPackagesSelector)
 			expect(workPackages).toMatchSnapshot()
+		})
+		it('caches the results for status and type color', async () => {
+			wrapper = mountWrapper()
+			axiosGetSpy = jest.spyOn(axios, 'get')
+				.mockImplementationOnce(() => Promise.resolve({
+					status: 200,
+					data: [{
+						id: 123,
+						subject: 'my task',
+						_links: {
+							status: {
+								href: '/api/v3/statuses/12',
+								title: 'open',
+							},
+							type: {
+								href: '/api/v3/types/6',
+								title: 'Task',
+							},
+							assignee: {
+								href: '/api/v3/users/1',
+								title: 'Bal Bahadur Pun',
+							},
+							project: { title: 'a big project' },
+						},
+					},
+					{
+						id: 456,
+						subject: 'your task',
+						_links: {
+							status: {
+								href: '/api/v3/statuses/12',
+								title: 'open',
+							},
+							type: {
+								href: '/api/v3/types/6',
+								title: 'Task',
+							},
+							assignee: {
+								href: '/api/v3/users/1',
+								title: 'Bal Bahadur Pun',
+							},
+							project: { title: 'a big project' },
+						},
+					}],
+				}))
+				.mockImplementation(() => Promise.resolve({
+					status: 200,
+					data: { color: '#FFFFFF' },
+				}))
+			await wrapper.vm.update({ id: 2222 })
+
+			// there should be only 3 requests even there are 2 WP
+			// one request for the wp itself, one for status color one for type color
+			expect(axiosGetSpy).toBeCalledTimes(3)
+			expect(axiosGetSpy).toHaveBeenNthCalledWith(
+				2,
+				'http://localhost/apps/integration_openproject/statuses/12'
+			)
+			expect(axiosGetSpy).toHaveBeenNthCalledWith(
+				3,
+				'http://localhost/apps/integration_openproject/types/6'
+			)
 		})
 	})
 	describe('onSave', () => {

--- a/tests/jest/views/__snapshots__/ProjectsTab.spec.js.snap
+++ b/tests/jest/views/__snapshots__/ProjectsTab.spec.js.snap
@@ -108,7 +108,7 @@ exports[`ProjectsTab.vue Test fetchWorkpackages shows the linked workpackages 1`
     <div class="linked-workpackages--workpackage">
       <div class="workpackage linked-workpackages--workpackage--item" id="workpackage-589">
         <div class="row">
-          <div class="row__status">
+          <div class="row__status" style="background-color: rgb(165, 216, 255);">
             <div class="row__status__title">
               प्रगति हुदैछ
             </div>
@@ -118,7 +118,7 @@ exports[`ProjectsTab.vue Test fetchWorkpackages shows the linked workpackages 1`
           </div>
         </div>
         <div class="row">
-          <div class="row__subject"><span class="row__subject__type">
+          <div class="row__subject"><span class="row__subject__type" style="color: rgb(0, 176, 240);">
 				Epic
 			</span>
             नेपालमा IT उद्योग बनाउने


### PR DESCRIPTION
additionally to #129 this caches the colors also in JS, so that if a color was already used it even does not need to be requested from the caching server
the cache will be invalidated on page reload, but not when moving into an other folder