### PR TITLE
Public direct download page

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -15,6 +15,7 @@ return [
 		['name' => 'config#setConfig', 'url' => '/config', 'verb' => 'PUT'],
 		['name' => 'config#setAdminConfig', 'url' => '/admin-config', 'verb' => 'PUT'],
 		['name' => 'config#autoOauthCreation', 'url' => '/nc-oauth', 'verb' => 'POST'],
+		['name' => 'config#directDownloadPage', 'url' => '/direct', 'verb' => 'GET'],
 		['name' => 'openProjectAPI#getNotifications', 'url' => '/notifications', 'verb' => 'GET'],
 		['name' => 'openProjectAPI#getOpenProjectUrl', 'url' => '/url', 'verb' => 'GET'],
 		['name' => 'openProjectAPI#getOpenProjectAvatar', 'url' => '/avatar', 'verb' => 'GET'],

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -11,6 +11,8 @@
 
 namespace OCA\OpenProject\Controller;
 
+use OCP\AppFramework\Http\Template\PublicTemplateResponse;
+use OCP\AppFramework\Services\IInitialState;
 use OCP\IURLGenerator;
 use OCP\IConfig;
 use OCP\IL10N;
@@ -63,10 +65,15 @@ class ConfigController extends Controller {
 	 * @var OauthService
 	 */
 	private $oauthService;
+	/**
+	 * @var IInitialState
+	 */
+	private $initialStateService;
 
 	public function __construct(string $appName,
 								IRequest $request,
 								IConfig $config,
+								IInitialState $initialStateService,
 								IURLGenerator $urlGenerator,
 								IUserManager $userManager,
 								IL10N $l,
@@ -83,6 +90,7 @@ class ConfigController extends Controller {
 		$this->logger = $logger;
 		$this->userId = $userId;
 		$this->oauthService = $oauthService;
+		$this->initialStateService = $initialStateService;
 	}
 
 	/**
@@ -305,5 +313,22 @@ class ConfigController extends Controller {
 		$clientInfo = $this->oauthService->createNcOauthClient('OpenProject client', rtrim($opUrl, '/') .'/oauth_clients/%s/callback');
 		$this->config->setAppValue(Application::APP_ID, 'nc_oauth_client_id', $clientInfo['id']);
 		return new DataResponse($clientInfo);
+	}
+
+	/**
+	 * Direct download page
+	 * @NoCSRFRequired
+	 * @PublicPage
+	 */
+	public function directDownloadPage(string $token, string $fileName): PublicTemplateResponse {
+		$this->initialStateService->provideInitialState('direct', [
+			'token' => $token,
+			'fileName' => $fileName,
+		]);
+		$response = new PublicTemplateResponse(Application::APP_ID, 'directDownload');
+		$response->setHeaderTitle($this->l->t('Direct download'));
+		$response->setHeaderDetails($fileName);
+		$response->setFooterVisible(false);
+		return $response;
 	}
 }

--- a/src/components/DirectDownload.vue
+++ b/src/components/DirectDownload.vue
@@ -1,0 +1,56 @@
+<template>
+	<div id="openproject_direct_download">
+		<a :href="directDownloadLink" :download="state.fileName">
+			<Button>
+				<template #icon>
+					<DownloadIcon />
+				</template>
+				{{ state.fileName }}
+			</Button>
+		</a>
+	</div>
+</template>
+
+<script>
+import { loadState } from '@nextcloud/initial-state'
+import { generateUrl } from '@nextcloud/router'
+import Button from '@nextcloud/vue/dist/Components/Button'
+import DownloadIcon from 'vue-material-design-icons/Download'
+
+export default {
+	name: 'DirectDownload',
+
+	components: {
+		Button,
+		DownloadIcon,
+	},
+
+	data() {
+		return {
+			state: loadState('integration_openproject', 'direct'),
+		}
+	},
+
+	computed: {
+		directDownloadLink() {
+			return generateUrl('/remote.php/direct/{token}', { token: this.state.token }).replace('index.php/', '')
+		},
+	},
+
+	mounted() {
+	},
+
+	methods: {
+	},
+}
+</script>
+
+<style scoped lang="scss">
+// nothing yet
+#openproject_direct_download {
+	width: 100%;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+</style>

--- a/src/directDownload.js
+++ b/src/directDownload.js
@@ -1,0 +1,25 @@
+/* jshint esversion: 6 */
+
+/**
+ * Nextcloud - openproject
+ *
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Julien Veyssier <eneiluj@posteo.net>
+ * @copyright Julien Veyssier 2022
+ */
+
+import Vue from 'vue'
+import './bootstrap'
+import DirectDownload from './components/DirectDownload'
+
+// eslint-disable-next-line
+'use strict'
+
+// eslint-disable-next-line
+new Vue({
+	el: '#openproject_direct_download',
+	render: h => h(DirectDownload),
+})

--- a/templates/directDownload.php
+++ b/templates/directDownload.php
@@ -1,0 +1,6 @@
+<?php
+$appId = OCA\OpenProject\AppInfo\Application::APP_ID;
+script($appId, $appId . '-directDownload');
+?>
+
+<div id="openproject_direct_download"></div>

--- a/tests/lib/Controller/ConfigControllerTest.php
+++ b/tests/lib/Controller/ConfigControllerTest.php
@@ -4,6 +4,7 @@ namespace OCA\OpenProject\Controller;
 
 use OCA\OpenProject\Service\OauthService;
 use OCA\OpenProject\Service\OpenProjectAPIService;
+use OCP\AppFramework\Services\IInitialState;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IRequest;
@@ -111,6 +112,7 @@ class ConfigControllerTest extends TestCase {
 			'integration_openproject',
 			$this->createMock(IRequest::class),
 			$configMock,
+			$this->createMock(IInitialState::class),
 			$urlGeneratorMock,
 			$this->createMock(IUserManager::class),
 			$this->l,
@@ -175,6 +177,7 @@ class ConfigControllerTest extends TestCase {
 			'integration_openproject',
 			$this->createMock(IRequest::class),
 			$configMock,
+			$this->createMock(IInitialState::class),
 			$urlGeneratorMock,
 			$this->createMock(IUserManager::class),
 			$this->l,
@@ -208,6 +211,7 @@ class ConfigControllerTest extends TestCase {
 			'integration_openproject',
 			$this->createMock(IRequest::class),
 			$configMock,
+			$this->createMock(IInitialState::class),
 			$this->createMock(IURLGenerator::class),
 			$this->createMock(IUserManager::class),
 			$this->l,
@@ -274,6 +278,7 @@ class ConfigControllerTest extends TestCase {
 			'integration_openproject',
 			$this->createMock(IRequest::class),
 			$configMock,
+			$this->createMock(IInitialState::class),
 			$this->createMock(IURLGenerator::class),
 			$this->createMock(IUserManager::class),
 			$this->l,
@@ -342,6 +347,7 @@ class ConfigControllerTest extends TestCase {
 			'integration_openproject',
 			$this->createMock(IRequest::class),
 			$configMock,
+			$this->createMock(IInitialState::class),
 			$this->createMock(IURLGenerator::class),
 			$this->createMock(IUserManager::class),
 			$this->l,
@@ -415,6 +421,7 @@ class ConfigControllerTest extends TestCase {
 			'integration_openproject',
 			$this->createMock(IRequest::class),
 			$configMock,
+			$this->createMock(IInitialState::class),
 			$this->createMock(IURLGenerator::class),
 			$this->createMock(IUserManager::class),
 			$this->l,
@@ -517,6 +524,7 @@ class ConfigControllerTest extends TestCase {
 			'integration_openproject',
 			$this->createMock(IRequest::class),
 			$configMock,
+			$this->createMock(IInitialState::class),
 			$this->createMock(IURLGenerator::class),
 			$userManager,
 			$this->l,

--- a/webpack.js
+++ b/webpack.js
@@ -18,6 +18,7 @@ webpackConfig.entry = {
 	adminSettings: { import: path.join(__dirname, 'src', 'adminSettings.js'), filename: appId + '-adminSettings.js' },
 	dashboard: { import: path.join(__dirname, 'src', 'dashboard.js'), filename: appId + '-dashboard.js' },
 	'openproject-tab': { import: path.join(__dirname, 'src', 'projectTab.js'), filename: appId + '-projectTab.js' },
+	directDownload: { import: path.join(__dirname, 'src', 'directDownload.js'), filename: appId + '-directDownload.js' },
 }
 
 webpackConfig.plugins.push(


### PR DESCRIPTION
OpenProject generates Nextcloud [direct download](https://docs.nextcloud.com/server/22/developer_manual/client_apis/OCS/ocs-api-overview.html#direct-download) links to let users get files linked with a work package.

There is an issue with this direct download endpoint in Nextcloud. It messes with cookies and refuses to be accessed when put in a link in OpenProject.

This is a workaround. This public page takes the download token and an arbitrary file name and shows a link to the direct download endpoint. For some reason it works fine.