### PR TITLE
[#43168] All links in instructions need to open in a new tab

### DIFF
--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -263,13 +263,13 @@ export default {
 		},
 		openProjectClientHint() {
 			const linkText = t('integration_openproject', 'Administration > File storages')
-			const htmlLink = `<a class="link" href="${this.adminFileStorageHref}" target="_blank" title="${linkText}">${linkText}</a>`
+			const htmlLink = `<a class="link" href="${this.adminFileStorageHref}" title="${linkText}">${linkText}</a>`
 			return t('integration_openproject', 'Go to your OpenProject {htmlLink} as an Administrator and start the setup and copy the values here.', { htmlLink }, null, { escape: false })
 		},
 		nextcloudClientHint() {
 			const linkText = t('integration_openproject', 'Administration > File storages')
-			const htmlLink = `<a class="link" href="${this.adminFileStorageHref}" target="_blank" title="${linkText}">${linkText}</a>`
-			return t('integration_openproject', 'Copy the following values back into the OpenProject {htmlLink} as an Administrator.', { htmlLink }, null, { escape: false })
+			const htmlLink = `<a class="link" title="${linkText}" href="${this.adminFileStorageHref}">${linkText}</a>`
+			return  t('integration_openproject', 'Copy the following values back into the OpenProject {htmlLink} as an Administrator.', { htmlLink }, null, { escape: false })
 		},
 	},
 	created() {

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -268,8 +268,8 @@ export default {
 		},
 		nextcloudClientHint() {
 			const linkText = t('integration_openproject', 'Administration > File storages')
-			const htmlLink = `<a class="link" title="${linkText}" href="${this.adminFileStorageHref}">${linkText}</a>`
-			return  t('integration_openproject', 'Copy the following values back into the OpenProject {htmlLink} as an Administrator.', { htmlLink }, null, { escape: false })
+			const htmlLink = `<a class="link" href="${this.adminFileStorageHref}" title="${linkText}">${linkText}</a>`
+			return t('integration_openproject', 'Copy the following values back into the OpenProject {htmlLink} as an Administrator.', { htmlLink }, null, { escape: false })
 		},
 	},
 	created() {

--- a/src/components/admin/TextInput.vue
+++ b/src/components/admin/TextInput.vue
@@ -121,7 +121,8 @@ export default {
 			}
 		},
 		sanitizedHintText() {
-			return dompurify.sanitize(this.hintText)
+			const hint = this.hintText.replace("<a", "<a target='_blank'")
+			return dompurify.sanitize(hint, { ADD_ATTR: ['target'] })
 		},
 	},
 	methods: {

--- a/src/components/admin/TextInput.vue
+++ b/src/components/admin/TextInput.vue
@@ -121,7 +121,7 @@ export default {
 			}
 		},
 		sanitizedHintText() {
-			const hint = this.hintText.replace("<a", "<a target='_blank'")
+			const hint = this.hintText.replace('<a', "<a target='_blank'")
 			return dompurify.sanitize(hint, { ADD_ATTR: ['target'] })
 		},
 	},

--- a/tests/jest/components/admin/TextInput.spec.js
+++ b/tests/jest/components/admin/TextInput.spec.js
@@ -45,7 +45,7 @@ describe('TextInput', () => {
 			})
 			expect(wrapper).toMatchSnapshot()
 		})
-		it('should add the target blank on ta "a" tag if present', () => {
+		it('should add the target blank on the "a" tag if present', () => {
 			const wrapper = getWrapper({
 				hintText: 'some hint <a href="some-link">here to go</a> message',
 			})

--- a/tests/jest/components/admin/TextInput.spec.js
+++ b/tests/jest/components/admin/TextInput.spec.js
@@ -17,6 +17,7 @@ const selector = {
 	textInputLabel: '.text-input-label',
 	copyButton: '.text-input-copy-value',
 	copyIcon: '.icon-clippy',
+	textInputHint: '.text-input-hint'
 }
 
 global.t = (app, text) => text
@@ -43,6 +44,12 @@ describe('TextInput', () => {
 				errorMessage: 'some error message',
 			})
 			expect(wrapper).toMatchSnapshot()
+		})
+		it('should add the target blank on ta "a" tag if present', () => {
+			const wrapper = getWrapper({
+				hintText: 'some hint <a href="some-link">here to go</a> message',
+			})
+			expect(wrapper.find(selector.textInputHint)).toMatchSnapshot()
 		})
 	})
 	describe('is required prop', () => {

--- a/tests/jest/components/admin/TextInput.spec.js
+++ b/tests/jest/components/admin/TextInput.spec.js
@@ -17,7 +17,7 @@ const selector = {
 	textInputLabel: '.text-input-label',
 	copyButton: '.text-input-copy-value',
 	copyIcon: '.icon-clippy',
-	textInputHint: '.text-input-hint'
+	textInputHint: '.text-input-hint',
 }
 
 global.t = (app, text) => text

--- a/tests/jest/components/admin/__snapshots__/TextInput.spec.js.snap
+++ b/tests/jest/components/admin/__snapshots__/TextInput.spec.js.snap
@@ -12,7 +12,7 @@ exports[`TextInput is required prop should not add asterik to the label text 1`]
 </div>
 `;
 
-exports[`TextInput messages should add the target blank on ta "a" tag if present 1`] = `<div class="text-input-hint">some hint <a href="some-link" target="_blank">here to go</a> message</div>`;
+exports[`TextInput messages should add the target blank on the "a" tag if present 1`] = `<div class="text-input-hint">some hint <a href="some-link" target="_blank">here to go</a> message</div>`;
 
 exports[`TextInput messages should show error message if both error message and hint text are provided 1`] = `
 <div class="text-input">

--- a/tests/jest/components/admin/__snapshots__/TextInput.spec.js.snap
+++ b/tests/jest/components/admin/__snapshots__/TextInput.spec.js.snap
@@ -12,6 +12,8 @@ exports[`TextInput is required prop should not add asterik to the label text 1`]
 </div>
 `;
 
+exports[`TextInput messages should add the target blank on ta "a" tag if present 1`] = `<div class="text-input-hint">some hint <a href="some-link" target="_blank">here to go</a> message</div>`;
+
 exports[`TextInput messages should show error message if both error message and hint text are provided 1`] = `
 <div class="text-input">
   <div class="text-input-label">


### PR DESCRIPTION
## Description
- translation fn from nextcloud strips `target="_blank"` from the text
- dompurify.sanitize() also strips the target blank from the input text

with this pr,
- removed target blank for the translation input
- added target blank for the hint text inside the `TextInput` component
- the dompurify sanitize is made to allow the target blank

## Related:
fixes: https://community.openproject.org/projects/nextcloud-integration/work_packages/43168/github?query_id=3407


https://community.openproject.org/work_packages/43168
Signed-off-by: Kiran Parajuli <kiranparajuli589@gmail.com>