### PR TITLE
delete overlayIconUrl property from Dashboard

### DIFF
--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -82,7 +82,6 @@ export default {
 					targetUrl: this.getNotificationTarget(n),
 					avatarUrl: this.getAuthorAvatarUrl(n),
 					avatarUsername: this.getAuthorShortName(n) + 'z',
-					overlayIconUrl: false,
 					mainText: this.getTargetTitle(n),
 					subText: this.getSubline(n),
 				}


### PR DESCRIPTION
follow up of #122

usigng `false` generated this log output in the browser console:
```
[Vue warn]: Invalid prop: type check failed for prop "overlayIconUrl". Expected String, got Boolean with value false.

found in

---> <DashboardWidgetItem>
       <DashboardWidget>
         <Root>
```

according to the documentation https://github.com/nextcloud/nextcloud-vue-dashboard#all-props-1 it is optional, so delete it completely

