### PR TITLE
calculate contrast for wp type and show border if low

### DIFF
--- a/src/components/tab/WorkPackage.vue
+++ b/src/components/tab/WorkPackage.vue
@@ -56,7 +56,7 @@ export default {
 	data: () => ({
 		wpTypeTextStroke: 'unset',
 		wpStatusFontColor: '#FFFFFF',
-		wpStatusBorder: '0px',
+		wpStatusBorder: '0',
 	}),
 	created() {
 		this.setWPTypeTextStroke()
@@ -100,7 +100,7 @@ export default {
 					this.wpStatusBorder = 'solid 1px #000000'
 					return
 				}
-				this.wpStatusBorder = '0px'
+				this.wpStatusBorder = '0'
 			} catch (e) {
 				// something went  wrong, leave the values as they are
 			}

--- a/src/components/tab/WorkPackage.vue
+++ b/src/components/tab/WorkPackage.vue
@@ -2,8 +2,9 @@
 	<div class="workpackage" @mouseover="setWPTypeTextStroke" @mouseleave="setWPTypeTextStroke">
 		<div class="row">
 			<div class="row__status"
-				:style="{'background-color':workpackage.statusCol}">
-				<div class="row__status__title">
+				:style="{'background-color': getWPStatusColor()}">
+				<div class="row__status__title"
+					:style="{'color': wpStatusFontColor }">
 					{{ workpackage.statusTitle }}
 				</div>
 			</div>
@@ -54,11 +55,33 @@ export default {
 	},
 	data: () => ({
 		wpTypeTextStroke: 'unset',
+		wpStatusFontColor: '#FFFFFF',
 	}),
 	created() {
 		this.setWPTypeTextStroke()
+		this.setWPStatusFontColor()
 	},
 	methods: {
+		getWPStatusColor() {
+			if (this.workpackage.statusCol === undefined || this.workpackage.statusCol === '') {
+				return '#F99601'
+			}
+			return this.workpackage.statusCol
+		},
+		setWPStatusFontColor() {
+			this.wpStatusFontColor = '#FFFFFF'
+			try {
+				const contrast = this.contrastRatio(
+					this.wpStatusFontColor,
+					this.getWPStatusColor()
+				)
+				if (contrast <= 2) {
+					this.wpStatusFontColor = '#000000'
+				}
+			} catch (e) {
+				// something went  wrong, leave the values as they are
+			}
+		},
 		setWPTypeTextStroke() {
 			this.wpTypeTextStroke = 'unset'
 			try {
@@ -195,13 +218,11 @@ export default {
 			font-size: 0.75rem;
 			border-radius: 2px;
 			margin-right: 4px;
-			background-color: #F99601;
 
 			&__title {
 				font-size: 0.75rem;
 				line-height: 14px;
 				text-align: center;
-				filter: contrast(0) brightness(0);
 			}
 		}
 

--- a/src/components/tab/WorkPackage.vue
+++ b/src/components/tab/WorkPackage.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="workpackage">
+	<div class="workpackage" @mouseover="setWPTypeTextStroke" @mouseleave="setWPTypeTextStroke">
 		<div class="row">
 			<div class="row__status"
 				:style="{'background-color':workpackage.statusCol}">
@@ -13,7 +13,9 @@
 		</div>
 		<div class="row">
 			<div class="row__subject">
-				<span class="row__subject__type" :style="{'color':workpackage.typeCol}">
+				<span :ref="workpackage.typeTitle"
+					class="row__subject__type"
+					:style="{'color': workpackage.typeCol, '-webkit-text-stroke': wpTypeTextStroke}">
 					{{ workpackage.typeTitle }}
 				</span>
 				{{ workpackage.subject }}
@@ -48,6 +50,124 @@ export default {
 		workpackage: {
 			type: Object,
 			required: true,
+		},
+	},
+	data: () => ({
+		wpTypeTextStroke: 'unset',
+	}),
+	created() {
+		this.setWPTypeTextStroke()
+	},
+	methods: {
+		setWPTypeTextStroke() {
+			this.wpTypeTextStroke = 'unset'
+			try {
+				const contrast = this.getContrastBetweenTypeColorAndBackground()
+				if (contrast <= 2) {
+					this.wpTypeTextStroke = '0.5px grey'
+				}
+			} catch {
+				// something went  wrong, leave the values as they are
+			}
+		},
+		getContrastBetweenTypeColorAndBackground() {
+			let el = document.getElementById('workpackage-' + this.workpackage.id)
+			if (el === null) {
+				el = document.getElementById('tab-open-project')
+			}
+			const backgroundColor = this.getBackgroundColor(el)
+
+			return this.contrastRatio(
+				this.workpackage.typeCol,
+				backgroundColor
+			)
+		},
+
+		hexToRgbA(hex) {
+			let c
+			if (/^#([A-Fa-f0-9]{3}){1,2}$/.test(hex)) {
+				c = hex.substring(1).split('')
+				if (c.length === 3) {
+					c = [c[0], c[0], c[1], c[1], c[2], c[2]]
+				}
+				c = '0x' + c.join('')
+				return 'rgba(' + [(c >> 16) & 255, (c >> 8) & 255, c & 255].join(',') + ',1)'
+			}
+			throw new Error('Bad Hex')
+		},
+		// Parse rgb(r, g, b) and rgba(r, g, b, a) strings into an array.
+		// originated from https://github.com/jasonday/color-contrast/blob/e533684ce5d0c8d28479b3301b184bf88f5b7dd6/color-contrast.js
+		// Adapted from https://github.com/gka/chroma.js
+		parseRgb(colorString) {
+			let i, rgb, _i, _j
+			try {
+				colorString = this.hexToRgbA(colorString)
+			} catch (e) {
+				// it was not a hex string, so most likely a rgb(a) string
+			}
+			const rgbMatch = colorString.match(/rgb\(\s*(-?\d+),\s*(-?\d+)\s*,\s*(-?\d+)\s*\)/)
+			const rgbaMatch = colorString.match(/rgba\(\s*(-?\d+),\s*(-?\d+)\s*,\s*(-?\d+)\s*,\s*([01]|[01]?\.\d+)\)/)
+			if (rgbMatch !== null) {
+				rgb = rgbMatch.slice(1, 4)
+				for (i = _i = 0; _i <= 2; i = ++_i) {
+					rgb[i] = +rgb[i]
+				}
+				rgb[3] = 1
+				// eslint-disable-next-line no-cond-assign
+			} else if (rgbaMatch !== null) {
+				rgb = rgbaMatch.slice(1, 5)
+				for (i = _j = 0; _j <= 3; i = ++_j) {
+					rgb[i] = +rgb[i]
+				}
+			} else {
+				throw new Error('could not parse color')
+			}
+			return rgb
+
+		},
+		// originated from https://github.com/jasonday/color-contrast/blob/e533684ce5d0c8d28479b3301b184bf88f5b7dd6/color-contrast.js
+		// Based on http://www.w3.org/TR/WCAG20/#relativeluminancedef
+		relativeLuminance(c) {
+			const lum = []
+			for (let i = 0; i < 3; i++) {
+				const v = c[i] / 255
+				lum.push(v < 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4))
+			}
+			return (0.2126 * lum[0]) + (0.7152 * lum[1]) + (0.0722 * lum[2])
+		},
+		// originated from https://github.com/jasonday/color-contrast/blob/e533684ce5d0c8d28479b3301b184bf88f5b7dd6/color-contrast.js
+		// Based on http://www.w3.org/TR/WCAG20/#contrast-ratiodef
+		contrastRatio(x, y) {
+			const l1 = this.relativeLuminance(this.parseRgb(x))
+			const l2 = this.relativeLuminance(this.parseRgb(y))
+			return (Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05)
+		},
+		// originated from https://github.com/jasonday/color-contrast/blob/e533684ce5d0c8d28479b3301b184bf88f5b7dd6/color-contrast.js
+		getBackgroundColor(el) {
+			const styles = getComputedStyle(el)
+			const bgColor = styles.backgroundColor
+			const bgImage = styles.backgroundImage
+			const rgb = this.parseRgb(bgColor) + ''
+			const alpha = rgb.split(',')
+
+			// if background has alpha transparency, flag manual check
+			if (alpha[3] < 1 && alpha[3] > 0) {
+				throw new Error('could not determine background color')
+			}
+
+			// if element has no background image, or transparent background (alpha == 0) return bgColor
+			if (bgColor !== 'rgba(0, 0, 0, 0)' && bgColor !== 'transparent' && bgImage === 'none' && alpha[3] !== '0') {
+				return bgColor
+			} else if (bgImage !== 'none') {
+				throw new Error('could not determine background color')
+			}
+
+			// retest if not returned above
+			if (el.tagName === 'HTML') {
+				return 'rgb(255, 255, 255)'
+			} else {
+				return this.getBackgroundColor(el.parentNode)
+			}
 		},
 	},
 }

--- a/src/components/tab/WorkPackage.vue
+++ b/src/components/tab/WorkPackage.vue
@@ -1,8 +1,8 @@
 <template>
-	<div class="workpackage" @mouseover="setWPTypeTextStroke" @mouseleave="setWPTypeTextStroke">
+	<div class="workpackage" @mouseover="resetColorsOnHover" @mouseleave="resetColorsOnHover">
 		<div class="row">
 			<div class="row__status"
-				:style="{'background-color': getWPStatusColor()}">
+				:style="{'background-color': getWPStatusColor(), border: wpStatusBorder}">
 				<div class="row__status__title"
 					:style="{'color': wpStatusFontColor }">
 					{{ workpackage.statusTitle }}
@@ -56,12 +56,18 @@ export default {
 	data: () => ({
 		wpTypeTextStroke: 'unset',
 		wpStatusFontColor: '#FFFFFF',
+		wpStatusBorder: '0px',
 	}),
 	created() {
 		this.setWPTypeTextStroke()
 		this.setWPStatusFontColor()
+		this.setWPStatusBorder()
 	},
 	methods: {
+		resetColorsOnHover() {
+			this.setWPTypeTextStroke()
+			this.setWPStatusBorder()
+		},
 		getWPStatusColor() {
 			if (this.workpackage.statusCol === undefined || this.workpackage.statusCol === '') {
 				return '#F99601'
@@ -82,6 +88,27 @@ export default {
 				// something went  wrong, leave the values as they are
 			}
 		},
+		setWPStatusBorder() {
+			try {
+				let contrast = this.getContrastBetweenStatusColorAndBackground()
+				if (contrast <= 2) {
+					contrast = this.contrastRatio(this.getWPStatusColor(), '#000000')
+					if (contrast <= 2) {
+						this.wpStatusBorder = 'solid 1px #FFFFFF'
+						return
+					}
+					this.wpStatusBorder = 'solid 1px #000000'
+					return
+				}
+				this.wpStatusBorder = '0px'
+			} catch (e) {
+				// something went  wrong, leave the values as they are
+			}
+		},
+		getContrastBetweenStatusColorAndBackground() {
+			const backgroundColor = this.getBackgroundColor(this.getWPBackgroundElement())
+			return this.contrastRatio(this.getWPStatusColor(), backgroundColor)
+		},
 		setWPTypeTextStroke() {
 			this.wpTypeTextStroke = 'unset'
 			try {
@@ -94,18 +121,16 @@ export default {
 			}
 		},
 		getContrastBetweenTypeColorAndBackground() {
+			const backgroundColor = this.getBackgroundColor(this.getWPBackgroundElement())
+			return this.contrastRatio(this.workpackage.typeCol, backgroundColor)
+		},
+		getWPBackgroundElement() {
 			let el = document.getElementById('workpackage-' + this.workpackage.id)
 			if (el === null) {
 				el = document.getElementById('tab-open-project')
 			}
-			const backgroundColor = this.getBackgroundColor(el)
-
-			return this.contrastRatio(
-				this.workpackage.typeCol,
-				backgroundColor
-			)
+			return el
 		},
-
 		hexToRgbA(hex) {
 			let c
 			if (/^#([A-Fa-f0-9]{3}){1,2}$/.test(hex)) {

--- a/tests/jest/components/tab/__snapshots__/WorkPackage.spec.js.snap
+++ b/tests/jest/components/tab/__snapshots__/WorkPackage.spec.js.snap
@@ -4,7 +4,7 @@ exports[`WorkPackage.vue shows work packages information 1`] = `
 <div class="workpackage">
   <div class="row">
     <div class="row__status" style="background-color: blue;">
-      <div class="row__status__title">
+      <div class="row__status__title" style="color: rgb(255, 255, 255);">
         in-progress
       </div>
     </div>

--- a/tests/jest/components/tab/__snapshots__/WorkPackage.spec.js.snap
+++ b/tests/jest/components/tab/__snapshots__/WorkPackage.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`WorkPackage.vue shows work packages information 1`] = `
 <div class="workpackage">
   <div class="row">
-    <div class="row__status" style="background-color: blue;">
+    <div class="row__status" style="background-color: blue; border: 0px;">
       <div class="row__status__title" style="color: rgb(255, 255, 255);">
         in-progress
       </div>

--- a/tests/jest/views/__snapshots__/ProjectsTab.spec.js.snap
+++ b/tests/jest/views/__snapshots__/ProjectsTab.spec.js.snap
@@ -9,7 +9,7 @@ exports[`ProjectsTab.vue fetchWorkpackages adds every work-package only once 1`]
     <div class="linked-workpackages--workpackage">
       <div class="workpackage linked-workpackages--workpackage--item" id="workpackage-123">
         <div class="row">
-          <div class="row__status" style="background-color: rgb(249, 150, 1);">
+          <div class="row__status" style="background-color: rgb(249, 150, 1); border: 0px;">
             <div class="row__status__title" style="color: rgb(255, 255, 255);">
               open
             </div>
@@ -74,7 +74,7 @@ exports[`ProjectsTab.vue fetchWorkpackages shows the linked workpackages 1`] = `
     <div class="linked-workpackages--workpackage">
       <div class="workpackage linked-workpackages--workpackage--item" id="workpackage-123">
         <div class="row">
-          <div class="row__status" style="background-color: rgb(165, 216, 255);">
+          <div class="row__status" style="background-color: rgb(165, 216, 255); border: 0px;">
             <div class="row__status__title" style="color: rgb(0, 0, 0);">
               open
             </div>
@@ -114,7 +114,7 @@ exports[`ProjectsTab.vue fetchWorkpackages shows the linked workpackages 1`] = `
     <div class="linked-workpackages--workpackage">
       <div class="workpackage linked-workpackages--workpackage--item" id="workpackage-589">
         <div class="row">
-          <div class="row__status" style="background-color: rgb(165, 216, 255);">
+          <div class="row__status" style="background-color: rgb(165, 216, 255); border: 0px;">
             <div class="row__status__title" style="color: rgb(0, 0, 0);">
               प्रगति हुदैछ
             </div>
@@ -162,7 +162,7 @@ exports[`ProjectsTab.vue fetchWorkpackages shows the linked workpackages 2`] = `
     <div class="linked-workpackages--workpackage">
       <div class="workpackage linked-workpackages--workpackage--item" id="workpackage-123">
         <div class="row">
-          <div class="row__status" style="background-color: rgb(249, 150, 1);">
+          <div class="row__status" style="background-color: rgb(249, 150, 1); border: 0px;">
             <div class="row__status__title" style="color: rgb(255, 255, 255);">
               open
             </div>
@@ -202,7 +202,7 @@ exports[`ProjectsTab.vue fetchWorkpackages shows the linked workpackages 2`] = `
     <div class="linked-workpackages--workpackage">
       <div class="workpackage linked-workpackages--workpackage--item" id="workpackage-589">
         <div class="row">
-          <div class="row__status" style="background-color: rgb(249, 150, 1);">
+          <div class="row__status" style="background-color: rgb(249, 150, 1); border: 0px;">
             <div class="row__status__title" style="color: rgb(255, 255, 255);">
               प्रगति हुदैछ
             </div>
@@ -250,7 +250,7 @@ exports[`ProjectsTab.vue onSave shows the just linked workpackage 1`] = `
     <div class="linked-workpackages--workpackage">
       <div class="workpackage linked-workpackages--workpackage--item workpackage-transition" id="workpackage-1">
         <div class="row">
-          <div class="row__status" style="background-color: blue;">
+          <div class="row__status" style="background-color: blue; border: 0px;">
             <div class="row__status__title" style="color: rgb(255, 255, 255);">
               in-progress
             </div>

--- a/tests/jest/views/__snapshots__/ProjectsTab.spec.js.snap
+++ b/tests/jest/views/__snapshots__/ProjectsTab.spec.js.snap
@@ -9,8 +9,8 @@ exports[`ProjectsTab.vue fetchWorkpackages adds every work-package only once 1`]
     <div class="linked-workpackages--workpackage">
       <div class="workpackage linked-workpackages--workpackage--item" id="workpackage-123">
         <div class="row">
-          <div class="row__status">
-            <div class="row__status__title">
+          <div class="row__status" style="background-color: rgb(249, 150, 1);">
+            <div class="row__status__title" style="color: rgb(255, 255, 255);">
               open
             </div>
           </div>
@@ -75,7 +75,7 @@ exports[`ProjectsTab.vue fetchWorkpackages shows the linked workpackages 1`] = `
       <div class="workpackage linked-workpackages--workpackage--item" id="workpackage-123">
         <div class="row">
           <div class="row__status" style="background-color: rgb(165, 216, 255);">
-            <div class="row__status__title">
+            <div class="row__status__title" style="color: rgb(0, 0, 0);">
               open
             </div>
           </div>
@@ -115,7 +115,7 @@ exports[`ProjectsTab.vue fetchWorkpackages shows the linked workpackages 1`] = `
       <div class="workpackage linked-workpackages--workpackage--item" id="workpackage-589">
         <div class="row">
           <div class="row__status" style="background-color: rgb(165, 216, 255);">
-            <div class="row__status__title">
+            <div class="row__status__title" style="color: rgb(0, 0, 0);">
               प्रगति हुदैछ
             </div>
           </div>
@@ -162,8 +162,8 @@ exports[`ProjectsTab.vue fetchWorkpackages shows the linked workpackages 2`] = `
     <div class="linked-workpackages--workpackage">
       <div class="workpackage linked-workpackages--workpackage--item" id="workpackage-123">
         <div class="row">
-          <div class="row__status">
-            <div class="row__status__title">
+          <div class="row__status" style="background-color: rgb(249, 150, 1);">
+            <div class="row__status__title" style="color: rgb(255, 255, 255);">
               open
             </div>
           </div>
@@ -202,8 +202,8 @@ exports[`ProjectsTab.vue fetchWorkpackages shows the linked workpackages 2`] = `
     <div class="linked-workpackages--workpackage">
       <div class="workpackage linked-workpackages--workpackage--item" id="workpackage-589">
         <div class="row">
-          <div class="row__status">
-            <div class="row__status__title">
+          <div class="row__status" style="background-color: rgb(249, 150, 1);">
+            <div class="row__status__title" style="color: rgb(255, 255, 255);">
               प्रगति हुदैछ
             </div>
           </div>
@@ -251,7 +251,7 @@ exports[`ProjectsTab.vue onSave shows the just linked workpackage 1`] = `
       <div class="workpackage linked-workpackages--workpackage--item workpackage-transition" id="workpackage-1">
         <div class="row">
           <div class="row__status" style="background-color: blue;">
-            <div class="row__status__title">
+            <div class="row__status__title" style="color: rgb(255, 255, 255);">
               in-progress
             </div>
           </div>


### PR DESCRIPTION
check the contrast between the wp-type color and the background and set `-webkit-text-stroke` if the contrast is too little
1. if the workpackage is not listed yet, get the background color from the whole tab
2. if the workpackage is listed and an hover event happens, recalculate again

part of https://community.openproject.org/projects/nextcloud-integration/work_packages/43206

test-cases:
1. light theme and type color=white/light gray
before:
![image](https://user-images.githubusercontent.com/2425577/179176673-a622fe94-4e0f-4d01-a36f-fdf80ebaee7f.png)
![image](https://user-images.githubusercontent.com/2425577/179176928-b05b4360-66a7-4f13-9be6-ecdd8c16af6a.png)
now:
![image](https://user-images.githubusercontent.com/2425577/179175273-3a054064-dc8b-4499-900c-6f2c29b15e0a.png)
![image](https://user-images.githubusercontent.com/2425577/179175658-9e0323fd-29e1-4d73-a39f-0e64445a8d04.png)
3. dark theme and type color=black
before:
![image](https://user-images.githubusercontent.com/2425577/179176513-2748fd12-74bb-4c26-a8db-89194072e697.png)
now:
![image](https://user-images.githubusercontent.com/2425577/179175750-a793118b-687b-4abc-9cee-b3a1a6f05495.png)
4. high contrast mode and color=same as hover color of wp
before:
![image](https://user-images.githubusercontent.com/2425577/179176359-dc6c58ed-fee7-4534-8a9f-98d77304dc92.png)
now:
![image](https://user-images.githubusercontent.com/2425577/179176151-da985290-2f82-43a4-a035-9bbe3048a507.png)
