### PR TITLE
Fix link sanitation, allow target="_blank"

### DIFF
--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -264,12 +264,12 @@ export default {
 		openProjectClientHint() {
 			const linkText = t('integration_openproject', 'Administration > File storages')
 			const htmlLink = `<a class="link" href="${this.adminFileStorageHref}" target="_blank" title="${linkText}">${linkText}</a>`
-			return t('integration_openproject', 'Go to your OpenProject {htmlLink} as an Administrator and start the setup and copy the values here.', { htmlLink }, null, { escape: false })
+			return t('integration_openproject', 'Go to your OpenProject {htmlLink} as an Administrator and start the setup and copy the values here.', { htmlLink }, null, { escape: false, sanitize: false })
 		},
 		nextcloudClientHint() {
 			const linkText = t('integration_openproject', 'Administration > File storages')
 			const htmlLink = `<a class="link" href="${this.adminFileStorageHref}" target="_blank" title="${linkText}">${linkText}</a>`
-			return t('integration_openproject', 'Copy the following values back into the OpenProject {htmlLink} as an Administrator.', { htmlLink }, null, { escape: false })
+			return t('integration_openproject', 'Copy the following values back into the OpenProject {htmlLink} as an Administrator.', { htmlLink }, null, { escape: false, sanitize: false })
 		},
 	},
 	created() {

--- a/src/components/admin/TextInput.vue
+++ b/src/components/admin/TextInput.vue
@@ -121,7 +121,7 @@ export default {
 			}
 		},
 		sanitizedHintText() {
-			return dompurify.sanitize(this.hintText)
+			return dompurify.sanitize(this.hintText, { ADD_ATTR: ['target'] })
 		},
 	},
 	methods: {


### PR DESCRIPTION
There was a double sanitation from t() and dompurify.
This removes the t() one and tells dompurify to allow `target="_blank"`

## Related:
fixes: https://community.openproject.org/projects/nextcloud-integration/work_packages/43168/github?query_id=3407