### PR TITLE
[OP#42855] redirect user back to where oauth journey was started

### DIFF
--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -168,13 +168,13 @@ class ConfigController extends Controller {
 	 */
 	public function oauthRedirect(string $code = '', string $state = ''): RedirectResponse {
 		$configState = $this->config->getUserValue($this->userId, Application::APP_ID, 'oauth_state');
-		$oauthJourneyStartingPage = $this->config->getUserValue(
-			$this->userId, Application::APP_ID, 'oauth_journey_starting_page'
-		);
 		$clientID = $this->config->getAppValue(Application::APP_ID, 'client_id');
 		$clientSecret = $this->config->getAppValue(Application::APP_ID, 'client_secret');
 		$codeVerifier = $this->config->getUserValue(
 			$this->userId, Application::APP_ID, 'code_verifier', false
+		);
+		$oauthJourneyStartingPage = $this->config->getUserValue(
+			$this->userId, Application::APP_ID, 'oauth_journey_starting_page'
 		);
 
 		try {

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -26,8 +26,6 @@ use OCA\OpenProject\Service\OauthService;
 use OCA\OpenProject\Service\OpenProjectAPIService;
 use OCA\OpenProject\AppInfo\Application;
 use Psr\Log\LoggerInterface;
-use Punic\Exception;
-use function PHPUnit\Framework\throwException;
 
 class ConfigController extends Controller {
 
@@ -187,7 +185,7 @@ class ConfigController extends Controller {
 					'settings.PersonalSettings.index', ['section' => 'connected-accounts']
 				);
 			} elseif ($oauthJourneyStartingPageDecoded->page === 'files') {
-				$newUrl = $this->urlGenerator->linkToRoute('files.view.index',[
+				$newUrl = $this->urlGenerator->linkToRoute('files.view.index', [
 					'dir' => $oauthJourneyStartingPageDecoded->file->dir,
 					'scrollto' => $oauthJourneyStartingPageDecoded->file->name
 				]);

--- a/lib/Dashboard/OpenProjectWidget.php
+++ b/lib/Dashboard/OpenProjectWidget.php
@@ -29,6 +29,8 @@ use OCP\Dashboard\IWidget;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserSession;
 use OCP\Util;
 
 use OCA\OpenProject\AppInfo\Application;
@@ -52,16 +54,23 @@ class OpenProjectWidget implements IWidget {
 	 */
 	private $config;
 
+	/**
+	 * @var IUser
+	 */
+	private $user;
+
 	public function __construct(
 		IL10N $l10n,
 		IInitialState $initialStateService,
 		IURLGenerator $url,
-		IConfig $config
+		IConfig $config,
+		IUserSession $userSession
 	) {
 		$this->initialStateService = $initialStateService;
 		$this->l10n = $l10n;
 		$this->url = $url;
 		$this->config = $config;
+		$this->user = $userSession->getUser();
 	}
 
 	/**
@@ -116,5 +125,23 @@ class OpenProjectWidget implements IWidget {
 		} catch (\Exception $e) {
 			$this->initialStateService->provideInitialState('request-url', false);
 		}
+		$oauthConnectionResult = $this->config->getUserValue(
+			$this->user->getUID(), Application::APP_ID, 'oauth_connection_result'
+		);
+		$this->config->deleteUserValue(
+			$this->user->getUID(), Application::APP_ID, 'oauth_connection_result'
+		);
+		$this->initialStateService->provideInitialState(
+			'oauth-connection-result', $oauthConnectionResult
+		);
+		$oauthConnectionErrorMessage = $this->config->getUserValue(
+			$this->user->getUID(), Application::APP_ID, 'oauth_connection_error_message'
+		);
+		$this->config->deleteUserValue(
+			$this->user->getUID(), Application::APP_ID, 'oauth_connection_error_message'
+		);
+		$this->initialStateService->provideInitialState(
+			'oauth-connection-error-message', $oauthConnectionErrorMessage
+		);
 	}
 }

--- a/lib/Listener/LoadSidebarScript.php
+++ b/lib/Listener/LoadSidebarScript.php
@@ -34,6 +34,8 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\IConfig;
 use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserSession;
 use OCP\Util;
 
 class LoadSidebarScript implements IEventListener {
@@ -51,14 +53,21 @@ class LoadSidebarScript implements IEventListener {
 	 */
 	private $config;
 
+	/**
+	 * @var IUser|null
+	 */
+	private $user;
+
 	public function __construct(
 		IInitialState $initialStateService,
 		IURLGenerator $url,
-		IConfig $config
+		IConfig $config,
+		IUserSession $userSession
 	) {
 		$this->initialStateService = $initialStateService;
 		$this->config = $config;
 		$this->url = $url;
+		$this->user = $userSession->getUser();
 	}
 
 	public function handle(Event $event): void {
@@ -81,5 +90,12 @@ class LoadSidebarScript implements IEventListener {
 		} catch (\Exception $e) {
 			$this->initialStateService->provideInitialState('request-url', false);
 		}
+		$oauthConnectionErrorMessage = $this->config->getUserValue(
+			$this->user->getUID(), Application::APP_ID, 'oauth_connection_error_message'
+		);
+		$this->config->deleteUserValue(
+			$this->user->getUID(), Application::APP_ID, 'oauth_connection_error_message'
+		);
+		$this->initialStateService->provideInitialState('oauth-connection-error-message', $oauthConnectionErrorMessage);
 	}
 }

--- a/lib/Listener/LoadSidebarScript.php
+++ b/lib/Listener/LoadSidebarScript.php
@@ -33,6 +33,7 @@ use OCP\AppFramework\Services\IInitialState;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\IConfig;
+use OCP\IRequest;
 use OCP\IURLGenerator;
 use OCP\IUserSession;
 use OCP\Util;
@@ -71,18 +72,20 @@ class LoadSidebarScript implements IEventListener {
 		$this->config = $config;
 		$this->url = $url;
 		$user = $userSession->getUser();
-		$this->oauthConnectionResult = $this->config->getUserValue(
-			$user->getUID(), Application::APP_ID, 'oauth_connection_result'
-		);
-		$this->config->deleteUserValue(
-			$user->getUID(), Application::APP_ID, 'oauth_connection_result'
-		);
-		$this->oauthConnectionErrorMessage = $this->config->getUserValue(
-			$user->getUID(), Application::APP_ID, 'oauth_connection_error_message'
-		);
-		$this->config->deleteUserValue(
-			$user->getUID(), Application::APP_ID, 'oauth_connection_error_message'
-		);
+		if (strpos(\OC::$server->get(IRequest::class)->getRequestUri(), 'files') !== false) {
+			$this->oauthConnectionResult = $this->config->getUserValue(
+				$user->getUID(), Application::APP_ID, 'oauth_connection_result'
+			);
+			$this->config->deleteUserValue(
+				$user->getUID(), Application::APP_ID, 'oauth_connection_result'
+			);
+			$this->oauthConnectionErrorMessage = $this->config->getUserValue(
+				$user->getUID(), Application::APP_ID, 'oauth_connection_error_message'
+			);
+			$this->config->deleteUserValue(
+				$user->getUID(), Application::APP_ID, 'oauth_connection_error_message'
+			);
+		}
 	}
 
 	public function handle(Event $event): void {

--- a/lib/Listener/LoadSidebarScript.php
+++ b/lib/Listener/LoadSidebarScript.php
@@ -54,9 +54,13 @@ class LoadSidebarScript implements IEventListener {
 	private $config;
 
 	/**
-	 * @var IUser|null
+	 * @var string "error"|"success"|""
 	 */
-	private $user;
+	private $oauthConnectionResult;
+	/**
+	 * @var string
+	 */
+	private $oauthConnectionErrorMessage;
 
 	public function __construct(
 		IInitialState $initialStateService,
@@ -67,7 +71,19 @@ class LoadSidebarScript implements IEventListener {
 		$this->initialStateService = $initialStateService;
 		$this->config = $config;
 		$this->url = $url;
-		$this->user = $userSession->getUser();
+		$user = $userSession->getUser();
+		$this->oauthConnectionResult = $this->config->getUserValue(
+			$user->getUID(), Application::APP_ID, 'oauth_connection_result'
+		);
+		$this->config->deleteUserValue(
+			$user->getUID(), Application::APP_ID, 'oauth_connection_result'
+		);
+		$this->oauthConnectionErrorMessage = $this->config->getUserValue(
+			$user->getUID(), Application::APP_ID, 'oauth_connection_error_message'
+		);
+		$this->config->deleteUserValue(
+			$user->getUID(), Application::APP_ID, 'oauth_connection_error_message'
+		);
 	}
 
 	public function handle(Event $event): void {
@@ -90,12 +106,12 @@ class LoadSidebarScript implements IEventListener {
 		} catch (\Exception $e) {
 			$this->initialStateService->provideInitialState('request-url', false);
 		}
-		$oauthConnectionErrorMessage = $this->config->getUserValue(
-			$this->user->getUID(), Application::APP_ID, 'oauth_connection_error_message'
+
+		$this->initialStateService->provideInitialState(
+			'oauth-connection-result', $this->oauthConnectionResult
 		);
-		$this->config->deleteUserValue(
-			$this->user->getUID(), Application::APP_ID, 'oauth_connection_error_message'
+		$this->initialStateService->provideInitialState(
+			'oauth-connection-error-message', $this->oauthConnectionErrorMessage
 		);
-		$this->initialStateService->provideInitialState('oauth-connection-error-message', $oauthConnectionErrorMessage);
 	}
 }

--- a/lib/Listener/LoadSidebarScript.php
+++ b/lib/Listener/LoadSidebarScript.php
@@ -34,7 +34,6 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\IConfig;
 use OCP\IURLGenerator;
-use OCP\IUser;
 use OCP\IUserSession;
 use OCP\Util;
 

--- a/lib/Settings/Personal.php
+++ b/lib/Settings/Personal.php
@@ -68,6 +68,26 @@ class Personal implements ISettings {
 			$this->initialStateService->provideInitialState('user-config', $userConfig);
 		}
 
+		$oauthConnectionResult = $this->config->getUserValue(
+			$this->userId, Application::APP_ID, 'oauth_connection_result'
+		);
+		$this->config->deleteUserValue(
+			$this->userId, Application::APP_ID, 'oauth_connection_result'
+		);
+		$this->initialStateService->provideInitialState(
+			'oauth-connection-result', $oauthConnectionResult
+		);
+		$oauthConnectionErrorMessage = $this->config->getUserValue(
+			$this->userId, Application::APP_ID, 'oauth_connection_error_message'
+		);
+		$this->config->deleteUserValue(
+			$this->userId, Application::APP_ID, 'oauth_connection_error_message'
+		);
+		$this->initialStateService->provideInitialState(
+			'oauth-connection-error-message', $oauthConnectionErrorMessage
+		);
+
+
 		return new TemplateResponse(Application::APP_ID, 'personalSettings');
 	}
 

--- a/src/components/OAuthConnectButton.vue
+++ b/src/components/OAuthConnectButton.vue
@@ -39,6 +39,15 @@ export default {
 	},
 
 	methods: {
+		getOauthJourneyStartingPage() {
+			if (window.location.pathname.includes('dashboard')) {
+				return { page: 'dashboard' }
+			}
+			if (window.location.pathname.includes('apps/files') && this.fileInfo.id !== undefined) {
+				return { page: 'files', file: this.fileInfo }
+			}
+			return { page: 'settings' }
+		},
 		async onOAuthClick() {
 			const url = generateUrl('/apps/integration_openproject/op-oauth-url')
 			axios.get(url)

--- a/src/components/OAuthConnectButton.vue
+++ b/src/components/OAuthConnectButton.vue
@@ -23,6 +23,12 @@ export default {
 			type: [String, Boolean],
 			required: true,
 		},
+		fileInfo: {
+			type: Object,
+			default() {
+				return {}
+			},
+		},
 	},
 
 	computed: {
@@ -37,7 +43,16 @@ export default {
 			const url = generateUrl('/apps/integration_openproject/op-oauth-url')
 			axios.get(url)
 				.then((result) => {
-					window.location.replace(result.data)
+					const req = {
+						values: {
+							oauth_journey_starting_page: JSON.stringify(this.getOauthJourneyStartingPage()),
+						},
+					}
+					const url = generateUrl('/apps/integration_openproject/config')
+					axios.put(url, req)
+						.then(() => {
+							window.location.replace(result.data)
+						})
 				})
 				.catch((error) => {
 					showError(

--- a/src/components/PersonalSettings.vue
+++ b/src/components/PersonalSettings.vue
@@ -54,6 +54,7 @@ import '@nextcloud/dialogs/styles/toast.scss'
 import SettingsTitle from '../components/settings/SettingsTitle'
 import OAuthConnectButton from './OAuthConnectButton'
 import { translate as t } from '@nextcloud/l10n'
+import { checkOauthConnectionResult } from '../utils'
 
 export default {
 	name: 'PersonalSettings',
@@ -83,16 +84,7 @@ export default {
 	},
 
 	mounted() {
-		if (this.oauthConnectionResult === 'success') {
-			showSuccess(t('integration_openproject', 'Successfully connected to OpenProject!'))
-		} else if (this.oauthConnectionResult === 'error') {
-			showError(
-				t(
-					'integration_openproject',
-					'OAuth access token could not be obtained:'
-				) + ' ' + this.oauthConnectionErrorMessage
-			)
-		}
+		checkOauthConnectionResult(this.oauthConnectionResult, this.oauthConnectionErrorMessage)
 	},
 
 	methods: {

--- a/src/components/PersonalSettings.vue
+++ b/src/components/PersonalSettings.vue
@@ -53,6 +53,7 @@ import { showSuccess, showError } from '@nextcloud/dialogs'
 import '@nextcloud/dialogs/styles/toast.scss'
 import SettingsTitle from '../components/settings/SettingsTitle'
 import OAuthConnectButton from './OAuthConnectButton'
+import { translate as t } from '@nextcloud/l10n'
 
 export default {
 	name: 'PersonalSettings',
@@ -65,6 +66,8 @@ export default {
 		return {
 			loading: false,
 			state: loadState('integration_openproject', 'user-config'),
+			oauthConnectionErrorMessage: loadState('integration_openproject', 'oauth-connection-error-message'),
+			oauthConnectionResult: loadState('integration_openproject', 'oauth-connection-result'),
 		}
 	},
 
@@ -80,14 +83,15 @@ export default {
 	},
 
 	mounted() {
-		const paramString = window.location.search.substr(1)
-		// eslint-disable-next-line
-		const urlParams = new URLSearchParams(paramString)
-		const zmToken = urlParams.get('openprojectToken')
-		if (zmToken === 'success') {
+		if (this.oauthConnectionResult === 'success') {
 			showSuccess(t('integration_openproject', 'Successfully connected to OpenProject!'))
-		} else if (zmToken === 'error') {
-			showError(t('integration_openproject', 'OAuth access token could not be obtained:') + ' ' + urlParams.get('message'))
+		} else if (this.oauthConnectionResult === 'error') {
+			showError(
+				t(
+					'integration_openproject',
+					'OAuth access token could not be obtained:'
+				) + ' ' + this.oauthConnectionErrorMessage
+			)
 		}
 	},
 

--- a/src/components/tab/EmptyContent.vue
+++ b/src/components/tab/EmptyContent.vue
@@ -15,7 +15,8 @@
 				</div>
 			</div>
 			<div v-if="showConnectButton" class="empty-content--connect-button">
-				<OAuthConnectButton :request-url="requestUrl" />
+				<OAuthConnectButton :request-url="requestUrl"
+					:file-info="fileInfo" />
 			</div>
 		</div>
 	</div>
@@ -43,6 +44,12 @@ export default {
 		errorMessage: {
 			type: String,
 			default: '',
+		},
+		fileInfo: {
+			type: Object,
+			default() {
+				return {}
+			},
 		},
 	},
 	data() {

--- a/src/components/tab/EmptyContent.vue
+++ b/src/components/tab/EmptyContent.vue
@@ -15,8 +15,7 @@
 				</div>
 			</div>
 			<div v-if="showConnectButton" class="empty-content--connect-button">
-				<OAuthConnectButton :request-url="requestUrl"
-					:file-info="fileInfo" />
+				<OAuthConnectButton :request-url="requestUrl" :file-info="fileInfo" />
 			</div>
 		</div>
 	</div>

--- a/src/utils.js
+++ b/src/utils.js
@@ -23,6 +23,8 @@ export function checkOauthConnectionResult(oauthConnectionResult, oauthConnectio
 				'OAuth access token could not be obtained:'
 			) + ' ' + oauthConnectionErrorMessage
 		)
+	} else {
+		console.error(`'${oauthConnectionResult}' is an invalid value`)
 	}
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -23,8 +23,6 @@ export function checkOauthConnectionResult(oauthConnectionResult, oauthConnectio
 				'OAuth access token could not be obtained:'
 			) + ' ' + oauthConnectionErrorMessage
 		)
-	} else {
-		console.error(`'${oauthConnectionResult}' is an invalid value`)
 	}
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,6 @@
+import { showError, showSuccess } from '@nextcloud/dialogs'
+import { translate as t } from '@nextcloud/l10n'
+
 let mytimer = 0
 export function delay(callback, ms) {
 	return function() {
@@ -7,6 +10,19 @@ export function delay(callback, ms) {
 		mytimer = setTimeout(function() {
 			callback.apply(context, args)
 		}, ms || 0)
+	}
+}
+
+export function checkOauthConnectionResult(oauthConnectionResult, oauthConnectionErrorMessage) {
+	if (oauthConnectionResult === 'success') {
+		showSuccess(t('integration_openproject', 'Successfully connected to OpenProject!'))
+	} else if (oauthConnectionResult === 'error') {
+		showError(
+			t(
+				'integration_openproject',
+				'OAuth access token could not be obtained:'
+			) + ' ' + oauthConnectionErrorMessage
+		)
 	}
 }
 

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -23,13 +23,13 @@
 import axios from '@nextcloud/axios'
 import { generateUrl } from '@nextcloud/router'
 import { DashboardWidget } from '@nextcloud/vue-dashboard'
-import { showError, showSuccess } from '@nextcloud/dialogs'
+import { showError } from '@nextcloud/dialogs'
 import '@nextcloud/dialogs/styles/toast.scss'
 import moment from '@nextcloud/moment'
 import EmptyContent from '@nextcloud/vue/dist/Components/EmptyContent'
 import { loadState } from '@nextcloud/initial-state'
 import OAuthConnectButton from '../components/OAuthConnectButton'
-import { STATE } from '../utils'
+import { checkOauthConnectionResult, STATE } from '../utils'
 import { translate as t } from '@nextcloud/l10n'
 
 export default {
@@ -118,16 +118,7 @@ export default {
 		},
 	},
 	mounted() {
-		if (this.oauthConnectionResult === 'success') {
-			showSuccess(t('integration_openproject', 'Successfully connected to OpenProject!'))
-		} else if (this.oauthConnectionResult === 'error') {
-			showError(
-				t(
-					'integration_openproject',
-					'OAuth access token could not be obtained:'
-				) + ' ' + this.oauthConnectionErrorMessage
-			)
-		}
+		checkOauthConnectionResult(this.oauthConnectionResult, this.oauthConnectionErrorMessage)
 	},
 
 	beforeDestroy() {

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -23,13 +23,14 @@
 import axios from '@nextcloud/axios'
 import { generateUrl } from '@nextcloud/router'
 import { DashboardWidget } from '@nextcloud/vue-dashboard'
-import { showError } from '@nextcloud/dialogs'
+import { showError, showSuccess } from '@nextcloud/dialogs'
 import '@nextcloud/dialogs/styles/toast.scss'
 import moment from '@nextcloud/moment'
 import EmptyContent from '@nextcloud/vue/dist/Components/EmptyContent'
 import { loadState } from '@nextcloud/initial-state'
 import OAuthConnectButton from '../components/OAuthConnectButton'
 import { STATE } from '../utils'
+import { translate as t } from '@nextcloud/l10n'
 
 export default {
 	name: 'Dashboard',
@@ -52,12 +53,13 @@ export default {
 			loop: null,
 			state: STATE.LOADING,
 			requestUrl: loadState('integration_openproject', 'request-url'),
+			oauthConnectionErrorMessage: loadState('integration_openproject', 'oauth-connection-error-message'),
+			oauthConnectionResult: loadState('integration_openproject', 'oauth-connection-result'),
 			settingsUrl: generateUrl('/settings/user/connected-accounts'),
 			themingColor: OCA.Theming ? OCA.Theming.color.replace('#', '') : '0082C9',
 			windowVisibility: true,
 		}
 	},
-
 	computed: {
 		isLoading() {
 			return this.state === STATE.LOADING
@@ -106,7 +108,6 @@ export default {
 			return [STATE.NO_TOKEN, STATE.ERROR].includes(this.state)
 		},
 	},
-
 	watch: {
 		windowVisibility(newValue) {
 			if (newValue) {
@@ -115,6 +116,18 @@ export default {
 				this.stopLoop()
 			}
 		},
+	},
+	mounted() {
+		if (this.oauthConnectionResult === 'success') {
+			showSuccess(t('integration_openproject', 'Successfully connected to OpenProject!'))
+		} else if (this.oauthConnectionResult === 'error') {
+			showError(
+				t(
+					'integration_openproject',
+					'OAuth access token could not be obtained:'
+				) + ' ' + this.oauthConnectionErrorMessage
+			)
+		}
 	},
 
 	beforeDestroy() {

--- a/src/views/ProjectsTab.vue
+++ b/src/views/ProjectsTab.vue
@@ -71,7 +71,7 @@ import { translate as t } from '@nextcloud/l10n'
 import SearchInput from '../components/tab/SearchInput'
 import { loadState } from '@nextcloud/initial-state'
 import { workpackageHelper } from '../utils/workpackageHelper'
-import { STATE } from '../utils'
+import { STATE, checkOauthConnectionResult } from '../utils'
 
 export default {
 	name: 'ProjectsTab',
@@ -107,17 +107,7 @@ export default {
 		},
 	},
 	mounted() {
-		if (this.oauthConnectionResult === 'success') {
-			showSuccess(t('integration_openproject', 'Successfully connected to OpenProject!'))
-		} else if (this.oauthConnectionResult === 'error') {
-			showError(
-				t(
-					'integration_openproject',
-					'OAuth access token could not be obtained:'
-				) + ' ' + this.oauthConnectionErrorMessage
-			)
-		}
-
+		checkOauthConnectionResult(this.oauthConnectionResult, this.oauthConnectionErrorMessage)
 	},
 	methods: {
 		/**

--- a/src/views/ProjectsTab.vue
+++ b/src/views/ProjectsTab.vue
@@ -54,6 +54,7 @@
 		<EmptyContent v-else
 			id="openproject-empty-content"
 			:state="state"
+			:file-info="fileInfo"
 			:request-url="requestUrl" />
 	</div>
 </template>

--- a/src/views/ProjectsTab.vue
+++ b/src/views/ProjectsTab.vue
@@ -89,6 +89,7 @@ export default {
 		workpackages: [],
 		requestUrl: loadState('integration_openproject', 'request-url'),
 		oauthConnectionErrorMessage: loadState('integration_openproject', 'oauth-connection-error-message'),
+		oauthConnectionResult: loadState('integration_openproject', 'oauth-connection-result'),
 		color: null,
 	}),
 	computed: {
@@ -106,7 +107,17 @@ export default {
 		},
 	},
 	mounted() {
-		showError(t('integration_openproject', 'OAuth access token could not be obtained:') + ' ' + this.oauthConnectionErrorMessage)
+		if (this.oauthConnectionResult === 'success') {
+			showSuccess(t('integration_openproject', 'Successfully connected to OpenProject!'))
+		} else if (this.oauthConnectionResult === 'error') {
+			showError(
+				t(
+					'integration_openproject',
+					'OAuth access token could not be obtained:'
+				) + ' ' + this.oauthConnectionErrorMessage
+			)
+		}
+
 	},
 	methods: {
 		/**

--- a/src/views/ProjectsTab.vue
+++ b/src/views/ProjectsTab.vue
@@ -88,6 +88,7 @@ export default {
 		state: STATE.LOADING,
 		workpackages: [],
 		requestUrl: loadState('integration_openproject', 'request-url'),
+		oauthConnectionErrorMessage: loadState('integration_openproject', 'oauth-connection-error-message'),
 		color: null,
 	}),
 	computed: {
@@ -103,6 +104,9 @@ export default {
 				return wp.fileId === this.fileInfo.id
 			})
 		},
+	},
+	mounted() {
+		showError(t('integration_openproject', 'OAuth access token could not be obtained:') + ' ' + this.oauthConnectionErrorMessage)
 	},
 	methods: {
 		/**

--- a/tests/jest/components/OAuthConnectButton.spec.js
+++ b/tests/jest/components/OAuthConnectButton.spec.js
@@ -26,13 +26,28 @@ describe('OAuthConnectButton.vue Test', () => {
 	describe('when the request url is valid', () => {
 		beforeEach(() => {
 			delete window.location
-			window.location = { replace: jest.fn() }
+			window.location = { replace: jest.fn(), pathname: '/index.php/apps/files/' }
 			wrapper = getWrapper()
 		})
 		describe('on successful retrieving of the OP OAuth URI', () => {
 			beforeEach(() => {
 				axios.get.mockImplementationOnce(() =>
-					Promise.resolve({ data: 'http://openproject/oauth' }),
+					Promise.resolve({ data: 'http://openproject/oauth' })
+				)
+				axios.put.mockImplementationOnce(() =>
+					Promise.resolve({}),
+				)
+			})
+			it('saves the state to user config', async () => {
+				wrapper.find('button').trigger('click')
+				await localVue.nextTick()
+				expect(axios.put).toHaveBeenCalledWith(
+					'http://localhost/apps/integration_openproject/config',
+					{
+						values: {
+							oauth_journey_starting_page: expect.stringMatching(/{.*}/),
+						},
+					},
 				)
 			})
 			it('redirects to the openproject oauth uri', async () => {

--- a/tests/lib/Controller/ConfigControllerTest.php
+++ b/tests/lib/Controller/ConfigControllerTest.php
@@ -81,7 +81,7 @@ class ConfigControllerTest extends TestCase {
 				['testUser', 'integration_openproject', 'token', 'oAuthAccessToken'],
 				['testUser', 'integration_openproject', 'refresh_token', 'oAuthRefreshToken'],
 				['testUser', 'integration_openproject', 'user_id', 1],
-				['testUser', 'integration_openproject', 'user_name', 'Tripatti Himal'],
+				['testUser', 'integration_openproject', 'user_name', 'Tripathi Himal'],
 				['testUser', 'integration_openproject', 'oauth_connection_result', 'success'],
 			);
 		$urlGeneratorMock = $this->getMockBuilder(IURLGenerator::class)
@@ -101,7 +101,7 @@ class ConfigControllerTest extends TestCase {
 				'testUser',
 				'users/me'
 			)
-			->willReturn(['lastName' => 'Himal', 'firstName' => 'Tripatti', 'id' => 1]);
+			->willReturn(['lastName' => 'Himal', 'firstName' => 'Tripathi', 'id' => 1]);
 
 		$apiServiceMock
 			->method('requestOAuthAccessToken')

--- a/tests/lib/Settings/PersonalTest.php
+++ b/tests/lib/Settings/PersonalTest.php
@@ -128,14 +128,20 @@ class PersonalTest extends TestCase {
 
 		$this->initialState
 			->method('provideInitialState')
-			->with('user-config', [
-				'token' => 'some-token',
-				'user_name' => 'some-username',
-				'search_enabled' => false,
-				'notification_enabled' => false,
-				'navigation_enabled' => false,
-				'request_url' => $expectedRequestUrl === '' ? false : $expectedRequestUrl,
-			]);
+			->withConsecutive(
+				[
+					'user-config', [
+						'token' => 'some-token',
+						'user_name' => 'some-username',
+						'search_enabled' => false,
+						'notification_enabled' => false,
+						'navigation_enabled' => false,
+						'request_url' => $expectedRequestUrl === '' ? false : $expectedRequestUrl,
+					]
+				],
+				['oauth-connection-result'],
+				['oauth-connection-error-message']
+			);
 
 		$form = $this->setting->getForm();
 		$expected = new TemplateResponse('integration_openproject', 'personalSettings');


### PR DESCRIPTION
The journey to connect to OpenProject can be started from Dashboar, FilesPage or the personal settings, this PR brings the user back to where the journey was started.

fixes https://community.openproject.org/projects/nextcloud-integration/work_packages/42855