### PR TITLE
set default color when no color is set for status

### DIFF
--- a/src/components/tab/WorkPackage.vue
+++ b/src/components/tab/WorkPackage.vue
@@ -75,6 +75,7 @@ export default {
 			font-size: 0.75rem;
 			border-radius: 2px;
 			margin-right: 4px;
+			background-color: #F99601;
 
 			&__title {
 				font-size: 0.75rem;


### PR DESCRIPTION
part of https://community.openproject.org/projects/nextcloud-integration/work_packages/43206

if the status has no color set by the API use a default one
