### PR TITLE
[#43211] reset OP host validity check

### DIFF
--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -21,7 +21,8 @@
 				place-holder="https://www.my-openproject.com"
 				:hint-text="t('integration_openproject', 'Please introduce your OpenProject host name')"
 				:error-message="serverHostErrorMessage"
-				@click="isServerHostUrlReadOnly = false" />
+				@click="isServerHostUrlReadOnly = false"
+				@input="isOpenProjectInstanceValid = null" />
 			<div class="d-flex">
 				<Button v-if="isServerHostFormInView"
 					data-test-id="reset-server-host-btn"

--- a/tests/jest/components/AdminSettings.spec.js
+++ b/tests/jest/components/AdminSettings.spec.js
@@ -218,6 +218,19 @@ describe('AdminSettings', () => {
 			})
 		})
 		describe('edit mode', () => {
+			it('should reset open project server host validity check on input', async () => {
+				const wrapper = getMountedWrapper()
+				await wrapper.setData({
+					isOpenProjectInstanceValid: true,
+				})
+
+				const oauthInstanceInput = wrapper.find(selectors.oauthInstanceInput)
+				await oauthInstanceInput.trigger('input')
+				await wrapper.vm.$nextTick()
+
+				expect(wrapper.vm.isOpenProjectInstanceValid).toBe(null)
+			})
+
 			describe('readonly state', () => {
 				let wrapper, oauthInstanceInput
 				beforeEach(() => {


### PR DESCRIPTION
when the host was checked if it served an open project instance but the input was changed the data of the check also needs to be invalidated

fixes https://community.openproject.org/projects/nextcloud-integration/work_packages/43211
