### PR TITLE
[#43173] use 'typeahead' filter to search for WP

### DIFF
--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -265,35 +265,24 @@ class OpenProjectAPIService {
 			$filters[] = ['file_link_origin_id' => ['operator' => '=', 'values' => [(string)$fileId]]];
 		}
 		if ($query !== null) {
-			$filters[] = ['description' => ['operator' => '~', 'values' => [$query]]];
+			$filters[] = ['typeahead' => ['operator' => '**', 'values' => [$query]]];
 		}
 		$resultsById = $this->searchRequest($userId, $filters);
 		if (isset($resultsById['error'])) {
 			return $resultsById;
 		}
-		// search by subject
-		if ($query !== null) {
-			$filters = [
-				['subject' => ['operator' => '~', 'values' => [$query]]],
-			];
-			$resultsById = $this->searchRequest($userId, $filters, $resultsById);
-			if (isset($resultsById['error'])) {
-				return $resultsById;
-			}
-		}
-
 		return array_values($resultsById);
 	}
 
 	/**
 	 * @param string $userId
 	 * @param array<mixed> $filters
-	 * @param array<mixed> $resultsById
 	 * @return array<mixed>
 	 * @throws \OCP\PreConditionNotMetException
 	 * @throws \Safe\Exceptions\JsonException
 	 */
-	private function searchRequest(string $userId, array $filters, array $resultsById = []): array {
+	private function searchRequest(string $userId, array $filters): array {
+		$resultsById = [];
 		$sortBy = [['status', 'asc'],['updatedAt', 'desc']];
 		$filters[] = [
 			'linkable_to_storage_url' =>

--- a/src/components/tab/SearchInput.vue
+++ b/src/components/tab/SearchInput.vue
@@ -39,7 +39,7 @@ import { showError, showSuccess } from '@nextcloud/dialogs'
 import { workpackageHelper } from '../../utils/workpackageHelper'
 import { STATE } from '../../utils'
 
-const SEARCH_CHAR_LIMIT = 3
+const SEARCH_CHAR_LIMIT = 1
 const DEBOUNCE_THRESHOLD = 500
 
 export default {
@@ -121,7 +121,7 @@ export default {
 			await this.debounceMakeSearchRequest(query, this.fileInfo.id)
 		},
 		debounceMakeSearchRequest: debounce(function(...args) {
-			if (args[0].length <= SEARCH_CHAR_LIMIT) return
+			if (args[0].length < SEARCH_CHAR_LIMIT) return
 			return this.makeSearchRequest(...args)
 		}, DEBOUNCE_THRESHOLD),
 		async linkWorkPackageToFile(selectedOption) {

--- a/tests/jest/components/tab/SearchInput.spec.js
+++ b/tests/jest/components/tab/SearchInput.spec.js
@@ -77,6 +77,11 @@ describe('SearchInput.vue tests', () => {
 	describe('work packages multiselect', () => {
 		describe('search input', () => {
 			it('should reset the state if search value length becomes lesser than search char limit', async () => {
+				const axiosSpy = jest.spyOn(axios, 'get')
+					.mockImplementationOnce(() => Promise.resolve({
+						status: 200,
+						data: [],
+					}))
 				wrapper = mountSearchInput()
 				const inputField = wrapper.find(inputSelector)
 				await wrapper.setData({
@@ -87,30 +92,27 @@ describe('SearchInput.vue tests', () => {
 				await wrapper.setData({
 					state: STATE.LOADING,
 				})
-
-				await inputField.setValue('org')
+				await inputField.setValue('a')
+				await inputField.setValue('')
 
 				expect(wrapper.vm.searchResults).toMatchObject([])
 				expect(wrapper.vm.state).toBe(STATE.OK)
+				axiosSpy.mockRestore()
 			})
 			it.each([
 				{
-					search: 'o',
+					search: '',
 					expectedCallCount: 0,
+				},
+				{
+					search: 'o',
+					expectedCallCount: 1,
 				},
 				{
 					search: 'or',
-					expectedCallCount: 0,
-				},
-				{
-					search: 'org',
-					expectedCallCount: 0,
-				},
-				{
-					search: 'orga',
 					expectedCallCount: 1,
 				},
-			])('should send search request only if the search text is greater than search threshold', async ({
+			])('should send search request only if the search text is greater than or equal to the search char limit', async ({
 				search,
 				expectedCallCount,
 			}) => {


### PR DESCRIPTION
using the `typeahead` filter for the search has several advantages

1. we need only one request and not multiple
2. it also searches for WP ids (fixes https://community.openproject.org/projects/nextcloud-integration/work_packages/43173/)

To make it possible to search also for short ids, the min input is one character

P.S. the global search also now searches for WP ids, but that still has a minimum input of 2 characters
