### PR TITLE
[OP#42922] only show copy button when copy to clipboard is possible

### DIFF
--- a/src/components/admin/TextInput.vue
+++ b/src/components/admin/TextInput.vue
@@ -25,9 +25,9 @@
 					v-html="hintText" />
 			</div>
 		</div>
-		<button v-if="withCopyBtn"
+		<button v-if="showCopyButton"
 			class="text-input-copy-value"
-			:disabled="isCopyDisabled"
+			:disabled="isInputFieldEmpty"
 			:title="copyButtonTooltip"
 			@click="copyValue">
 			<div class="text-input-icon icon-clippy" />
@@ -94,8 +94,11 @@ export default {
 				return `${this.label} *`
 			} else return this.label
 		},
-		isCopyDisabled() {
+		isInputFieldEmpty() {
 			return !this.value
+		},
+		showCopyButton() {
+			return (this.withCopyBtn && navigator.clipboard)
 		},
 		copyButtonTooltip() {
 			if (this.isCopied) {


### PR DESCRIPTION
copy to clipboard is only possible in secure context, see https://developer.mozilla.org/en-US/docs/Web/API/Clipboard
so in not secure contexts the user will have to copy manually

fixes, or avoids the problem of https://community.openproject.org/projects/nextcloud-integration/work_packages/42922
