### PR TITLE
[#43199] use host.docker.internal instead of network_mode: "host"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,4 @@ log/
 vendor/
 .php-cs-fixer.cache
 tests/pact/
-
+docker-compose.override.yml

--- a/README.md
+++ b/README.md
@@ -16,13 +16,15 @@ Requirements:
   - for v2, make sure to use `docker compose` instead of `docker-compose`
 - OpenProject server instance running in the host machine
 
-  it must be reachable by the hostname `host.docker.internal`.
+  It must be reachable by the hostname `host.docker.internal`, you can do this through this environment variable: `OPENPROJECT_DEV_EXTRA_HOSTS=host.docker.internal`.
 
-  This hostname will resolve to `127.0.0.1` on the docker host and to something like `172.17.0.1` inside of the docker services, so OpenProject needs to listen to those addresses
+  This hostname will resolve to `127.0.0.1` on the docker host and to something like `172.17.0.1` inside of the docker services, so OpenProject needs to listen to those addresses. For that use the `-b` option if you are running OpenProject manually e.g. `bin/rails server -b 0.0.0.0` or when using foreman set `HOST=0.0.0.0` as env. variable.
+
+  The whole OpenProject start command might look something like:
+  - manual start: `OPENPROJECT_DEV_EXTRA_HOSTS=host.docker.internal RAILS_ENV=development bin/rails server -b 0.0.0.0`
+  - using foreman: `HOST=0.0.0.0 OPENPROJECT_DEV_EXTRA_HOSTS=host.docker.internal foreman start -f Procfile.dev`
 
   For more information see: [OpenProject documentation](https://www.openproject.org/docs/development/development-environment-ubuntu/)
-
->**Note:**  While starting the OpenProject server make sure to add environment variable `OPENPROJECT_FEATURE__STORAGES__MODULE__ACTIVE=true` or set `feature_storages_module_active: true` in the `configuration.yml`
 
 - OpenProject integration app
 
@@ -49,7 +51,6 @@ sudo chmod g+w $HOME/development/custom_apps -R
   - default: `./../../custom_apps`
 
 ### Start compose
-**Note:** If your host machine has anything up on port `80`, please kill it before starting. 
 
 It is highly recommended to regularly update the included containers.
 ```shell

--- a/README.md
+++ b/README.md
@@ -14,7 +14,13 @@ Requirements:
 - Docker Compose
   - for v1, minimum version required is v1.29.0 (our guide is for v1)
   - for v2, make sure to use `docker compose` instead of `docker-compose`
-- OpenProject server instance running in the host machine, you can set up openProject and get it running with the help of this [documentation](https://www.openproject.org/docs/development/development-environment-ubuntu/)
+- OpenProject server instance running in the host machine
+
+  it must be reachable by the hostname `host.docker.internal`.
+
+  This hostname will resolve to `127.0.0.1` on the docker host and to something like `172.17.0.1` inside of the docker services, so OpenProject needs to listen to those addresses
+
+  For more information see: [OpenProject documentation](https://www.openproject.org/docs/development/development-environment-ubuntu/)
 
 >**Note:**  While starting the OpenProject server make sure to add environment variable `OPENPROJECT_FEATURE__STORAGES__MODULE__ACTIVE=true` or set `feature_storages_module_active: true` in the `configuration.yml`
 
@@ -56,7 +62,7 @@ docker-compose up
 ```
 **Note:** If you've cloned the integration app anywhere other that the default `./../../custom_apps`, provide its path in the `APP_DIR` environment variable
 ```shell
-APP_DIR = <path-to-integration-app> docker-compose up
+APP_DIR=<path-to-integration-app> docker-compose up
 ```
 
 After this, you should be able to access the Nextcloud server at [http://localhost](http://localhost).
@@ -66,7 +72,7 @@ After this, you should be able to access the Nextcloud server at [http://localho
 > **Note:** These steps will only be necessary for the first setup.
 
 #### Create admin
-1. Browse to [http://localhost](http://localhost)
+1. Browse to [http://localhost:8080](http://localhost:8080)
 2. Create an admin user
 3. Get an installed NC server
 
@@ -75,7 +81,7 @@ For the database, **PostgreSQL** is used with the following credentials:
 - **User:** `nextcloud`
 - **Password:** `nextcloud`
 
-#### Enable integration app 
+#### Enable the integration app:
 You can browse as admin to the apps center and enable it using the webUI or you can just use the terminal as:
 
 ```shell
@@ -87,6 +93,11 @@ docker exec --user www-data integration_openproject_nc php occ a:e integration_o
 ```shell
 docker exec --user www-data integration_openproject_nc php occ config:system:set allow_local_remote_servers --value 1
 ```
+
+#### Configure the integration app:
+- as NextCloud admin browse to Settings->Administration->OpenProject
+- configure the connection to OpenProject using `http://host.docker.internal:3000` as the OpenProject URL
+- in OpenProject use `http://localhost:8080` as the NextCloud URL
 
 ### Start Developing
 Now you can watch for the app code changes using the following command and start developing.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     restart: always
     volumes:
       - db:/var/lib/postgresql/data
+    networks:
+      - nextcloud
     environment:
       - POSTGRES_DB=nextcloud
       - POSTGRES_USER=nextcloud
@@ -23,6 +25,8 @@ services:
     volumes:
       - nextcloud:/var/www/html
       - ${APP_DIR:-./../../custom_apps}:/var/www/html/custom_apps
+    networks:
+      - nextcloud
     environment:
       - POSTGRES_HOST=db
       - POSTGRES_DB=nextcloud
@@ -37,10 +41,15 @@ services:
     restart: always
     volumes:
       - nextcloud:/var/www/html
+    networks:
+      - nextcloud
     entrypoint: /cron.sh
     depends_on:
       - db
 
 volumes:
   db:
+  nextcloud:
+
+networks:
   nextcloud:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,6 @@ services:
     image: postgres:alpine
     container_name: integration_openproject_db
     restart: always
-    ports:
-      - "5433:5432"
     volumes:
       - db:/var/lib/postgresql/data
     environment:
@@ -18,12 +16,15 @@ services:
     image: nextcloud:apache
     container_name: integration_openproject_nc
     restart: always
-    network_mode: "host"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    ports:
+      - "8080:80"
     volumes:
       - nextcloud:/var/www/html
       - ${APP_DIR:-./../../custom_apps}:/var/www/html/custom_apps
     environment:
-      - POSTGRES_HOST=localhost:5433
+      - POSTGRES_HOST=db
       - POSTGRES_DB=nextcloud
       - POSTGRES_USER=nextcloud
       - POSTGRES_PASSWORD=nextcloud


### PR DESCRIPTION
using the host network resulted in port 80 being blocked on the docker host

the issue is that the NextCloud UI (from the users browser, most likely on the docker host) needs to reach OpenProject using the same URL as the NextCloud backend (fron inside the docker service)
this is now achieved by using `host.docker.internal`
