### PR TITLE
move generating OP OAuth URI to the backend

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -25,7 +25,7 @@ return [
 		['name' => 'openProjectAPI#getOpenProjectWorkPackageType', 'url' => '/types/{id}', 'verb' => 'GET'],
 		['name' => 'openProjectAPI#deleteFileLink', 'url' => '/file-links/{id}', 'verb' => 'DELETE'],
 		['name' => 'openProjectAPI#isValidOpenProjectInstance', 'url' => '/is-valid-op-instance', 'verb' => 'POST'],
-		['name' => 'openProjectAPI#getOpenProjectOauthURL', 'url' => '/op-oauth-url', 'verb' => 'GET'],
+		['name' => 'openProjectAPI#getOpenProjectOauthURLWithStateAndPKCE', 'url' => '/op-oauth-url', 'verb' => 'GET'],
 	],
 	'ocs' => [
 		['name' => 'files#getFileInfo', 'url' => '/fileinfo/{fileId}', 'verb' => 'GET'],

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -25,6 +25,7 @@ return [
 		['name' => 'openProjectAPI#getOpenProjectWorkPackageType', 'url' => '/types/{id}', 'verb' => 'GET'],
 		['name' => 'openProjectAPI#deleteFileLink', 'url' => '/file-links/{id}', 'verb' => 'DELETE'],
 		['name' => 'openProjectAPI#isValidOpenProjectInstance', 'url' => '/is-valid-op-instance', 'verb' => 'POST'],
+		['name' => 'openProjectAPI#getOpenProjectOauthURL', 'url' => '/op-oauth-url', 'verb' => 'GET'],
 	],
 	'ocs' => [
 		['name' => 'files#getFileInfo', 'url' => '/fileinfo/{fileId}', 'verb' => 'GET'],

--- a/lib/Controller/OpenProjectAPIController.php
+++ b/lib/Controller/OpenProjectAPIController.php
@@ -353,7 +353,8 @@ class OpenProjectAPIController extends Controller {
 			'oauth_state',
 			$oauthState
 		);
-		$randomString = bin2hex(random_bytes(64));
+		// this results in a random string of 192 char and after packing and encoding a 128 char verifier
+		$randomString = bin2hex(random_bytes(96));
 		$codeVerifier = $this->base64UrlEncode(pack('H*', $randomString));
 		$this->config->setUserValue(
 			$this->userId,

--- a/lib/Controller/OpenProjectAPIController.php
+++ b/lib/Controller/OpenProjectAPIController.php
@@ -342,7 +342,7 @@ class OpenProjectAPIController extends Controller {
 	 *
 	 * @return DataResponse
 	 */
-	public function getOpenProjectOauthURL(): DataResponse {
+	public function getOpenProjectOauthURLWithStateAndPKCE(): DataResponse {
 		$url = $this->openprojectAPIService::getOpenProjectOauthURL(
 			$this->config, $this->urlGenerator
 		);

--- a/lib/Controller/OpenProjectAPIController.php
+++ b/lib/Controller/OpenProjectAPIController.php
@@ -371,7 +371,7 @@ class OpenProjectAPIController extends Controller {
 		return new DataResponse($url);
 	}
 
-	private function base64UrlEncode($plainText) {
+	private function base64UrlEncode(string $plainText): string {
 		$base64 = base64_encode($plainText);
 		$base64 = trim($base64, "=");
 		$base64url = strtr($base64, '+/', '-_');

--- a/src/components/OAuthConnectButton.vue
+++ b/src/components/OAuthConnectButton.vue
@@ -33,47 +33,15 @@ export default {
 	},
 
 	methods: {
-		generateRandomString(length) {
-			let text = ''
-			const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~'
-			for (let i = 0; i < length; i++) {
-				text += possible.charAt(Math.floor(Math.random() * possible.length))
-			}
-			return text
-		},
-		async digest(text) {
-			return await crypto.subtle.digest('SHA-256', new TextEncoder().encode(text))
-		},
-		async generateCodeChallenge(codeVerifier) {
-			const digest = await this.digest(codeVerifier)
-			return btoa(String.fromCharCode(...new Uint8Array(digest)))
-				.replace(/=/g, '')
-				.replace(/\+/g, '-')
-				.replace(/\//g, '_')
-		},
 		async onOAuthClick() {
-			const oauthState = this.generateRandomString(10)
-			const codeVerifier = this.generateRandomString(128)
-			const codeChallenge = await this.generateCodeChallenge(codeVerifier)
-			const requestUrl = this.requestUrl
-				+ '&state=' + encodeURIComponent(oauthState)
-				+ '&code_challenge=' + codeChallenge
-				+ '&code_challenge_method=S256'
-
-			const req = {
-				values: {
-					oauth_state: oauthState,
-					code_verifier: codeVerifier,
-				},
-			}
-			const url = generateUrl('/apps/integration_openproject/config')
-			axios.put(url, req)
-				.then(() => {
-					window.location.replace(requestUrl)
+			const url = generateUrl('/apps/integration_openproject/op-oauth-url')
+			axios.get(url)
+				.then((result) => {
+					window.location.replace(result.data)
 				})
 				.catch((error) => {
 					showError(
-						t('integration_openproject', 'Failed to save OpenProject OAuth state')
+						t('integration_openproject', 'Failed to redirect to OpenProject')
 						+ ': ' + error.message
 					)
 				})

--- a/tests/jest/components/OAuthConnectButton.spec.js
+++ b/tests/jest/components/OAuthConnectButton.spec.js
@@ -13,7 +13,6 @@ const localVue = createLocalVue()
 
 describe('OAuthConnectButton.vue Test', () => {
 	let wrapper
-	let generateCodeChallengeSpy
 	afterEach(() => {
 		window.location = location
 		jest.clearAllMocks()
@@ -28,69 +27,37 @@ describe('OAuthConnectButton.vue Test', () => {
 		beforeEach(() => {
 			delete window.location
 			window.location = { replace: jest.fn() }
-			OAuthConnectButton.methods.digest = jest.fn(
-				() => Promise.resolve(new ArrayBuffer(8))
-			)
-			generateCodeChallengeSpy = jest.spyOn(
-				OAuthConnectButton.methods, 'generateCodeChallenge'
-			)
 			wrapper = getWrapper()
 		})
-		describe('on successful saving of the state & challenge', () => {
+		describe('on successful retrieving of the OP OAuth URI', () => {
 			beforeEach(() => {
-				axios.put.mockImplementationOnce(() =>
-					Promise.resolve({}),
-				)
-			})
-			it('saves the state to user config', async () => {
-				wrapper.find('button').trigger('click')
-				await localVue.nextTick()
-				expect(axios.put).toHaveBeenCalledWith(
-					'http://localhost/apps/integration_openproject/config',
-					{
-						values: {
-							oauth_state: expect.stringMatching(/[A-Za-z0-9\-._~]{10}/),
-							code_verifier: expect.stringMatching(/[A-Za-z0-9\-._~]{128}/),
-						},
-					},
+				axios.get.mockImplementationOnce(() =>
+					Promise.resolve({ data: 'http://openproject/oauth' }),
 				)
 			})
 			it('redirects to the openproject oauth uri', async () => {
 				wrapper.find('button').trigger('click')
 				await localVue.nextTick()
-				expect(generateCodeChallengeSpy).toHaveBeenCalledTimes(1)
-				await localVue.nextTick()
 				expect(window.location.replace).toHaveBeenCalledWith(
-					expect.stringMatching(
-						/http:\/\/openproject\/oauth\/&state=[A-Za-z0-9\-._~]{10}&code_challenge=A{11}&code_challenge_method=S256/
-					),
+					'http://openproject/oauth',
 				)
 			})
 		})
-		describe('on unsuccessful saving of the state', () => {
+		describe('on unsuccessful retrieving of the OP OAuth URI', () => {
 			beforeEach(() => {
 				const err = new Error()
 				err.message = 'some issue'
-				axios.put.mockRejectedValueOnce(err)
+				axios.get.mockRejectedValueOnce(err)
 			})
 			it('shows an error', async () => {
 				dialogs.showError.mockImplementationOnce()
 				wrapper.find('button').trigger('click')
 				await localVue.nextTick()
-				expect(generateCodeChallengeSpy).toHaveBeenCalledTimes(1)
-				await localVue.nextTick()
 				expect(dialogs.showError).toHaveBeenCalledWith(
-					'Failed to save OpenProject OAuth state: some issue'
+					'Failed to redirect to OpenProject: some issue'
 				)
 				expect(window.location.replace).not.toHaveBeenCalled()
 			})
-		})
-		it('generates a random string', () => {
-			const r1 = wrapper.vm.generateRandomString(128)
-			const r2 = wrapper.vm.generateRandomString(128)
-			expect(r1).not.toEqual(r2)
-			expect(r1).toMatch(/[A-Za-z0-9\-._~]{128}/)
-			expect(r2).toMatch(/[A-Za-z0-9\-._~]{128}/)
 		})
 	})
 })

--- a/tests/lib/Controller/OpenProjectAPIControllerTest.php
+++ b/tests/lib/Controller/OpenProjectAPIControllerTest.php
@@ -18,6 +18,7 @@ use OCP\Http\Client\IResponse;
 use OCP\IConfig;
 use OCP\IRequest;
 use OCP\AppFramework\Http;
+use OCP\IURLGenerator;
 use PHPUnit\Framework\TestCase;
 use Exception;
 use OCP\Files\NotFoundException;
@@ -30,11 +31,16 @@ class OpenProjectAPIControllerTest extends TestCase {
 	private $requestMock;
 
 	/**
+	 * @var IURLGenerator
+	 */
+	private $urlGeneratorMock;
+	/**
 	 * @return void
 	 * @before
 	 */
 	public function setUpMocks(): void {
 		$this->requestMock = $this->createMock(IRequest::class);
+		$this->urlGeneratorMock = $this->createMock(IURLGenerator::class);
 		$this->configMock = $this->getMockBuilder(IConfig::class)->getMock();
 		$this->configMock
 			->method('getAppValue')
@@ -71,7 +77,12 @@ class OpenProjectAPIControllerTest extends TestCase {
 			->willReturn(['some' => 'data']);
 
 		$controller = new OpenProjectAPIController(
-			'integration_openproject', $this->requestMock, $this->configMock, $service, 'test',
+			'integration_openproject',
+			$this->requestMock,
+			$this->configMock,
+			$service,
+			$this->urlGeneratorMock,
+			'test',
 		);
 		$response = $controller->getNotifications();
 		$this->assertSame(Http::STATUS_OK, $response->getStatus());
@@ -85,7 +96,12 @@ class OpenProjectAPIControllerTest extends TestCase {
 		$this->getUserValueMock('');
 		$service = $this->createMock(OpenProjectAPIService::class);
 		$controller = new OpenProjectAPIController(
-			'integration_openproject', $this->requestMock, $this->configMock, $service, 'test'
+			'integration_openproject',
+			$this->requestMock,
+			$this->configMock,
+			$service,
+			$this->urlGeneratorMock,
+			'test'
 		);
 		$response = $controller->getNotifications();
 		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
@@ -104,7 +120,12 @@ class OpenProjectAPIControllerTest extends TestCase {
 			->willReturn(['error' => 'something went wrong']);
 
 		$controller = new OpenProjectAPIController(
-			'integration_openproject', $this->requestMock, $this->configMock, $service, 'test'
+			'integration_openproject',
+			$this->requestMock,
+			$this->configMock,
+			$service,
+			$this->urlGeneratorMock,
+			'test'
 		);
 		$response = $controller->getNotifications();
 		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
@@ -130,6 +151,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 			$this->requestMock,
 			$this->configMock,
 			$service,
+			$this->urlGeneratorMock,
 			'test'
 		);
 		$response = $controller->getOpenProjectAvatar('id', 'name');
@@ -159,7 +181,12 @@ class OpenProjectAPIControllerTest extends TestCase {
 			)
 			->willReturn(['avatar' => 'some image data']);
 		$controller = new OpenProjectAPIController(
-			'integration_openproject', $this->requestMock, $this->configMock, $service, 'test'
+			'integration_openproject',
+			$this->requestMock,
+			$this->configMock,
+			$service,
+			$this->urlGeneratorMock,
+			'test'
 		);
 		$response = $controller->getOpenProjectAvatar('id', 'name');
 		$this->assertSame('some image data', $response->render());
@@ -204,7 +231,12 @@ class OpenProjectAPIControllerTest extends TestCase {
 			->willReturn($expectedResponse);
 
 		$controller = new OpenProjectAPIController(
-			'integration_openproject', $this->requestMock, $this->configMock, $service, 'test'
+			'integration_openproject',
+			$this->requestMock,
+			$this->configMock,
+			$service,
+			$this->urlGeneratorMock,
+			'test'
 		);
 		$response = $controller->getSearchedWorkPackages($searchQuery, $fileId);
 		$this->assertSame(Http::STATUS_OK, $response->getStatus());
@@ -219,7 +251,12 @@ class OpenProjectAPIControllerTest extends TestCase {
 		$this->getUserValueMock('');
 		$service = $this->createMock(OpenProjectAPIService::class);
 		$controller = new OpenProjectAPIController(
-			'integration_openproject', $this->requestMock, $this->configMock, $service, 'test'
+			'integration_openproject',
+			$this->requestMock,
+			$this->configMock,
+			$service,
+			$this->urlGeneratorMock,
+			'test'
 		);
 		$response = $controller->getSearchedWorkPackages('test');
 		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
@@ -238,7 +275,12 @@ class OpenProjectAPIControllerTest extends TestCase {
 			->willReturn(['error' => 'something went wrong']);
 
 		$controller = new OpenProjectAPIController(
-			'integration_openproject', $this->requestMock, $this->configMock, $service, 'test'
+			'integration_openproject',
+			$this->requestMock,
+			$this->configMock,
+			$service,
+			$this->urlGeneratorMock,
+			'test'
 		);
 		$response = $controller->getSearchedWorkPackages('test');
 		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
@@ -262,7 +304,12 @@ class OpenProjectAPIControllerTest extends TestCase {
 			]);
 
 		$controller = new OpenProjectAPIController(
-			'integration_openproject', $this->requestMock, $this->configMock, $service, 'test'
+			'integration_openproject',
+			$this->requestMock,
+			$this->configMock,
+			$service,
+			$this->urlGeneratorMock,
+			'test'
 		);
 		$response = $controller->getOpenProjectWorkPackageStatus('7');
 		$this->assertSame(Http::STATUS_OK, $response->getStatus());
@@ -279,7 +326,12 @@ class OpenProjectAPIControllerTest extends TestCase {
 		$this->getUserValueMock('');
 		$service = $this->createMock(OpenProjectAPIService::class);
 		$controller = new OpenProjectAPIController(
-			'integration_openproject', $this->requestMock, $this->configMock, $service, 'test'
+			'integration_openproject',
+			$this->requestMock,
+			$this->configMock,
+			$service,
+			$this->urlGeneratorMock,
+			'test'
 		);
 		$response = $controller->getOpenProjectWorkPackageStatus('7');
 		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
@@ -298,7 +350,12 @@ class OpenProjectAPIControllerTest extends TestCase {
 			->willReturn(['error' => 'something went wrong']);
 
 		$controller = new OpenProjectAPIController(
-			'integration_openproject', $this->requestMock, $this->configMock, $service, 'test'
+			'integration_openproject',
+			$this->requestMock,
+			$this->configMock,
+			$service,
+			$this->urlGeneratorMock,
+			'test'
 		);
 		$response = $controller->getOpenProjectWorkPackageStatus('7');
 		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
@@ -320,7 +377,12 @@ class OpenProjectAPIControllerTest extends TestCase {
 				"color" => "#CC5DE8", "position" => 4, "isDefault" => true, "isMilestone" => false, "createdAt" => "2022-01-12T08:53:15Z", "updatedAt" => "2022-01-12T08:53:34Z"]);
 
 		$controller = new OpenProjectAPIController(
-			'integration_openproject', $this->requestMock, $this->configMock, $service, 'test'
+			'integration_openproject',
+			$this->requestMock,
+			$this->configMock,
+			$service,
+			$this->urlGeneratorMock,
+			'test'
 		);
 		$response = $controller->getOpenProjectWorkPackageType('3');
 		$this->assertSame(Http::STATUS_OK, $response->getStatus());
@@ -335,7 +397,12 @@ class OpenProjectAPIControllerTest extends TestCase {
 		$this->getUserValueMock('');
 		$service = $this->createMock(OpenProjectAPIService::class);
 		$controller = new OpenProjectAPIController(
-			'integration_openproject', $this->requestMock, $this->configMock, $service, 'test'
+			'integration_openproject',
+			$this->requestMock,
+			$this->configMock,
+			$service,
+			$this->urlGeneratorMock,
+			'test'
 		);
 		$response = $controller->getOpenProjectWorkPackageType('3');
 		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
@@ -354,7 +421,12 @@ class OpenProjectAPIControllerTest extends TestCase {
 			->willReturn(['error' => 'something went wrong']);
 
 		$controller = new OpenProjectAPIController(
-			'integration_openproject', $this->requestMock, $this->configMock, $service, 'test'
+			'integration_openproject',
+			$this->requestMock,
+			$this->configMock,
+			$service,
+			$this->urlGeneratorMock,
+			'test'
 		);
 		$response = $controller->getOpenProjectWorkPackageType('3');
 		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
@@ -381,7 +453,12 @@ class OpenProjectAPIControllerTest extends TestCase {
 			]]);
 
 		$controller = new OpenProjectAPIController(
-			'integration_openproject', $this->requestMock, $this->configMock, $service, 'test'
+			'integration_openproject',
+			$this->requestMock,
+			$this->configMock,
+			$service,
+			$this->urlGeneratorMock,
+			'test'
 		);
 		$response = $controller->getWorkPackageFileLinks(7);
 		$this->assertSame(Http::STATUS_OK, $response->getStatus());
@@ -401,7 +478,12 @@ class OpenProjectAPIControllerTest extends TestCase {
 		$this->getUserValueMock('');
 		$service = $this->createMock(OpenProjectAPIService::class);
 		$controller = new OpenProjectAPIController(
-			'integration_openproject', $this->requestMock, $this->configMock, $service, 'test'
+			'integration_openproject',
+			$this->requestMock,
+			$this->configMock,
+			$service,
+			$this->urlGeneratorMock,
+			'test'
 		);
 		$response = $controller->getWorkPackageFileLinks(7);
 		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
@@ -419,7 +501,12 @@ class OpenProjectAPIControllerTest extends TestCase {
 			->method('getWorkPackageFileLinks')
 			->willThrowException(new NotFoundException('work package not found'));
 		$controller = new OpenProjectAPIController(
-			'integration_openproject', $this->requestMock, $this->configMock, $service, 'test'
+			'integration_openproject',
+			$this->requestMock,
+			$this->configMock,
+			$service,
+			$this->urlGeneratorMock,
+			'test'
 		);
 		$response = $controller->getWorkPackageFileLinks(7);
 		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
@@ -438,7 +525,12 @@ class OpenProjectAPIControllerTest extends TestCase {
 			->method('getWorkPackageFileLinks')
 			->willThrowException(new Exception('something went wrong'));
 		$controller = new OpenProjectAPIController(
-			'integration_openproject', $this->requestMock, $this->configMock, $service, 'test'
+			'integration_openproject',
+			$this->requestMock,
+			$this->configMock,
+			$service,
+			$this->urlGeneratorMock,
+			'test'
 		);
 		$response = $controller->getWorkPackageFileLinks(7);
 		$this->assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
@@ -459,7 +551,12 @@ class OpenProjectAPIControllerTest extends TestCase {
 			->willReturn(['success' => true]);
 
 		$controller = new OpenProjectAPIController(
-			'integration_openproject', $this->requestMock, $this->configMock, $service, 'test'
+			'integration_openproject',
+			$this->requestMock,
+			$this->configMock,
+			$service,
+			$this->urlGeneratorMock,
+			'test'
 		);
 		$response = $controller->deleteFileLink(7);
 		$this->assertSame(Http::STATUS_OK, $response->getStatus());
@@ -473,7 +570,12 @@ class OpenProjectAPIControllerTest extends TestCase {
 		$this->getUserValueMock('');
 		$service = $this->createMock(OpenProjectAPIService::class);
 		$controller = new OpenProjectAPIController(
-			'integration_openproject', $this->requestMock, $this->configMock, $service, 'test'
+			'integration_openproject',
+			$this->requestMock,
+			$this->configMock,
+			$service,
+			$this->urlGeneratorMock,
+			'test'
 		);
 		$response = $controller->deleteFileLink(7);
 		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
@@ -491,7 +593,12 @@ class OpenProjectAPIControllerTest extends TestCase {
 			->method('deleteFileLink')
 			->willThrowException(new NotFoundException('file not found'));
 		$controller = new OpenProjectAPIController(
-			'integration_openproject', $this->requestMock, $this->configMock, $service, 'test'
+			'integration_openproject',
+			$this->requestMock,
+			$this->configMock,
+			$service,
+			$this->urlGeneratorMock,
+			'test'
 		);
 		$response = $controller->deleteFileLink(7);
 		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
@@ -510,7 +617,12 @@ class OpenProjectAPIControllerTest extends TestCase {
 			->method('deleteFileLink')
 			->willThrowException(new Exception('something went wrong'));
 		$controller = new OpenProjectAPIController(
-			'integration_openproject', $this->requestMock, $this->configMock, $service, 'test'
+			'integration_openproject',
+			$this->requestMock,
+			$this->configMock,
+			$service,
+			$this->urlGeneratorMock,
+			'test'
 		);
 		$response = $controller->deleteFileLink(7);
 		$this->assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
@@ -546,7 +658,12 @@ class OpenProjectAPIControllerTest extends TestCase {
 			->method('rawRequest')
 			->willReturn($response);
 		$controller = new OpenProjectAPIController(
-			'integration_openproject', $this->requestMock, $this->configMock, $service, 'test'
+			'integration_openproject',
+			$this->requestMock,
+			$this->configMock,
+			$service,
+			$this->urlGeneratorMock,
+			'test'
 		);
 		$result = $controller->isValidOpenProjectInstance('http://openproject.org');
 		$this->assertSame($expectedResult, $result->getData());
@@ -622,7 +739,12 @@ class OpenProjectAPIControllerTest extends TestCase {
 			->method('rawRequest')
 			->willThrowException($thrownException);
 		$controller = new OpenProjectAPIController(
-			'integration_openproject', $this->requestMock, $this->configMock, $service, 'test'
+			'integration_openproject',
+			$this->requestMock,
+			$this->configMock,
+			$service,
+			$this->urlGeneratorMock,
+			'test'
 		);
 		$result = $controller->isValidOpenProjectInstance('http://openproject.org');
 		$this->assertSame($expectedResult, $result->getData());
@@ -649,7 +771,12 @@ class OpenProjectAPIControllerTest extends TestCase {
 			->onlyMethods([])
 			->getMock();
 		$controller = new OpenProjectAPIController(
-			'integration_openproject', $this->requestMock, $this->configMock, $service, 'test'
+			'integration_openproject',
+			$this->requestMock,
+			$this->configMock,
+			$service,
+			$this->urlGeneratorMock,
+			'test'
 		);
 		$result = $controller->isValidOpenProjectInstance($url);
 		$this->assertFalse($result->getData());


### PR DESCRIPTION
creating the PKCE code verifier and challenge in the frontend does not work reliable because the `crypto.subtle` only works in secure context see https://developer.mozilla.org/en-US/docs/Web/API/Crypto/subtle

So in this PR I moved generating the state and the PKCE values into the backend that returns the complete URL to the frontend

should fix https://community.openproject.org/projects/nextcloud-integration/work_packages/details/42915