### PR TITLE
[#42911] UI/UX improvements: use grey color for readonly input fields

### DIFF
--- a/src/components/admin/TextInput.vue
+++ b/src/components/admin/TextInput.vue
@@ -167,6 +167,11 @@ export default {
 		background-position: center;
 	}
 
+	input[data-focus-visible-added].text-input-error {
+		outline: none;
+		box-shadow: none;
+	}
+
 	&-copy-value {
 		cursor: copy;
 		display: flex;
@@ -178,24 +183,19 @@ export default {
 			margin-left: 6px;
 		}
 	}
+
 	&-readonly {
 		cursor: default;
-		outline: none !important;
-		border: 1px solid grey !important;
+		outline: none;
 		box-shadow: none !important;
-		background-color: transparent !important;
+		border: 1px solid grey !important;
 	}
-}
-
-input[data-focus-visible-added].text-input-error {
-	outline: none;
-	box-shadow: none;
 }
 
 body[data-theme-dark-highcontrast], body[data-theme-dark], body.theme--dark {
 	.text-input {
 		&-label {
-			color: #FFFFFF;
+			filter: invert(100%);
 		}
 	}
 }

--- a/src/components/admin/TextInput.vue
+++ b/src/components/admin/TextInput.vue
@@ -9,7 +9,10 @@
 				:value="value"
 				:type="type"
 				:readonly="readOnly"
-				:class="{'text-input-error': !!errorMessage}"
+				:class="{
+					'text-input-error': !!errorMessage,
+					'text-input-readonly': readOnly
+				}"
 				:placeholder="placeHolder"
 				@click="$emit('click', $event)"
 				@input="$emit('input', $event.target.value)"
@@ -164,11 +167,6 @@ export default {
 		background-position: center;
 	}
 
-	input[data-focus-visible-added].text-input-error {
-		outline: none;
-		box-shadow: none;
-	}
-
 	&-copy-value {
 		cursor: copy;
 		display: flex;
@@ -180,6 +178,18 @@ export default {
 			margin-left: 6px;
 		}
 	}
+	&-readonly {
+		cursor: default;
+		outline: none !important;
+		border: 1px solid grey !important;
+		box-shadow: none !important;
+		background-color: transparent !important;
+	}
+}
+
+input[data-focus-visible-added].text-input-error {
+	outline: none;
+	box-shadow: none;
 }
 
 body[data-theme-dark-highcontrast], body[data-theme-dark], body.theme--dark {

--- a/tests/jest/components/__snapshots__/AdminSettings.spec.js.snap
+++ b/tests/jest/components/__snapshots__/AdminSettings.spec.js.snap
@@ -105,14 +105,14 @@ exports[`AdminSettings server host url form edit mode cancel button should be vi
 
 exports[`AdminSettings server host url form edit mode readonly state should clear the readonly state when clicked on the input 1`] = `<input id="openproject-oauth-instance" type="text" placeholder="https://www.my-openproject.com" class="">`;
 
-exports[`AdminSettings server host url form edit mode readonly state should set the input field to readonly at first 1`] = `<input id="openproject-oauth-instance" type="text" readonly="readonly" placeholder="https://www.my-openproject.com" class="">`;
+exports[`AdminSettings server host url form edit mode readonly state should set the input field to readonly at first 1`] = `<input id="openproject-oauth-instance" type="text" readonly="readonly" placeholder="https://www.my-openproject.com" class="text-input-readonly">`;
 
 exports[`AdminSettings server host url form edit mode submit button should set the input to error state when the url is invalid when clicked 1`] = `
 <div class="text-input-wrapper pb-2">
   <div class="text-input">
     <div class="text-input-label">
       OpenProject host *
-    </div> <input id="openproject-oauth-instance" type="text" readonly="readonly" placeholder="https://www.my-openproject.com" class="text-input-error">
+    </div> <input id="openproject-oauth-instance" type="text" readonly="readonly" placeholder="https://www.my-openproject.com" class="text-input-error text-input-readonly">
     <div>
       <div class="text-input-error-message">
         Please introduce a valid OpenProject host name

--- a/tests/jest/components/admin/TextInput.spec.js
+++ b/tests/jest/components/admin/TextInput.spec.js
@@ -109,6 +109,14 @@ describe('TextInput', () => {
 			})
 		})
 	})
+	describe("readonly prop", () => {
+		it('should set the input to readonly', () => {
+			const wrapper = getWrapper({
+				readOnly: true,
+			})
+			expect(wrapper).toMatchSnapshot()
+		})
+	})
 })
 
 function getWrapper(props = {}) {

--- a/tests/jest/components/admin/TextInput.spec.js
+++ b/tests/jest/components/admin/TextInput.spec.js
@@ -109,7 +109,7 @@ describe('TextInput', () => {
 			})
 		})
 	})
-	describe("readonly prop", () => {
+	describe('readonly prop', () => {
 		it('should set the input to readonly', () => {
 			const wrapper = getWrapper({
 				readOnly: true,

--- a/tests/jest/components/admin/__snapshots__/TextInput.spec.js.snap
+++ b/tests/jest/components/admin/__snapshots__/TextInput.spec.js.snap
@@ -58,6 +58,18 @@ exports[`TextInput messages should show hint text if provided 1`] = `
 </div>
 `;
 
+exports[`TextInput readonly prop should set the input to readonly 1`] = `
+<div class="text-input-wrapper">
+  <div class="text-input">
+    <div class="text-input-label">
+      some label
+    </div> <input id="unique-id" type="text" readonly="readonly" placeholder="" class="text-input-readonly">
+    <!---->
+  </div>
+  <!---->
+</div>
+`;
+
 exports[`TextInput with copy button prop should render copy button if set 1`] = `
 <div class="text-input-wrapper">
   <div class="text-input">


### PR DESCRIPTION
**Description:** use a grey border for the input when set to `read-only` mode

**Related:** Should fix https://community.openproject.org/work_packages/42911

**Screenshots:**
![Screenshot from 2022-06-20 15-27-09](https://user-images.githubusercontent.com/39373750/174574405-a17fd33c-e485-4ead-a4f7-081316e21cc5.png)
![Screenshot from 2022-06-20 15-27-39](https://user-images.githubusercontent.com/39373750/174574434-bc9cfdc7-8daf-452e-b43d-0cf202e7ebe6.png)
![Screenshot from 2022-06-20 15-28-05](https://user-images.githubusercontent.com/39373750/174574449-548069eb-46ed-4257-957e-bc4e0bdf3d67.png)


Signed-off-by: Kiran Parajuli <kiranparajuli589@gmail.com>