### PR TITLE
Remove trailing slash from OpenProject instance URL before constructing OAuth URL

### DIFF
--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -601,6 +601,12 @@ class OpenProjectAPIService {
 		$clientID = $config->getAppValue(Application::APP_ID, 'client_id');
 		$oauthUrl = $config->getAppValue(Application::APP_ID, 'oauth_instance_url');
 		$redirectUri = $urlGenerator->linkToRouteAbsolute(Application::APP_ID . '.config.oauthRedirect');
+
+		// remove trailing slash from the oauthUrl if present
+		if (substr($oauthUrl, -1) === '/') {
+			$oauthUrl = substr($oauthUrl, 0, -1);
+		}
+
 		return $oauthUrl .
 			'/oauth/authorize' .
 			'?client_id=' . $clientID .

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -968,7 +968,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 	 * @dataProvider getOpenProjectOauthURLValidDataProvider
 	 * @return void
 	 */
-	public function testGetOpenProjectOauthURL($oauthInstanceUrl) {
+	public function testGetOpenProjectOauthURL(string $oauthInstanceUrl) {
 		$configMock = $this->getMockBuilder(IConfig::class)->getMock();
 		$configMock
 			->method('getAppValue')

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -954,9 +954,21 @@ class OpenProjectAPIServiceTest extends TestCase {
 	}
 
 	/**
+	 * @return array<mixed>
+	 */
+	public function getOpenProjectOauthURLValidDataProvider() {
+		return [
+			["https://openproject"],
+			["https://openproject/"]
+		];
+	}
+
+
+	/**
+	 * @dataProvider getOpenProjectOauthURLValidDataProvider
 	 * @return void
 	 */
-	public function testGetOpenProjectOauthURL() {
+	public function testGetOpenProjectOauthURL($oauthInstanceUrl) {
 		$configMock = $this->getMockBuilder(IConfig::class)->getMock();
 		$configMock
 			->method('getAppValue')
@@ -966,7 +978,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 				['integration_openproject', 'oauth_instance_url'],
 				['integration_openproject', 'client_id'],
 				['integration_openproject', 'oauth_instance_url'],
-			)->willReturnOnConsecutiveCalls('clientID', 'SECRET', 'https://openproject', 'clientID', 'https://openproject');
+			)->willReturnOnConsecutiveCalls('clientID', 'SECRET', $oauthInstanceUrl, 'clientID', $oauthInstanceUrl);
 
 		$url = $this->createMock(IURLGenerator::class);
 		$url->expects($this->once())
@@ -986,7 +998,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 	/**
 	 * @return array<mixed>
 	 */
-	public function getOpenProjectOauthURLDataProvider() {
+	public function getOpenProjectOauthURLInvalidDataProvider() {
 		return [
 			[
 				'clientId',
@@ -1014,7 +1026,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 	/**
 	 * @return void
 	 *
-	 * @dataProvider getOpenProjectOauthURLDataProvider
+	 * @dataProvider getOpenProjectOauthURLInvalidDataProvider
 	 */
 	public function testGetOpenProjectOauthURLWithInvalidAdminConfig(
 		string $clientId, string $clientSecret, string $oauthInstanceUrl


### PR DESCRIPTION
## Description

If we have saved the `oauth_instance_url` as `https://some-domain/` (with a trailing slash), the oauth URL constructed is like:
```js
return $oauthUrl .
  '/oauth/authorize' .
  '?client_id=' . $clientID .
  '&redirect_uri=' . urlencode($redirectUri) .
  '&response_type=code';
```
this results in URLs like this:
```
https://some-domain//oauth/authorize?...
```
The occurrence of double slash `//` after instance URL does not show the page error message on navigation. But it would be better to avoid such inconsistencies.


Signed-off-by: Kiran Parajuli <kiranparajuli589@gmail.com>