### PR TITLE
[Task/43200] update the `Reset`  button text to `Replace`

### DIFF
--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -84,9 +84,9 @@
 					data-test-id="reset-op-oauth-btn"
 					@click="resetOPOAuthClientValues">
 					<template #icon>
-						<RestoreIcon :size="20" />
+						<AutoRenewIcon :size="20" />
 					</template>
-					{{ t('integration_openproject', 'Reset OpenProject OAuth values') }}
+					{{ t('integration_openproject', 'Replace OpenProject OAuth values') }}
 				</Button>
 				<Button v-else
 					data-test-id="submit-op-oauth-btn"
@@ -149,9 +149,9 @@
 					data-test-id="reset-nc-oauth-btn"
 					@click="resetNcOauthValues">
 					<template #icon>
-						<RestoreIcon :size="20" />
+						<AutoRenewIcon :size="20" />
 					</template>
-					{{ t('integration_openproject', 'Reset Nextcloud OAuth values') }}
+					{{ t('integration_openproject', 'Replace Nextcloud OAuth values') }}
 				</Button>
 			</div>
 		</div>
@@ -167,8 +167,8 @@ import { generateUrl } from '@nextcloud/router'
 import { showSuccess, showError } from '@nextcloud/dialogs'
 import CheckBoldIcon from 'vue-material-design-icons/CheckBold.vue'
 import PencilIcon from 'vue-material-design-icons/Pencil.vue'
-import RestoreIcon from 'vue-material-design-icons/Restore.vue'
 import LoadingIcon from 'vue-material-design-icons/Loading.vue'
+import AutoRenewIcon from 'vue-material-design-icons/Autorenew.vue'
 import TextInput from './admin/TextInput'
 import FieldValue from './admin/FieldValue'
 import FormHeading from './admin/FormHeading'
@@ -187,8 +187,8 @@ export default {
 		SettingsTitle,
 		CheckBoldIcon,
 		PencilIcon,
-		RestoreIcon,
 		LoadingIcon,
+		AutoRenewIcon,
 	},
 	data() {
 		return {

--- a/tests/jest/components/__snapshots__/AdminSettings.spec.js.snap
+++ b/tests/jest/components/__snapshots__/AdminSettings.spec.js.snap
@@ -20,7 +20,7 @@ exports[`AdminSettings Nextcloud OAuth values form view mode with complete value
     <fieldvalue-stub title="Nextcloud OAuth client ID" value="some-nc-client-id-here" isrequired="true"></fieldvalue-stub>
     <fieldvalue-stub title="Nextcloud OAuth client secret" value="some-nc-client-secret-here" isrequired="true" encryptvalue="true" withinspection="true"></fieldvalue-stub>
     <button-stub type="secondary" nativetype="button" data-test-id="reset-nc-oauth-btn">
-      Reset Nextcloud OAuth values
+      Replace Nextcloud OAuth values
     </button-stub>
   </div>
 </div>
@@ -89,8 +89,8 @@ exports[`AdminSettings OpenProject OAuth values form view mode and completed sta
         openproj***************
       </div>
       <!---->
-    </div> <button data-v-27e36536="" type="button" data-test-id="reset-op-oauth-btn" class="button-vue button-vue--icon-and-text button-vue--vue-secondary"><span data-v-27e36536="" class="button-vue__wrapper"><span data-v-27e36536="" class="button-vue__icon"><span aria-hidden="true" role="img" class="material-design-icon restore-icon" data-v-27e36536=""><svg fill="currentColor" width="20" height="20" viewBox="0 0 24 24" class="material-design-icon__svg"><path d="M13,3A9,9 0 0,0 4,12H1L4.89,15.89L4.96,16.03L9,12H6A7,7 0 0,1 13,5A7,7 0 0,1 20,12A7,7 0 0,1 13,19C11.07,19 9.32,18.21 8.06,16.94L6.64,18.36C8.27,20 10.5,21 13,21A9,9 0 0,0 22,12A9,9 0 0,0 13,3Z"><!----></path></svg></span></span> <span data-v-27e36536="" class="button-vue__text">
-				Reset OpenProject OAuth values
+    </div> <button data-v-27e36536="" type="button" data-test-id="reset-op-oauth-btn" class="button-vue button-vue--icon-and-text button-vue--vue-secondary"><span data-v-27e36536="" class="button-vue__wrapper"><span data-v-27e36536="" class="button-vue__icon"><span aria-hidden="true" role="img" class="material-design-icon autorenew-icon" data-v-27e36536=""><svg fill="currentColor" width="20" height="20" viewBox="0 0 24 24" class="material-design-icon__svg"><path d="M12,6V9L16,5L12,1V4A8,8 0 0,0 4,12C4,13.57 4.46,15.03 5.24,16.26L6.7,14.8C6.25,13.97 6,13 6,12A6,6 0 0,1 12,6M18.76,7.74L17.3,9.2C17.74,10.04 18,11 18,12A6,6 0 0,1 12,18V15L8,19L12,23V20A8,8 0 0,0 20,12C20,10.43 19.54,8.97 18.76,7.74Z"><!----></path></svg></span></span> <span data-v-27e36536="" class="button-vue__text">
+				Replace OpenProject OAuth values
 			</span></span></button>
   </div>
 </div>


### PR DESCRIPTION
## Description
- repharase reset button text to `Replace`
- use double arrow icon https://materialdesignicons.com/icon/autorenew

## Snapshots
![Screenshot from 2022-07-14 12-08-45](https://user-images.githubusercontent.com/39373750/178914624-06e431ba-9b21-4684-97b3-7f789c54584e.png)
![Screenshot from 2022-07-14 12-09-02](https://user-images.githubusercontent.com/39373750/178914648-678510ac-1e3c-4205-83c9-0b55cf452ac6.png)

