### PR TITLE
[#OP42916] Remove requestUrl from front-end

### DIFF
--- a/lib/Dashboard/OpenProjectWidget.php
+++ b/lib/Dashboard/OpenProjectWidget.php
@@ -120,10 +120,10 @@ class OpenProjectWidget implements IWidget {
 		Util::addStyle(Application::APP_ID, 'dashboard');
 
 		try {
-			$requestUrl = OpenProjectAPIService::getOpenProjectOauthURL($this->config, $this->url);
-			$this->initialStateService->provideInitialState('request-url', $requestUrl);
+			$adminConfigStatus = OpenProjectAPIService::isAdminConfigOk($this->config);
+			$this->initialStateService->provideInitialState('admin-config-status', $adminConfigStatus);
 		} catch (\Exception $e) {
-			$this->initialStateService->provideInitialState('request-url', false);
+			$this->initialStateService->provideInitialState('admin-config-status', false);
 		}
 		$oauthConnectionResult = $this->config->getUserValue(
 			$this->user->getUID(), Application::APP_ID, 'oauth_connection_result'

--- a/lib/Dashboard/OpenProjectWidget.php
+++ b/lib/Dashboard/OpenProjectWidget.php
@@ -119,12 +119,8 @@ class OpenProjectWidget implements IWidget {
 		Util::addScript(Application::APP_ID, Application::APP_ID . '-dashboard');
 		Util::addStyle(Application::APP_ID, 'dashboard');
 
-		try {
-			$adminConfigStatus = OpenProjectAPIService::isAdminConfigOk($this->config);
-			$this->initialStateService->provideInitialState('admin-config-status', $adminConfigStatus);
-		} catch (\Exception $e) {
-			$this->initialStateService->provideInitialState('admin-config-status', false);
-		}
+		$this->initialStateService->provideInitialState('admin-config-status', OpenProjectAPIService::isAdminConfigOk($this->config));
+
 		$oauthConnectionResult = $this->config->getUserValue(
 			$this->user->getUID(), Application::APP_ID, 'oauth_connection_result'
 		);

--- a/lib/Listener/LoadSidebarScript.php
+++ b/lib/Listener/LoadSidebarScript.php
@@ -34,16 +34,11 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\IConfig;
 use OCP\IRequest;
-use OCP\IURLGenerator;
 use OCP\IUserSession;
 use OCP\Util;
 
 class LoadSidebarScript implements IEventListener {
 
-	/**
-	 * @var IURLGenerator
-	 */
-	private $url;
 	/**
 	 * @var IInitialState
 	 */
@@ -64,13 +59,11 @@ class LoadSidebarScript implements IEventListener {
 
 	public function __construct(
 		IInitialState $initialStateService,
-		IURLGenerator $url,
 		IConfig $config,
 		IUserSession $userSession
 	) {
 		$this->initialStateService = $initialStateService;
 		$this->config = $config;
-		$this->url = $url;
 		$user = $userSession->getUser();
 		if (strpos(\OC::$server->get(IRequest::class)->getRequestUri(), 'files') !== false) {
 			$this->oauthConnectionResult = $this->config->getUserValue(

--- a/lib/Listener/LoadSidebarScript.php
+++ b/lib/Listener/LoadSidebarScript.php
@@ -103,10 +103,10 @@ class LoadSidebarScript implements IEventListener {
 		Util::addStyle(Application::APP_ID, 'tab');
 
 		try {
-			$requestUrl = OpenProjectAPIService::getOpenProjectOauthURL($this->config, $this->url);
-			$this->initialStateService->provideInitialState('request-url', $requestUrl);
+			$adminConfigStatus = OpenProjectAPIService::isAdminConfigOk($this->config);
+			$this->initialStateService->provideInitialState('admin-config-status', $adminConfigStatus);
 		} catch (\Exception $e) {
-			$this->initialStateService->provideInitialState('request-url', false);
+			$this->initialStateService->provideInitialState('admin-config-status', false);
 		}
 
 		$this->initialStateService->provideInitialState(

--- a/lib/Listener/LoadSidebarScript.php
+++ b/lib/Listener/LoadSidebarScript.php
@@ -95,12 +95,7 @@ class LoadSidebarScript implements IEventListener {
 		}
 		Util::addStyle(Application::APP_ID, 'tab');
 
-		try {
-			$adminConfigStatus = OpenProjectAPIService::isAdminConfigOk($this->config);
-			$this->initialStateService->provideInitialState('admin-config-status', $adminConfigStatus);
-		} catch (\Exception $e) {
-			$this->initialStateService->provideInitialState('admin-config-status', false);
-		}
+		$this->initialStateService->provideInitialState('admin-config-status', OpenProjectAPIService::isAdminConfigOk($this->config));
 
 		$this->initialStateService->provideInitialState(
 			'oauth-connection-result', $this->oauthConnectionResult

--- a/lib/Settings/Personal.php
+++ b/lib/Settings/Personal.php
@@ -60,10 +60,10 @@ class Personal implements ISettings {
 		];
 
 		try {
-			$requestUrl = OpenProjectAPIService::getOpenProjectOauthURL($this->config, $this->url);
-			$userConfig['request_url'] = $requestUrl;
+			$adminConfigStatus = OpenProjectAPIService::isAdminConfigOk($this->config);
+			$userConfig['isAdminConfigOk'] = $adminConfigStatus;
 		} catch (\Exception $e) {
-			$userConfig['request_url'] = false;
+			$userConfig['isAdminConfigOk'] = false;
 		} finally {
 			$this->initialStateService->provideInitialState('user-config', $userConfig);
 		}

--- a/lib/Settings/Personal.php
+++ b/lib/Settings/Personal.php
@@ -61,9 +61,9 @@ class Personal implements ISettings {
 
 		try {
 			$adminConfigStatus = OpenProjectAPIService::isAdminConfigOk($this->config);
-			$userConfig['isAdminConfigOk'] = $adminConfigStatus;
+			$userConfig['admin_config_ok'] = $adminConfigStatus;
 		} catch (\Exception $e) {
-			$userConfig['isAdminConfigOk'] = false;
+			$userConfig['admin_config_ok'] = false;
 		} finally {
 			$this->initialStateService->provideInitialState('user-config', $userConfig);
 		}

--- a/lib/Settings/Personal.php
+++ b/lib/Settings/Personal.php
@@ -53,14 +53,8 @@ class Personal implements ISettings {
 			'user_name' => $userName,
 		];
 
-		try {
-			$adminConfigStatus = OpenProjectAPIService::isAdminConfigOk($this->config);
-			$userConfig['admin_config_ok'] = $adminConfigStatus;
-		} catch (\Exception $e) {
-			$userConfig['admin_config_ok'] = false;
-		} finally {
-			$this->initialStateService->provideInitialState('user-config', $userConfig);
-		}
+		$userConfig['admin_config_ok'] = OpenProjectAPIService::isAdminConfigOk($this->config);
+		$this->initialStateService->provideInitialState('user-config', $userConfig);
 
 		$oauthConnectionResult = $this->config->getUserValue(
 			$this->userId, Application::APP_ID, 'oauth_connection_result'

--- a/lib/Settings/Personal.php
+++ b/lib/Settings/Personal.php
@@ -5,7 +5,6 @@ namespace OCA\OpenProject\Settings;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\IConfig;
-use OCP\IURLGenerator;
 use OCP\Settings\ISettings;
 
 use OCA\OpenProject\AppInfo\Application;
@@ -25,19 +24,14 @@ class Personal implements ISettings {
 	 * @var string|null
 	 */
 	private $userId;
-	/**
-	 * @var IURLGenerator
-	 */
-	private $url;
+
 
 	public function __construct(
 								IConfig $config,
 								IInitialState $initialStateService,
-								IURLGenerator $url,
 								?string $userId) {
 		$this->config = $config;
 		$this->initialStateService = $initialStateService;
-		$this->url = $url;
 		$this->userId = $userId;
 	}
 

--- a/src/components/OAuthConnectButton.vue
+++ b/src/components/OAuthConnectButton.vue
@@ -1,5 +1,5 @@
 <template>
-	<button v-if="!!requestUrl"
+	<button v-if="!!isAdminConfigOk"
 		class="oauth-connect--button"
 		@click="onOAuthClick">
 		<span class="icon icon-external" />
@@ -19,8 +19,8 @@ export default {
 	name: 'OAuthConnectButton',
 
 	props: {
-		requestUrl: {
-			type: [String, Boolean],
+		isAdminConfigOk: {
+			type: Boolean,
 			required: true,
 		},
 		fileInfo: {

--- a/src/components/PersonalSettings.vue
+++ b/src/components/PersonalSettings.vue
@@ -40,7 +40,7 @@
 					@input="onNotificationChange">
 				<label for="notification-openproject">{{ t('integration_openproject', 'Enable notifications for activity in my work packages') }}</label>
 			</div>
-			<OAuthConnectButton v-else :request-url="requestUrl" />
+			<OAuthConnectButton v-else :is-admin-config-ok="state.isAdminConfigOk" />
 		</div>
 	</div>
 </template>
@@ -73,11 +73,8 @@ export default {
 	},
 
 	computed: {
-		requestUrl() {
-			return this.state.request_url
-		},
 		connected() {
-			if (!this.requestUrl) return false
+			if (!this.state.isAdminConfigOk) return false
 			return this.state.token && this.state.token !== ''
 				&& this.state.user_name && this.state.user_name !== ''
 		},

--- a/src/components/PersonalSettings.vue
+++ b/src/components/PersonalSettings.vue
@@ -40,7 +40,7 @@
 					@input="onNotificationChange">
 				<label for="notification-openproject">{{ t('integration_openproject', 'Enable notifications for activity in my work packages') }}</label>
 			</div>
-			<OAuthConnectButton v-else :is-admin-config-ok="state.isAdminConfigOk" />
+			<OAuthConnectButton v-else :is-admin-config-ok="state.admin_config_ok" />
 		</div>
 	</div>
 </template>
@@ -74,7 +74,7 @@ export default {
 
 	computed: {
 		connected() {
-			if (!this.state.isAdminConfigOk) return false
+			if (!this.state.admin_config_ok) return false
 			return this.state.token && this.state.token !== ''
 				&& this.state.user_name && this.state.user_name !== ''
 		},

--- a/src/components/tab/EmptyContent.vue
+++ b/src/components/tab/EmptyContent.vue
@@ -2,11 +2,11 @@
 	<div class="empty-content">
 		<div class="empty-content--wrapper">
 			<div class="empty-content--icon">
-				<img v-if="!!requestUrl && !isStateOk" :src="noConnectionSvg" alt="no connection">
-				<img v-else-if="!!requestUrl && isStateOk" :src="addLinkSvg" alt="add work package">
+				<img v-if="!!isAdminConfigOk && !isStateOk" :src="noConnectionSvg" alt="no connection">
+				<img v-else-if="!!isAdminConfigOk && isStateOk" :src="addLinkSvg" alt="add work package">
 				<img v-else :src="noConnectionSvg" alt="error">
 			</div>
-			<div v-if="!!requestUrl" class="empty-content--message">
+			<div v-if="!!isAdminConfigOk" class="empty-content--message">
 				<div class="empty-content--message--title">
 					{{ emptyContentTitleMessage }}
 				</div>
@@ -15,7 +15,7 @@
 				</div>
 			</div>
 			<div v-if="showConnectButton" class="empty-content--connect-button">
-				<OAuthConnectButton :request-url="requestUrl" :file-info="fileInfo" />
+				<OAuthConnectButton :is-admin-config-ok="isAdminConfigOk" :file-info="fileInfo" />
 			</div>
 		</div>
 	</div>
@@ -36,8 +36,8 @@ export default {
 			required: true,
 			default: STATE.OK,
 		},
-		requestUrl: {
-			type: [String, Boolean],
+		isAdminConfigOk: {
+			type: Boolean,
 			required: true,
 		},
 		errorMessage: {

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -11,7 +11,7 @@
 						{{ emptyContentMessage }}
 					</div>
 					<div v-if="showOauthConnect" class="connect-button">
-						<OAuthConnectButton :request-url="requestUrl" />
+						<OAuthConnectButton :is-admin-config-ok="isAdminConfigOk" />
 					</div>
 				</template>
 			</EmptyContent>
@@ -52,9 +52,9 @@ export default {
 			notifications: [],
 			loop: null,
 			state: STATE.LOADING,
-			requestUrl: loadState('integration_openproject', 'request-url'),
 			oauthConnectionErrorMessage: loadState('integration_openproject', 'oauth-connection-error-message'),
 			oauthConnectionResult: loadState('integration_openproject', 'oauth-connection-result'),
+			isAdminConfigOk: loadState('integration_openproject', 'admin-config-status'),
 			settingsUrl: generateUrl('/settings/user/connected-accounts'),
 			themingColor: OCA.Theming ? OCA.Theming.color.replace('#', '') : '0082C9',
 			windowVisibility: true,
@@ -138,7 +138,7 @@ export default {
 			clearInterval(this.loop)
 		},
 		async launchLoop() {
-			if (!this.requestUrl) {
+			if (!this.isAdminConfigOk) {
 				this.state = STATE.ERROR
 				return
 			}

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -7,7 +7,7 @@
 			<EmptyContent v-if="emptyContentMessage"
 				:icon="emptyContentIcon">
 				<template #desc>
-					<div v-if="!!requestUrl">
+					<div v-if="!!isAdminConfigOk">
 						{{ emptyContentMessage }}
 					</div>
 					<div v-if="showOauthConnect" class="connect-button">

--- a/src/views/ProjectsTab.vue
+++ b/src/views/ProjectsTab.vue
@@ -23,7 +23,7 @@
 <template>
 	<div class="projects"
 		:class="{'projects--empty': filterWorkpackagesByFileId.length === 0}">
-		<SearchInput v-if="!!requestUrl && !isLoading"
+		<SearchInput v-if="!!isAdminConfigOk && !isLoading"
 			:file-info="fileInfo"
 			:linked-work-packages="filterWorkpackagesByFileId"
 			@saved="onSaved" />
@@ -55,7 +55,7 @@
 			id="openproject-empty-content"
 			:state="state"
 			:file-info="fileInfo"
-			:request-url="requestUrl" />
+			:is-admin-config-ok="isAdminConfigOk" />
 	</div>
 </template>
 
@@ -87,9 +87,9 @@ export default {
 		fileInfo: {},
 		state: STATE.LOADING,
 		workpackages: [],
-		requestUrl: loadState('integration_openproject', 'request-url'),
 		oauthConnectionErrorMessage: loadState('integration_openproject', 'oauth-connection-error-message'),
 		oauthConnectionResult: loadState('integration_openproject', 'oauth-connection-result'),
+		isAdminConfigOk: loadState('integration_openproject', 'admin-config-status'),
 		color: null,
 	}),
 	computed: {
@@ -119,7 +119,7 @@ export default {
 			this.fileInfo = fileInfo
 			this.workpackages = []
 			this.state = STATE.LOADING
-			if (this.requestUrl) {
+			if (this.isAdminConfigOk) {
 				// only fetch if we have a request url
 				await this.fetchWorkpackages(this.fileInfo.id)
 			} else {

--- a/tests/jest/components/OAuthConnectButton.spec.js
+++ b/tests/jest/components/OAuthConnectButton.spec.js
@@ -17,13 +17,13 @@ describe('OAuthConnectButton.vue Test', () => {
 		window.location = location
 		jest.clearAllMocks()
 	})
-	describe('when the request url is not valid', () => {
+	describe('when the admin config is not okay', () => {
 		it('should show message', async () => {
-			wrapper = getWrapper({ requestUrl: false })
+			wrapper = getWrapper({ isAdminConfigOk: false })
 			expect(wrapper).toMatchSnapshot()
 		})
 	})
-	describe('when the request url is valid', () => {
+	describe('when the admin config is ok', () => {
 		beforeEach(() => {
 			delete window.location
 			window.location = { replace: jest.fn(), pathname: '/index.php/apps/files/' }
@@ -84,7 +84,7 @@ function getWrapper(props = {}) {
 			t: (app, msg) => msg,
 		},
 		propsData: {
-			requestUrl: 'http://openproject/oauth/',
+			isAdminConfigOk: true,
 			...props,
 		},
 	})

--- a/tests/jest/components/PersonalSettings.spec.js
+++ b/tests/jest/components/PersonalSettings.spec.js
@@ -9,7 +9,7 @@ const localVue = createLocalVue()
 // eslint-disable-next-line no-import-assign
 initialState.loadState = jest.fn(() => {
 	return {
-		request_url: 'https://nextcloud.com/',
+		admin_config_ok: true,
 	}
 })
 
@@ -32,7 +32,7 @@ describe('PersonalSettings.vue Test', () => {
 			})
 		})
 
-		describe('when the request url is valid', () => {
+		describe('when the admin config is okay', () => {
 			describe.each([
 				{ user_name: 'test', token: '' },
 				{ user_name: 'test', token: null },
@@ -47,7 +47,7 @@ describe('PersonalSettings.vue Test', () => {
 				beforeEach(async () => {
 					await wrapper.setData({
 						state: {
-							request_url: 'http://someurl.com',
+							admin_config_ok: true,
 							...cases,
 						},
 					})
@@ -65,7 +65,7 @@ describe('PersonalSettings.vue Test', () => {
 			describe('when username and token are given', () => {
 				beforeEach(async () => {
 					await wrapper.setData({
-						state: { user_name: 'test', token: '123', request_url: 'http://someurl.com' },
+						state: { user_name: 'test', token: '123', admin_config_ok: true },
 					})
 				})
 				it('oAuth connect button is not displayed', () => {
@@ -82,16 +82,16 @@ describe('PersonalSettings.vue Test', () => {
 				})
 			})
 		})
-		describe('when request url is not valid', () => {
+		describe('when the admin config is not okay', () => {
 			beforeEach(async () => {
 				await wrapper.setData({
-					state: { user_name: 'test', token: '123', request_url: false },
+					state: { user_name: 'test', token: '123', admin_config_ok: false },
 				})
 			})
 			it('should set proper props to the oauth connect component', () => {
 				expect(wrapper.find(oAuthButtonSelector).exists()).toBeTruthy()
 				expect(wrapper.find(oAuthButtonSelector).props()).toMatchObject({
-					requestUrl: false,
+					isAdminConfigOk: false,
 				})
 			})
 		})

--- a/tests/jest/components/__snapshots__/OAuthConnectButton.spec.js.snap
+++ b/tests/jest/components/__snapshots__/OAuthConnectButton.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`OAuthConnectButton.vue Test when the request url is not valid should show message 1`] = `
+exports[`OAuthConnectButton.vue Test when the admin config is not okay should show message 1`] = `
 <div class="oauth-connect--message">
   Some OpenProject integration application settings are not working. Please contact your Nextcloud administrator.
 </div>

--- a/tests/jest/components/tab/EmptyContent.spec.js
+++ b/tests/jest/components/tab/EmptyContent.spec.js
@@ -28,8 +28,8 @@ describe('EmptyContent.vue Test', () => {
 		})
 	})
 	describe('content title', () => {
-		it('should not be displayed if the request url is not valid', () => {
-			wrapper = getWrapper({ requestUrl: false })
+		it('should not be displayed if the admin config is not okay', () => {
+			wrapper = getWrapper({ isAdminConfigOk: false })
 			expect(wrapper.find(emptyContentMessageSelector).exists()).toBe(false)
 		})
 		it.each([
@@ -38,7 +38,7 @@ describe('EmptyContent.vue Test', () => {
 			STATE.CONNECTION_ERROR,
 			STATE.FAILED_FETCHING_WORKPACKAGES,
 			STATE.OK,
-		])('shows the correct empty message depending on states if the request url is valid', async (state) => {
+		])('shows the correct empty message depending on states if the admin config is okay', async (state) => {
 			wrapper = getWrapper({ state, adminConfigStatus: true })
 			expect(wrapper.find(emptyContentMessageSelector).exists()).toBeTruthy()
 			expect(wrapper.find(emptyContentMessageSelector)).toMatchSnapshot()
@@ -54,7 +54,7 @@ function getWrapper(propsData = {}) {
 		},
 		propsData: {
 			state: 'ok',
-			requestUrl: 'http://openproject/',
+			isAdminConfigOk: true,
 			...propsData,
 		},
 	})

--- a/tests/jest/components/tab/__snapshots__/EmptyContent.spec.js.snap
+++ b/tests/jest/components/tab/__snapshots__/EmptyContent.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EmptyContent.vue Test content title shows the correct empty message depending on states if the request url is valid 1`] = `
+exports[`EmptyContent.vue Test content title shows the correct empty message depending on states if the admin config is okay 1`] = `
 <div class="empty-content--message">
   <div class="empty-content--message--title">
     No connection with OpenProject
@@ -9,7 +9,7 @@ exports[`EmptyContent.vue Test content title shows the correct empty message dep
 </div>
 `;
 
-exports[`EmptyContent.vue Test content title shows the correct empty message depending on states if the request url is valid 2`] = `
+exports[`EmptyContent.vue Test content title shows the correct empty message depending on states if the admin config is okay 2`] = `
 <div class="empty-content--message">
   <div class="empty-content--message--title">
     Unexpected Error
@@ -18,7 +18,7 @@ exports[`EmptyContent.vue Test content title shows the correct empty message dep
 </div>
 `;
 
-exports[`EmptyContent.vue Test content title shows the correct empty message depending on states if the request url is valid 3`] = `
+exports[`EmptyContent.vue Test content title shows the correct empty message depending on states if the admin config is okay 3`] = `
 <div class="empty-content--message">
   <div class="empty-content--message--title">
     Error connecting to OpenProject
@@ -27,7 +27,7 @@ exports[`EmptyContent.vue Test content title shows the correct empty message dep
 </div>
 `;
 
-exports[`EmptyContent.vue Test content title shows the correct empty message depending on states if the request url is valid 4`] = `
+exports[`EmptyContent.vue Test content title shows the correct empty message depending on states if the admin config is okay 4`] = `
 <div class="empty-content--message">
   <div class="empty-content--message--title">
     Could not fetch work packages from OpenProject
@@ -36,7 +36,7 @@ exports[`EmptyContent.vue Test content title shows the correct empty message dep
 </div>
 `;
 
-exports[`EmptyContent.vue Test content title shows the correct empty message depending on states if the request url is valid 5`] = `
+exports[`EmptyContent.vue Test content title shows the correct empty message depending on states if the admin config is okay 5`] = `
 <div class="empty-content--message">
   <div class="empty-content--message--title">
     No OpenProject links yet

--- a/tests/jest/views/ProjectsTab.spec.js
+++ b/tests/jest/views/ProjectsTab.spec.js
@@ -40,26 +40,26 @@ describe('ProjectsTab.vue Test', () => {
 	beforeEach(() => {
 		jest.useFakeTimers()
 		// eslint-disable-next-line no-import-assign
-		initialState.loadState = jest.fn(() => 'https://openproject/oauth/')
+		initialState.loadState = jest.fn(() => true)
 		wrapper = shallowMount(ProjectsTab, { localVue })
 	})
 	describe('search input existence', () => {
-		it('should not exist if the request url is not valid', async () => {
+		it('should not exist if admin config is not ok', async () => {
 			await wrapper.setData({
-				requestUrl: false,
+				isAdminConfigOk: false,
 			})
 			expect(wrapper.find(searchInputStubSelector).exists()).toBeFalsy()
 		})
 		it('should not exist if the wrapper is in "loading" state', async () => {
 			await wrapper.setData({
-				requestUrl: true,
+				isAdminConfigOk: true,
 				state: STATE.LOADING,
 			})
 			expect(wrapper.find(searchInputStubSelector).exists()).toBeFalsy()
 		})
-		it('should exist if the request url is valid and wrapper is not "loading"', async () => {
+		it('should exist if the admin config is ok but wrapper is not "loading"', async () => {
 			await wrapper.setData({
-				requestUrl: 'https://open.project/',
+				isAdminConfigOk: true,
 				state: STATE.OK,
 
 			})
@@ -237,12 +237,12 @@ describe('ProjectsTab.vue Test', () => {
 			await wrapper.vm.update({ id: 123 })
 			expect(wrapper.vm.state).toBe(STATE.OK)
 		})
-		it('sets the "error" state if the request url is not valid', async () => {
+		it('sets the "error" state if the admin config is not okay', async () => {
 			const wrapper = mountWrapper()
 			axios.get
 				.mockImplementation(() => Promise.resolve({ status: 200, data: [] }))
 			await wrapper.setData({
-				requestUrl: false,
+				isAdminConfigOk: false,
 			})
 			await wrapper.vm.update({ id: 123 })
 			expect(wrapper.vm.state).toBe(STATE.ERROR)
@@ -589,7 +589,7 @@ function mountWrapper() {
 			state: STATE.OK,
 			fileInfo: {},
 			workpackages: [],
-			requestUrl: 'something',
+			isAdminConfigOk: true,
 		}),
 	})
 }

--- a/tests/jest/views/__snapshots__/ProjectsTab.spec.js.snap
+++ b/tests/jest/views/__snapshots__/ProjectsTab.spec.js.snap
@@ -35,12 +35,8 @@ exports[`ProjectsTab.vue Test fetchWorkpackages adds every work-package only onc
             </div>
           </div>
         </div>
-      </div> <button data-v-2a98ba3b="" rel="nofollow noreferrer noopener" class="action-item action-item--single icon-noConnection linked-workpackages--workpackage--unlinkactionbutton undefined has-tooltip" aria-label="" icon="icon-noConnection" data-original-title="">
-        <!---->
-
-
-
-        <span data-v-2a98ba3b="" aria-hidden="true" hidden="hidden"><li data-v-ef50c406="" class="action linked-workpackages--workpackage--unlinkactionbutton" data-v-2a98ba3b=""><button data-v-ef50c406="" aria-label="" type="button" class="action-button focusable"><span data-v-ef50c406="" class="action-button__icon icon-noConnection"></span> <span data-v-ef50c406="" class="action-button__text">Unlink WorkPackage</span>
+      </div> <button data-v-68f2cb4a="" rel="noreferrer noopener" class="action-item action-item--single icon-noConnection linked-workpackages--workpackage--unlinkactionbutton undefined has-tooltip" aria-label="" icon="icon-noConnection" data-original-title="">
+        <!----> <span data-v-68f2cb4a="" aria-hidden="true" hidden="hidden"><li data-v-71ea20d2="" class="action linked-workpackages--workpackage--unlinkactionbutton" data-v-68f2cb4a=""><button data-v-71ea20d2="" aria-label="" type="button" class="action-button focusable"><span data-v-71ea20d2="" class="action-button__icon icon-noConnection"></span> <span data-v-71ea20d2="" class="action-button__text">Unlink WorkPackage</span>
         <!---->
       </button></li></span></button>
     </div>
@@ -49,7 +45,7 @@ exports[`ProjectsTab.vue Test fetchWorkpackages adds every work-package only onc
 </div>
 `;
 
-exports[`ProjectsTab.vue Test fetchWorkpackages sets the "error" state if the request url is not valid 1`] = `
+exports[`ProjectsTab.vue Test fetchWorkpackages sets the "error" state if the admin config is not okay 1`] = `
 <div class="projects projects--empty">
   <!---->
   <div class="empty-content" id="openproject-empty-content">
@@ -101,12 +97,8 @@ exports[`ProjectsTab.vue Test fetchWorkpackages shows the linked workpackages 1`
             </div>
           </div>
         </div>
-      </div> <button data-v-2a98ba3b="" rel="nofollow noreferrer noopener" class="action-item action-item--single icon-noConnection linked-workpackages--workpackage--unlinkactionbutton undefined has-tooltip" aria-label="" icon="icon-noConnection" data-original-title="">
-        <!---->
-
-
-
-        <span data-v-2a98ba3b="" aria-hidden="true" hidden="hidden"><li data-v-ef50c406="" class="action linked-workpackages--workpackage--unlinkactionbutton" data-v-2a98ba3b=""><button data-v-ef50c406="" aria-label="" type="button" class="action-button focusable"><span data-v-ef50c406="" class="action-button__icon icon-noConnection"></span> <span data-v-ef50c406="" class="action-button__text">Unlink WorkPackage</span>
+      </div> <button data-v-68f2cb4a="" rel="noreferrer noopener" class="action-item action-item--single icon-noConnection linked-workpackages--workpackage--unlinkactionbutton undefined has-tooltip" aria-label="" icon="icon-noConnection" data-original-title="">
+        <!----> <span data-v-68f2cb4a="" aria-hidden="true" hidden="hidden"><li data-v-71ea20d2="" class="action linked-workpackages--workpackage--unlinkactionbutton" data-v-68f2cb4a=""><button data-v-71ea20d2="" aria-label="" type="button" class="action-button focusable"><span data-v-71ea20d2="" class="action-button__icon icon-noConnection"></span> <span data-v-71ea20d2="" class="action-button__text">Unlink WorkPackage</span>
         <!---->
       </button></li></span></button>
     </div>
@@ -142,12 +134,8 @@ exports[`ProjectsTab.vue Test fetchWorkpackages shows the linked workpackages 1`
             </div>
           </div>
         </div>
-      </div> <button data-v-2a98ba3b="" rel="nofollow noreferrer noopener" class="action-item action-item--single icon-noConnection linked-workpackages--workpackage--unlinkactionbutton undefined has-tooltip" aria-label="" icon="icon-noConnection" data-original-title="">
-        <!---->
-
-
-
-        <span data-v-2a98ba3b="" aria-hidden="true" hidden="hidden"><li data-v-ef50c406="" class="action linked-workpackages--workpackage--unlinkactionbutton" data-v-2a98ba3b=""><button data-v-ef50c406="" aria-label="" type="button" class="action-button focusable"><span data-v-ef50c406="" class="action-button__icon icon-noConnection"></span> <span data-v-ef50c406="" class="action-button__text">Unlink WorkPackage</span>
+      </div> <button data-v-68f2cb4a="" rel="noreferrer noopener" class="action-item action-item--single icon-noConnection linked-workpackages--workpackage--unlinkactionbutton undefined has-tooltip" aria-label="" icon="icon-noConnection" data-original-title="">
+        <!----> <span data-v-68f2cb4a="" aria-hidden="true" hidden="hidden"><li data-v-71ea20d2="" class="action linked-workpackages--workpackage--unlinkactionbutton" data-v-68f2cb4a=""><button data-v-71ea20d2="" aria-label="" type="button" class="action-button focusable"><span data-v-71ea20d2="" class="action-button__icon icon-noConnection"></span> <span data-v-71ea20d2="" class="action-button__text">Unlink WorkPackage</span>
         <!---->
       </button></li></span></button>
     </div>
@@ -191,12 +179,8 @@ exports[`ProjectsTab.vue Test fetchWorkpackages shows the linked workpackages 2`
             </div>
           </div>
         </div>
-      </div> <button data-v-2a98ba3b="" rel="nofollow noreferrer noopener" class="action-item action-item--single icon-noConnection linked-workpackages--workpackage--unlinkactionbutton undefined has-tooltip" aria-label="" icon="icon-noConnection" data-original-title="">
-        <!---->
-
-
-
-        <span data-v-2a98ba3b="" aria-hidden="true" hidden="hidden"><li data-v-ef50c406="" class="action linked-workpackages--workpackage--unlinkactionbutton" data-v-2a98ba3b=""><button data-v-ef50c406="" aria-label="" type="button" class="action-button focusable"><span data-v-ef50c406="" class="action-button__icon icon-noConnection"></span> <span data-v-ef50c406="" class="action-button__text">Unlink WorkPackage</span>
+      </div> <button data-v-68f2cb4a="" rel="noreferrer noopener" class="action-item action-item--single icon-noConnection linked-workpackages--workpackage--unlinkactionbutton undefined has-tooltip" aria-label="" icon="icon-noConnection" data-original-title="">
+        <!----> <span data-v-68f2cb4a="" aria-hidden="true" hidden="hidden"><li data-v-71ea20d2="" class="action linked-workpackages--workpackage--unlinkactionbutton" data-v-68f2cb4a=""><button data-v-71ea20d2="" aria-label="" type="button" class="action-button focusable"><span data-v-71ea20d2="" class="action-button__icon icon-noConnection"></span> <span data-v-71ea20d2="" class="action-button__text">Unlink WorkPackage</span>
         <!---->
       </button></li></span></button>
     </div>
@@ -232,12 +216,8 @@ exports[`ProjectsTab.vue Test fetchWorkpackages shows the linked workpackages 2`
             </div>
           </div>
         </div>
-      </div> <button data-v-2a98ba3b="" rel="nofollow noreferrer noopener" class="action-item action-item--single icon-noConnection linked-workpackages--workpackage--unlinkactionbutton undefined has-tooltip" aria-label="" icon="icon-noConnection" data-original-title="">
-        <!---->
-
-
-
-        <span data-v-2a98ba3b="" aria-hidden="true" hidden="hidden"><li data-v-ef50c406="" class="action linked-workpackages--workpackage--unlinkactionbutton" data-v-2a98ba3b=""><button data-v-ef50c406="" aria-label="" type="button" class="action-button focusable"><span data-v-ef50c406="" class="action-button__icon icon-noConnection"></span> <span data-v-ef50c406="" class="action-button__text">Unlink WorkPackage</span>
+      </div> <button data-v-68f2cb4a="" rel="noreferrer noopener" class="action-item action-item--single icon-noConnection linked-workpackages--workpackage--unlinkactionbutton undefined has-tooltip" aria-label="" icon="icon-noConnection" data-original-title="">
+        <!----> <span data-v-68f2cb4a="" aria-hidden="true" hidden="hidden"><li data-v-71ea20d2="" class="action linked-workpackages--workpackage--unlinkactionbutton" data-v-68f2cb4a=""><button data-v-71ea20d2="" aria-label="" type="button" class="action-button focusable"><span data-v-71ea20d2="" class="action-button__icon icon-noConnection"></span> <span data-v-71ea20d2="" class="action-button__text">Unlink WorkPackage</span>
         <!---->
       </button></li></span></button>
     </div>
@@ -281,12 +261,8 @@ exports[`ProjectsTab.vue Test onSave shows the just linked workpackage 1`] = `
             </div>
           </div>
         </div>
-      </div> <button data-v-2a98ba3b="" rel="nofollow noreferrer noopener" class="action-item action-item--single icon-noConnection linked-workpackages--workpackage--unlinkactionbutton undefined has-tooltip" aria-label="" icon="icon-noConnection" data-original-title="">
-        <!---->
-
-
-
-        <span data-v-2a98ba3b="" aria-hidden="true" hidden="hidden"><li data-v-ef50c406="" class="action linked-workpackages--workpackage--unlinkactionbutton" data-v-2a98ba3b=""><button data-v-ef50c406="" aria-label="" type="button" class="action-button focusable"><span data-v-ef50c406="" class="action-button__icon icon-noConnection"></span> <span data-v-ef50c406="" class="action-button__text">Unlink WorkPackage</span>
+      </div> <button data-v-68f2cb4a="" rel="noreferrer noopener" class="action-item action-item--single icon-noConnection linked-workpackages--workpackage--unlinkactionbutton undefined has-tooltip" aria-label="" icon="icon-noConnection" data-original-title="">
+        <!----> <span data-v-68f2cb4a="" aria-hidden="true" hidden="hidden"><li data-v-71ea20d2="" class="action linked-workpackages--workpackage--unlinkactionbutton" data-v-68f2cb4a=""><button data-v-71ea20d2="" aria-label="" type="button" class="action-button focusable"><span data-v-71ea20d2="" class="action-button__icon icon-noConnection"></span> <span data-v-71ea20d2="" class="action-button__text">Unlink WorkPackage</span>
         <!---->
       </button></li></span></button>
     </div>

--- a/tests/jest/views/__snapshots__/ProjectsTab.spec.js.snap
+++ b/tests/jest/views/__snapshots__/ProjectsTab.spec.js.snap
@@ -35,8 +35,12 @@ exports[`ProjectsTab.vue Test fetchWorkpackages adds every work-package only onc
             </div>
           </div>
         </div>
-      </div> <button data-v-68f2cb4a="" rel="noreferrer noopener" class="action-item action-item--single icon-noConnection linked-workpackages--workpackage--unlinkactionbutton undefined has-tooltip" aria-label="" icon="icon-noConnection" data-original-title="">
-        <!----> <span data-v-68f2cb4a="" aria-hidden="true" hidden="hidden"><li data-v-71ea20d2="" class="action linked-workpackages--workpackage--unlinkactionbutton" data-v-68f2cb4a=""><button data-v-71ea20d2="" aria-label="" type="button" class="action-button focusable"><span data-v-71ea20d2="" class="action-button__icon icon-noConnection"></span> <span data-v-71ea20d2="" class="action-button__text">Unlink WorkPackage</span>
+      </div> <button data-v-2a98ba3b="" rel="nofollow noreferrer noopener" class="action-item action-item--single icon-noConnection linked-workpackages--workpackage--unlinkactionbutton undefined has-tooltip" aria-label="" icon="icon-noConnection" data-original-title="">
+        <!---->
+
+
+
+        <span data-v-2a98ba3b="" aria-hidden="true" hidden="hidden"><li data-v-ef50c406="" class="action linked-workpackages--workpackage--unlinkactionbutton" data-v-2a98ba3b=""><button data-v-ef50c406="" aria-label="" type="button" class="action-button focusable"><span data-v-ef50c406="" class="action-button__icon icon-noConnection"></span> <span data-v-ef50c406="" class="action-button__text">Unlink WorkPackage</span>
         <!---->
       </button></li></span></button>
     </div>
@@ -97,8 +101,12 @@ exports[`ProjectsTab.vue Test fetchWorkpackages shows the linked workpackages 1`
             </div>
           </div>
         </div>
-      </div> <button data-v-68f2cb4a="" rel="noreferrer noopener" class="action-item action-item--single icon-noConnection linked-workpackages--workpackage--unlinkactionbutton undefined has-tooltip" aria-label="" icon="icon-noConnection" data-original-title="">
-        <!----> <span data-v-68f2cb4a="" aria-hidden="true" hidden="hidden"><li data-v-71ea20d2="" class="action linked-workpackages--workpackage--unlinkactionbutton" data-v-68f2cb4a=""><button data-v-71ea20d2="" aria-label="" type="button" class="action-button focusable"><span data-v-71ea20d2="" class="action-button__icon icon-noConnection"></span> <span data-v-71ea20d2="" class="action-button__text">Unlink WorkPackage</span>
+      </div> <button data-v-2a98ba3b="" rel="nofollow noreferrer noopener" class="action-item action-item--single icon-noConnection linked-workpackages--workpackage--unlinkactionbutton undefined has-tooltip" aria-label="" icon="icon-noConnection" data-original-title="">
+        <!---->
+
+
+
+        <span data-v-2a98ba3b="" aria-hidden="true" hidden="hidden"><li data-v-ef50c406="" class="action linked-workpackages--workpackage--unlinkactionbutton" data-v-2a98ba3b=""><button data-v-ef50c406="" aria-label="" type="button" class="action-button focusable"><span data-v-ef50c406="" class="action-button__icon icon-noConnection"></span> <span data-v-ef50c406="" class="action-button__text">Unlink WorkPackage</span>
         <!---->
       </button></li></span></button>
     </div>
@@ -134,8 +142,12 @@ exports[`ProjectsTab.vue Test fetchWorkpackages shows the linked workpackages 1`
             </div>
           </div>
         </div>
-      </div> <button data-v-68f2cb4a="" rel="noreferrer noopener" class="action-item action-item--single icon-noConnection linked-workpackages--workpackage--unlinkactionbutton undefined has-tooltip" aria-label="" icon="icon-noConnection" data-original-title="">
-        <!----> <span data-v-68f2cb4a="" aria-hidden="true" hidden="hidden"><li data-v-71ea20d2="" class="action linked-workpackages--workpackage--unlinkactionbutton" data-v-68f2cb4a=""><button data-v-71ea20d2="" aria-label="" type="button" class="action-button focusable"><span data-v-71ea20d2="" class="action-button__icon icon-noConnection"></span> <span data-v-71ea20d2="" class="action-button__text">Unlink WorkPackage</span>
+      </div> <button data-v-2a98ba3b="" rel="nofollow noreferrer noopener" class="action-item action-item--single icon-noConnection linked-workpackages--workpackage--unlinkactionbutton undefined has-tooltip" aria-label="" icon="icon-noConnection" data-original-title="">
+        <!---->
+
+
+
+        <span data-v-2a98ba3b="" aria-hidden="true" hidden="hidden"><li data-v-ef50c406="" class="action linked-workpackages--workpackage--unlinkactionbutton" data-v-2a98ba3b=""><button data-v-ef50c406="" aria-label="" type="button" class="action-button focusable"><span data-v-ef50c406="" class="action-button__icon icon-noConnection"></span> <span data-v-ef50c406="" class="action-button__text">Unlink WorkPackage</span>
         <!---->
       </button></li></span></button>
     </div>
@@ -179,8 +191,12 @@ exports[`ProjectsTab.vue Test fetchWorkpackages shows the linked workpackages 2`
             </div>
           </div>
         </div>
-      </div> <button data-v-68f2cb4a="" rel="noreferrer noopener" class="action-item action-item--single icon-noConnection linked-workpackages--workpackage--unlinkactionbutton undefined has-tooltip" aria-label="" icon="icon-noConnection" data-original-title="">
-        <!----> <span data-v-68f2cb4a="" aria-hidden="true" hidden="hidden"><li data-v-71ea20d2="" class="action linked-workpackages--workpackage--unlinkactionbutton" data-v-68f2cb4a=""><button data-v-71ea20d2="" aria-label="" type="button" class="action-button focusable"><span data-v-71ea20d2="" class="action-button__icon icon-noConnection"></span> <span data-v-71ea20d2="" class="action-button__text">Unlink WorkPackage</span>
+      </div> <button data-v-2a98ba3b="" rel="nofollow noreferrer noopener" class="action-item action-item--single icon-noConnection linked-workpackages--workpackage--unlinkactionbutton undefined has-tooltip" aria-label="" icon="icon-noConnection" data-original-title="">
+        <!---->
+
+
+
+        <span data-v-2a98ba3b="" aria-hidden="true" hidden="hidden"><li data-v-ef50c406="" class="action linked-workpackages--workpackage--unlinkactionbutton" data-v-2a98ba3b=""><button data-v-ef50c406="" aria-label="" type="button" class="action-button focusable"><span data-v-ef50c406="" class="action-button__icon icon-noConnection"></span> <span data-v-ef50c406="" class="action-button__text">Unlink WorkPackage</span>
         <!---->
       </button></li></span></button>
     </div>
@@ -216,8 +232,12 @@ exports[`ProjectsTab.vue Test fetchWorkpackages shows the linked workpackages 2`
             </div>
           </div>
         </div>
-      </div> <button data-v-68f2cb4a="" rel="noreferrer noopener" class="action-item action-item--single icon-noConnection linked-workpackages--workpackage--unlinkactionbutton undefined has-tooltip" aria-label="" icon="icon-noConnection" data-original-title="">
-        <!----> <span data-v-68f2cb4a="" aria-hidden="true" hidden="hidden"><li data-v-71ea20d2="" class="action linked-workpackages--workpackage--unlinkactionbutton" data-v-68f2cb4a=""><button data-v-71ea20d2="" aria-label="" type="button" class="action-button focusable"><span data-v-71ea20d2="" class="action-button__icon icon-noConnection"></span> <span data-v-71ea20d2="" class="action-button__text">Unlink WorkPackage</span>
+      </div> <button data-v-2a98ba3b="" rel="nofollow noreferrer noopener" class="action-item action-item--single icon-noConnection linked-workpackages--workpackage--unlinkactionbutton undefined has-tooltip" aria-label="" icon="icon-noConnection" data-original-title="">
+        <!---->
+
+
+
+        <span data-v-2a98ba3b="" aria-hidden="true" hidden="hidden"><li data-v-ef50c406="" class="action linked-workpackages--workpackage--unlinkactionbutton" data-v-2a98ba3b=""><button data-v-ef50c406="" aria-label="" type="button" class="action-button focusable"><span data-v-ef50c406="" class="action-button__icon icon-noConnection"></span> <span data-v-ef50c406="" class="action-button__text">Unlink WorkPackage</span>
         <!---->
       </button></li></span></button>
     </div>
@@ -261,8 +281,12 @@ exports[`ProjectsTab.vue Test onSave shows the just linked workpackage 1`] = `
             </div>
           </div>
         </div>
-      </div> <button data-v-68f2cb4a="" rel="noreferrer noopener" class="action-item action-item--single icon-noConnection linked-workpackages--workpackage--unlinkactionbutton undefined has-tooltip" aria-label="" icon="icon-noConnection" data-original-title="">
-        <!----> <span data-v-68f2cb4a="" aria-hidden="true" hidden="hidden"><li data-v-71ea20d2="" class="action linked-workpackages--workpackage--unlinkactionbutton" data-v-68f2cb4a=""><button data-v-71ea20d2="" aria-label="" type="button" class="action-button focusable"><span data-v-71ea20d2="" class="action-button__icon icon-noConnection"></span> <span data-v-71ea20d2="" class="action-button__text">Unlink WorkPackage</span>
+      </div> <button data-v-2a98ba3b="" rel="nofollow noreferrer noopener" class="action-item action-item--single icon-noConnection linked-workpackages--workpackage--unlinkactionbutton undefined has-tooltip" aria-label="" icon="icon-noConnection" data-original-title="">
+        <!---->
+
+
+
+        <span data-v-2a98ba3b="" aria-hidden="true" hidden="hidden"><li data-v-ef50c406="" class="action linked-workpackages--workpackage--unlinkactionbutton" data-v-2a98ba3b=""><button data-v-ef50c406="" aria-label="" type="button" class="action-button focusable"><span data-v-ef50c406="" class="action-button__icon icon-noConnection"></span> <span data-v-ef50c406="" class="action-button__text">Unlink WorkPackage</span>
         <!---->
       </button></li></span></button>
     </div>


### PR DESCRIPTION
## Description
after https://github.com/nextcloud/integration_openproject/pull/146 there is no need anymore to have the requestUrl  in the front end. This PR removes the `requestUrl` from the front end that we used, to determine if we should show the connect button to the user or not. Now instead of `requestUrl` we rely on `adminConfigStatus`

## Related workPackage
[#OP42916]  : https://community.openproject.org/projects/nextcloud-integration/work_packages/42916/activity