### PR TITLE
Add custom direct download page actually serving the file

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -15,7 +15,10 @@ return [
 		['name' => 'config#setConfig', 'url' => '/config', 'verb' => 'PUT'],
 		['name' => 'config#setAdminConfig', 'url' => '/admin-config', 'verb' => 'PUT'],
 		['name' => 'config#autoOauthCreation', 'url' => '/nc-oauth', 'verb' => 'POST'],
-		['name' => 'config#directDownloadPage', 'url' => '/direct', 'verb' => 'GET'],
+
+		['name' => 'directDownload#directDownloadPage', 'url' => '/direct', 'verb' => 'GET'],
+		['name' => 'directDownload#directDownload', 'url' => '/direct/{token}/{fileName}', 'verb' => 'GET'],
+
 		['name' => 'openProjectAPI#getNotifications', 'url' => '/notifications', 'verb' => 'GET'],
 		['name' => 'openProjectAPI#getOpenProjectUrl', 'url' => '/url', 'verb' => 'GET'],
 		['name' => 'openProjectAPI#getOpenProjectAvatar', 'url' => '/avatar', 'verb' => 'GET'],

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -11,8 +11,6 @@
 
 namespace OCA\OpenProject\Controller;
 
-use OCP\AppFramework\Http\Template\PublicTemplateResponse;
-use OCP\AppFramework\Services\IInitialState;
 use OCP\IURLGenerator;
 use OCP\IConfig;
 use OCP\IL10N;
@@ -65,15 +63,10 @@ class ConfigController extends Controller {
 	 * @var OauthService
 	 */
 	private $oauthService;
-	/**
-	 * @var IInitialState
-	 */
-	private $initialStateService;
 
 	public function __construct(string $appName,
 								IRequest $request,
 								IConfig $config,
-								IInitialState $initialStateService,
 								IURLGenerator $urlGenerator,
 								IUserManager $userManager,
 								IL10N $l,
@@ -90,7 +83,6 @@ class ConfigController extends Controller {
 		$this->logger = $logger;
 		$this->userId = $userId;
 		$this->oauthService = $oauthService;
-		$this->initialStateService = $initialStateService;
 	}
 
 	/**
@@ -313,22 +305,5 @@ class ConfigController extends Controller {
 		$clientInfo = $this->oauthService->createNcOauthClient('OpenProject client', rtrim($opUrl, '/') .'/oauth_clients/%s/callback');
 		$this->config->setAppValue(Application::APP_ID, 'nc_oauth_client_id', $clientInfo['id']);
 		return new DataResponse($clientInfo);
-	}
-
-	/**
-	 * Direct download page
-	 * @NoCSRFRequired
-	 * @PublicPage
-	 */
-	public function directDownloadPage(string $token, string $fileName): PublicTemplateResponse {
-		$this->initialStateService->provideInitialState('direct', [
-			'token' => $token,
-			'fileName' => $fileName,
-		]);
-		$response = new PublicTemplateResponse(Application::APP_ID, 'directDownload');
-		$response->setHeaderTitle($this->l->t('Direct download'));
-		$response->setHeaderDetails($fileName);
-		$response->setFooterVisible(false);
-		return $response;
 	}
 }

--- a/lib/Controller/DirectDownloadController.php
+++ b/lib/Controller/DirectDownloadController.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Nextcloud - openproject
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Julien Veyssier <eneiluj@posteo.net>
+ * @copyright Julien Veyssier 2022
+ */
+
+namespace OCA\OpenProject\Controller;
+
+use OCA\OpenProject\Service\DirectDownloadService;
+use OCP\AppFramework\Http\DataDownloadResponse;
+use OCP\AppFramework\Http\Template\PublicTemplateResponse;
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\AppFramework\Services\IInitialState;
+use OCP\IL10N;
+use OCP\IRequest;
+use OCP\AppFramework\Controller;
+
+use OCA\OpenProject\AppInfo\Application;
+
+class DirectDownloadController extends Controller {
+
+	/**
+	 * @var IL10N
+	 */
+	private $l;
+	/**
+	 * @var IInitialState
+	 */
+	private $initialStateService;
+	/**
+	 * @var DirectDownloadService
+	 */
+	private $directDownloadService;
+
+	public function __construct(string $appName,
+								IRequest $request,
+								IInitialState $initialStateService,
+								IL10N $l,
+								DirectDownloadService $directDownloadService) {
+		parent::__construct($appName, $request);
+		$this->l = $l;
+		$this->initialStateService = $initialStateService;
+		$this->directDownloadService = $directDownloadService;
+	}
+
+	/**
+	 * Direct download page
+	 * @NoCSRFRequired
+	 * @PublicPage
+	 */
+	public function directDownloadPage(string $token, string $fileName): PublicTemplateResponse {
+		$this->initialStateService->provideInitialState('direct', [
+			'token' => $token,
+			'fileName' => $fileName,
+		]);
+		$response = new PublicTemplateResponse(Application::APP_ID, 'directDownload');
+		$response->setHeaderTitle($this->l->t('Direct download'));
+		$response->setHeaderDetails($fileName);
+		$response->setFooterVisible(false);
+		return $response;
+	}
+
+	/**
+	 * Direct download
+	 * @NoCSRFRequired
+	 * @PublicPage
+	 *
+	 * @param string $token
+	 * @param string $fileName
+	 * @return DataDownloadResponse|TemplateResponse
+	 * @throws \OCP\Files\NotPermittedException
+	 * @throws \OCP\Lock\LockedException
+	 */
+	public function directDownload(string $token, string $fileName) {
+		$file = $this->directDownloadService->getDirectDownloadFile($token);
+		if ($file !== null) {
+			return new DataDownloadResponse($file->getContent(), $fileName, $file->getMimeType());
+		}
+		return new TemplateResponse('core', 'error', [
+			'errors' => [
+				[
+					'error' => $this->l->t('Direct download error.'),
+					'hint' => $this->l->t('This direct download link is invalid or has expired.'),
+				],
+			],
+		], TemplateResponse::RENDER_AS_GUEST);
+	}
+}

--- a/lib/Service/DirectDownloadService.php
+++ b/lib/Service/DirectDownloadService.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Nextcloud - openproject
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Julien Veyssier
+ * @copyright Julien Veyssier 2022
+ */
+
+namespace OCA\OpenProject\Service;
+
+use DateTime;
+use OC\Files\Node\File;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\Files\IRootFolder;
+use OCP\IDBConnection;
+
+class DirectDownloadService {
+	/**
+	 * @var IDBConnection
+	 */
+	private $db;
+	/**
+	 * @var IRootFolder
+	 */
+	private $root;
+
+	/**
+	 * Service to check and get direct download links
+	 */
+	public function __construct(IDBConnection $db,
+								IRootFolder $root) {
+		$this->db = $db;
+		$this->root = $root;
+	}
+
+	public function getDirectDownloadFile(string $token): ?File {
+		$qb = $this->db->getQueryBuilder();
+
+		$qb->select('id', 'user_id', 'file_id', 'token', 'expiration')
+		   ->from('directlink')
+		   ->where(
+			   $qb->expr()->eq('token', $qb->createNamedParameter($token, IQueryBuilder::PARAM_STR))
+		   );
+		$req = $qb->executeQuery();
+
+		while ($row = $req->fetch()) {
+			$dbFileId = (int) $row['file_id'];
+			$dbExpiration = (int) $row['expiration'];
+			$dbUserId = $row['user_id'];
+
+			$nowTs = (new DateTime())->getTimestamp();
+			if ($nowTs <= $dbExpiration) {
+				$userFolder = $this->root->getUserFolder($dbUserId);
+				$files = $userFolder->getById($dbFileId);
+				if (count($files) > 0 && $files[0] instanceof File) {
+					return $files[0];
+				}
+			}
+		}
+		$req->closeCursor();
+		$qb->resetQueryParts();
+
+		return null;
+	}
+}

--- a/tests/lib/Controller/ConfigControllerTest.php
+++ b/tests/lib/Controller/ConfigControllerTest.php
@@ -4,7 +4,6 @@ namespace OCA\OpenProject\Controller;
 
 use OCA\OpenProject\Service\OauthService;
 use OCA\OpenProject\Service\OpenProjectAPIService;
-use OCP\AppFramework\Services\IInitialState;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IRequest;
@@ -112,7 +111,6 @@ class ConfigControllerTest extends TestCase {
 			'integration_openproject',
 			$this->createMock(IRequest::class),
 			$configMock,
-			$this->createMock(IInitialState::class),
 			$urlGeneratorMock,
 			$this->createMock(IUserManager::class),
 			$this->l,
@@ -177,7 +175,6 @@ class ConfigControllerTest extends TestCase {
 			'integration_openproject',
 			$this->createMock(IRequest::class),
 			$configMock,
-			$this->createMock(IInitialState::class),
 			$urlGeneratorMock,
 			$this->createMock(IUserManager::class),
 			$this->l,
@@ -211,7 +208,6 @@ class ConfigControllerTest extends TestCase {
 			'integration_openproject',
 			$this->createMock(IRequest::class),
 			$configMock,
-			$this->createMock(IInitialState::class),
 			$this->createMock(IURLGenerator::class),
 			$this->createMock(IUserManager::class),
 			$this->l,
@@ -278,7 +274,6 @@ class ConfigControllerTest extends TestCase {
 			'integration_openproject',
 			$this->createMock(IRequest::class),
 			$configMock,
-			$this->createMock(IInitialState::class),
 			$this->createMock(IURLGenerator::class),
 			$this->createMock(IUserManager::class),
 			$this->l,
@@ -347,7 +342,6 @@ class ConfigControllerTest extends TestCase {
 			'integration_openproject',
 			$this->createMock(IRequest::class),
 			$configMock,
-			$this->createMock(IInitialState::class),
 			$this->createMock(IURLGenerator::class),
 			$this->createMock(IUserManager::class),
 			$this->l,
@@ -421,7 +415,6 @@ class ConfigControllerTest extends TestCase {
 			'integration_openproject',
 			$this->createMock(IRequest::class),
 			$configMock,
-			$this->createMock(IInitialState::class),
 			$this->createMock(IURLGenerator::class),
 			$this->createMock(IUserManager::class),
 			$this->l,
@@ -524,7 +517,6 @@ class ConfigControllerTest extends TestCase {
 			'integration_openproject',
 			$this->createMock(IRequest::class),
 			$configMock,
-			$this->createMock(IInitialState::class),
 			$this->createMock(IURLGenerator::class),
 			$userManager,
 			$this->l,

--- a/tests/lib/Service/DirectDownloadServiceTest.php
+++ b/tests/lib/Service/DirectDownloadServiceTest.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Nextcloud - OpenProject
+ *
+ *
+ * @author Julien Veyssier <eneiluj@posteo.net>
+ * @copyright Julien Veyssier 2022
+ */
+
+namespace OCA\OpenProject\Service;
+
+use OCA\DAV\Controller\DirectController;
+use OCA\DAV\Db\DirectMapper;
+use OCA\OpenProject\AppInfo\Application;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Files\IRootFolder;
+use OCP\IRequest;
+use OCP\IURLGenerator;
+use OCP\IUserManager;
+use OCP\Security\ISecureRandom;
+use PHPUnit\Framework\TestCase;
+
+class DirectDownloadServiceTest extends TestCase {
+	private const USER_ID = 'test';
+	private const USER_PASSWORD = 'T0T0T0T0T0T0T0';
+	/**
+	 * @var DirectDownloadService
+	 */
+	private $directDownloadService;
+	/**
+	 * @var \OCP\Files\Folder
+	 */
+	private $userFolder;
+	/**
+	 * @var DirectController
+	 */
+	private $directController;
+
+	public static function setUpBeforeClass(): void {
+		$app = new Application();
+		$c = $app->getContainer();
+
+		$userManager = $c->get(IUserManager::class);
+		$user = $userManager->get(self::USER_ID);
+		if ($user !== null) {
+			$user->delete();
+		}
+
+		// create dummy user
+		$userManager->createUser(self::USER_ID, self::USER_PASSWORD);
+	}
+
+	protected function setUp(): void {
+		$app = new Application();
+		$c = $app->getContainer();
+
+		/** @var DirectDownloadService directDownloadService */
+		$directDownloadService = $c->get(DirectDownloadService::class);
+		$this->directDownloadService = $directDownloadService;
+
+		/** @var IRootFolder $root */
+		$root = $c->get(IRootFolder::class);
+		$this->userFolder = $root->getUserFolder(self::USER_ID);
+
+		$this->directController = new DirectController(
+			'dav',
+			$c->get(IRequest::class),
+			$root,
+			self::USER_ID,
+			$c->get(DirectMapper::class),
+			$c->get(ISecureRandom::class),
+			$c->get(ITimeFactory::class),
+			$c->get(IURLGenerator::class)
+		);
+	}
+
+	public static function tearDownAfterClass(): void {
+		$app = new Application();
+		$c = $app->getContainer();
+		$userManager = $c->get(IUserManager::class);
+		$user = $userManager->get('test');
+		$user->delete();
+	}
+
+	protected function tearDown(): void {
+	}
+
+	/**
+	 * @return void
+	 * @throws \OCP\AppFramework\OCS\OCSBadRequestException
+	 * @throws \OCP\AppFramework\OCS\OCSNotFoundException
+	 * @throws \OCP\Files\InvalidPathException
+	 * @throws \OCP\Files\NotFoundException
+	 * @throws \OCP\Files\NotPermittedException
+	 */
+	public function testGetDirectDownloadFile() {
+		// create a file
+		$originalFile = $this->userFolder->newFile('example.txt', 'dummy content');
+
+		// create a direct download link and get its token
+		$response = $this->directController->getUrl($originalFile->getId());
+		$directLinkUrl = $response->getData()['url'];
+		preg_match('/.*\/([^\/]*)$/', $directLinkUrl, $matches);
+		$directLinkToken = $matches[1];
+
+		// get the file with our custom service
+		$serviceFile = $this->directDownloadService->getDirectDownloadFile($directLinkToken);
+		$this->assertSame($originalFile->getId(), $serviceFile->getId());
+	}
+}


### PR DESCRIPTION
Better alternative to the other public page which shows a link. This one checks the direct link token information and serves the file directly. It does not suffer from the real direct link limitations regarding cross site requests.