### PR TITLE
[#43302] show last modifier in files API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
         env:
           NEXTCLOUD_BASE_URL: http://localhost:8080
         run: |
-          git clone --depth 1 git@github.com:nextcloud/activity.git -b ${{ matrix.nextcloudVersion }} server/apps/activity
+          git clone --depth 1 https://github.com/nextcloud/activity.git -b ${{ matrix.nextcloudVersion }} server/apps/activity
           mkdir -p server/apps/integration_openproject
           cp -r `ls -A | grep -v 'server'` server/apps/integration_openproject/
           cd server

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,9 +93,11 @@ jobs:
         env:
           NEXTCLOUD_BASE_URL: http://localhost:8080
         run: |
+          git clone --depth 1 git@github.com:nextcloud/activity.git -b ${{ matrix.nextcloudVersion }} server/apps/activity
           mkdir -p server/apps/integration_openproject
           cp -r `ls -A | grep -v 'server'` server/apps/integration_openproject/
           cd server
+          ./occ a:e activity
           ./occ a:e integration_openproject
           php -S localhost:8080 2> /dev/null &
           cd apps/integration_openproject

--- a/lib/Controller/FilesController.php
+++ b/lib/Controller/FilesController.php
@@ -127,7 +127,10 @@ class FilesController extends OCSController {
 	 *               'size'?: int, 'owner_name'?: string, 'owner_id'?: string}
 	 */
 	private function compileFileInfo($fileId) {
-		$activity = new \OCA\Activity\Data($this->activityManager, $this->connection);
+		$activity = null;
+		if (class_exists('\OCA\Activity\Data')) {
+			$activity = new \OCA\Activity\Data($this->activityManager, $this->connection);
+		}
 
 
 		$userFolder = $this->rootFolder->getUserFolder($this->user->getUID());

--- a/lib/Controller/FilesController.php
+++ b/lib/Controller/FilesController.php
@@ -241,9 +241,11 @@ class FilesController extends OCSController {
 			}
 		}
 		if ($activities['has_more'] === true) {
-			return $this->getLastModifier(
-				$ownerId, $fileId, $activities['headers']['X-Activity-Last-Given']
-			);
+			$lastGiven = (int)$activities['headers']['X-Activity-Last-Given'];
+			if ($lastGiven > $since) {
+				return $this->getLastModifier($ownerId, $fileId, $lastGiven);
+			}
+
 		}
 		return null;
 	}

--- a/lib/Controller/FilesController.php
+++ b/lib/Controller/FilesController.php
@@ -152,7 +152,8 @@ class FilesController extends OCSController {
 	 * @param int $fileId
 	 * @return array{'status': string, 'statuscode': int, 'id'?: int, 'name'?:string,
 	 *               'mtime'?: int, 'ctime'?: int, 'mimetype'?: string, 'path'?: string,
-	 *               'size'?: int, 'owner_name'?: string, 'owner_id'?: string}
+	 *               'size'?: int, 'owner_name'?: string, 'owner_id'?: string, 'trashed'?: bool,
+	 *               'modifier_name'?: string, 'modifier_id'?: string}
 	 */
 	private function compileFileInfo($fileId) {
 		$userFolder = $this->rootFolder->getUserFolder($this->user->getUID());

--- a/lib/Controller/FilesController.php
+++ b/lib/Controller/FilesController.php
@@ -238,7 +238,12 @@ class FilesController extends OCSController {
 		);
 		foreach ($activities['data'] as $activity) {
 			if ($activity['type'] === 'file_changed') {
-				return $this->userManager->get($activity['user']);
+				$activityDetails = $activityData->getById($activity['activity_id']);
+				// rename and move events are also of type `file_changed` but don't have `changed_*` in the subject
+				// sadly we only get the localized subject from the `get()` request and need to do an other request
+				if (str_starts_with($activityDetails->getSubject(), 'changed')) {
+					return $this->userManager->get($activity['user']);
+				}
 			}
 		}
 		if ($activities['has_more'] === true) {

--- a/lib/Controller/FilesController.php
+++ b/lib/Controller/FilesController.php
@@ -251,7 +251,6 @@ class FilesController extends OCSController {
 			if ($lastGiven < $since || $since === 0) {
 				return $this->getLastModifier($ownerId, $fileId, $lastGiven);
 			}
-
 		}
 		return null;
 	}

--- a/lib/Controller/FilesController.php
+++ b/lib/Controller/FilesController.php
@@ -218,12 +218,14 @@ class FilesController extends OCSController {
 			return null;
 		}
 
+		// @phpstan-ignore-next-line - make phpstan not complain if activity app does not exist
 		$groupHelper = new GroupHelper(
 			$this->l,
 			$this->activityManager,
 			$this->richObjectValidator,
 			$this->logger
 		);
+		// @phpstan-ignore-next-line - make phpstan not complain if activity app does not exist
 		$userSettings = new UserSettings($this->activityManager, $this->config);
 		$activities = $activityData->get(
 			$groupHelper,

--- a/lib/Controller/FilesController.php
+++ b/lib/Controller/FilesController.php
@@ -248,7 +248,7 @@ class FilesController extends OCSController {
 		}
 		if ($activities['has_more'] === true) {
 			$lastGiven = (int)$activities['headers']['X-Activity-Last-Given'];
-			if ($lastGiven > $since) {
+			if ($lastGiven < $since || $since === 0) {
 				return $this->getLastModifier($ownerId, $fileId, $lastGiven);
 			}
 

--- a/lib/Controller/FilesController.php
+++ b/lib/Controller/FilesController.php
@@ -12,7 +12,6 @@
 namespace OCA\OpenProject\Controller;
 
 use OCA\Activity\Data;
-use OCA\Activity\GroupHelper;
 use OCA\Activity\GroupHelperDisabled;
 use OCA\Activity\UserSettings;
 use OCA\Files_Trashbin\Trash\ITrashManager;

--- a/lib/Controller/FilesController.php
+++ b/lib/Controller/FilesController.php
@@ -13,6 +13,7 @@ namespace OCA\OpenProject\Controller;
 
 use OCA\Activity\Data;
 use OCA\Activity\GroupHelper;
+use OCA\Activity\GroupHelperDisabled;
 use OCA\Activity\UserSettings;
 use OCA\Files_Trashbin\Trash\ITrashManager;
 use OCP\Activity\IManager;
@@ -219,12 +220,13 @@ class FilesController extends OCSController {
 		}
 
 		// @phpstan-ignore-next-line - make phpstan not complain if activity app does not exist
-		$groupHelper = new GroupHelper(
+		$groupHelper = new GroupHelperDisabled(
 			$this->l,
 			$this->activityManager,
 			$this->richObjectValidator,
 			$this->logger
 		);
+
 		// @phpstan-ignore-next-line - make phpstan not complain if activity app does not exist
 		$userSettings = new UserSettings($this->activityManager, $this->config);
 		$activities = $activityData->get(

--- a/tests/acceptance/features/api/getFileinfoByFileIDAPI.feature
+++ b/tests/acceptance/features/api/getFileinfoByFileIDAPI.feature
@@ -909,3 +909,62 @@ Feature: retrieve file information of a single file, using the file ID
       }
     }
    """
+
+
+  Scenario: get modifier of a file with a lot of unrelated change
+    Given user "Alice" has been created with display-name "Alice Hansen"
+    And user "Brian" has been created
+    And user "Chandra" has been created
+    And user "Alice" has uploaded file with content "some data" to "file.txt"
+    And user "Alice" has shared file "/file.txt" with user "Brian"
+    And user "Brian" has uploaded file with content "change" to "file.txt"
+    And user "Alice" has shared file "/file.txt" with user "Chandra"
+    And user "Brian" has shared file "/file.txt" with user "Chandra"
+    And user "Alice" has renamed file "/file.txt" to "/file1.txt"
+    And user "Alice" has renamed file "/file1.txt" to "/file2.txt"
+    And user "Alice" has renamed file "/file2.txt" to "/file3.txt"
+    And user "Alice" has renamed file "/file3.txt" to "/file4.txt"
+    And user "Alice" has renamed file "/file4.txt" to "/file5.txt"
+    And user "Alice" has renamed file "/file5.txt" to "/file6.txt"
+    And user "Alice" has renamed file "/file6.txt" to "/file7.txt"
+    And user "Alice" has renamed file "/file7.txt" to "/file8.txt"
+    And user "Alice" has renamed file "/file8.txt" to "/file9.txt"
+    And user "Alice" has renamed file "/file9.txt" to "/file10.txt"
+    And user "Alice" has renamed file "/file10.txt" to "/file11.txt"
+    And user "Alice" has renamed file "/file11.txt" to "/file12.txt"
+    And user "Alice" has renamed file "/file12.txt" to "/file13.txt"
+    And user "Alice" has renamed file "/file13.txt" to "/file14.txt"
+    And user "Alice" has renamed file "/file14.txt" to "/file15.txt"
+    And user "Alice" has renamed file "/file15.txt" to "/file16.txt"
+    And user "Alice" has renamed file "/file16.txt" to "/file17.txt"
+    And user "Alice" has renamed file "/file17.txt" to "/file18.txt"
+    And user "Alice" has renamed file "/file18.txt" to "/file19.txt"
+    And user "Alice" has renamed file "/file19.txt" to "/file20.txt"
+    When user "Alice" gets the information of last created file
+    Then the HTTP status code should be "200"
+    And the data of the response should match
+    """"
+    {
+    "type": "object",
+    "required": [
+        "status",
+        "statuscode",
+        "size",
+        "name",
+        "owner_id",
+        "owner_name",
+        "modifier_id",
+        "modifier_name"
+      ],
+      "properties": {
+          "status": {"type": "string", "pattern": "^OK$"},
+          "statuscode" : {"type" : "number", "enum": [200]},
+          "size" : {"type" : "integer", "enum": [6] },
+          "name": {"type": "string", "pattern": "^file20.txt$"},
+          "owner_id": {"type": "string", "pattern": "^Alice$"},
+          "owner_name": {"type": "string", "pattern": "^Alice Hansen$"},
+          "modifier_id": {"type": "string", "pattern": "^Brian"},
+          "modifier_name": {"type": "string", "pattern": "^Brian$"}
+      }
+    }
+   """

--- a/tests/acceptance/features/api/getFileinfoByFileIDAPI.feature
+++ b/tests/acceptance/features/api/getFileinfoByFileIDAPI.feature
@@ -35,8 +35,8 @@ Feature: retrieve file information of a single file, using the file ID
           "mimetype": {"type": "string", "pattern": "^text\/plain$"},
           "owner_id": {"type": "string", "pattern": "^Alice$"},
           "owner_name": {"type": "string", "pattern": "^Alice$"},
-          "modifier_id": null,
-          "modifier_name": null,
+          "modifier_id": {"type": "null"},
+          "modifier_name": {"type": "null"},
           "trashed": {"type": "boolean", "enum": [false]}
       }
     }
@@ -78,8 +78,8 @@ Feature: retrieve file information of a single file, using the file ID
           "mimetype": {"type": "string", "pattern": "^text\/plain$"},
           "owner_id": {"type": "string", "pattern": "^Alice$"},
           "owner_name": {"type": "string", "pattern": "^Alice$"},
-          "modifier_id": null,
-          "modifier_name": null,
+          "modifier_id": {"type": "null"},
+          "modifier_name": {"type": "null"},
           "trashed": {"type": "boolean", "enum": [false]}
       }
     }
@@ -121,8 +121,8 @@ Feature: retrieve file information of a single file, using the file ID
           "mimetype": {"type": "string", "pattern": "^text\/plain$"},
           "owner_id": {"type": "string", "pattern": "^Alice$"},
           "owner_name": {"type": "string", "pattern": "^Alice$"},
-          "modifier_id": null,
-          "modifier_name": null,
+          "modifier_id": {"type": "null"},
+          "modifier_name": {"type": "null"},
           "trashed": {"type": "boolean", "enum": [true]}
       }
     }
@@ -165,8 +165,8 @@ Feature: retrieve file information of a single file, using the file ID
           "mimetype": {"type": "string", "pattern": "^text\/plain$"},
           "owner_id": {"type": "string", "pattern": "^Alice$"},
           "owner_name": {"type": "string", "pattern": "^Alice$"},
-          "modifier_id": null,
-          "modifier_name": null,
+          "modifier_id": {"type": "null"},
+          "modifier_name": {"type": "null"},
           "trashed": {"type": "boolean", "enum": [true]}
       }
     }
@@ -269,8 +269,8 @@ Feature: retrieve file information of a single file, using the file ID
           "name": {"type": "string", "pattern": "^file.txt$"},
           "owner_id": {"type": "string", "pattern": "^Alice$"},
           "owner_name": {"type": "string", "pattern": "^Alice$"},
-          "modifier_id": null,
-          "modifier_name": null,
+          "modifier_id": {"type": "null"},
+          "modifier_name": {"type": "null"},
           "trashed": {"type": "boolean", "enum": [false]}
       }
     }
@@ -304,8 +304,8 @@ Feature: retrieve file information of a single file, using the file ID
           "name": {"type": "string", "pattern": "^file.txt$"},
           "owner_id": {"type": "string", "pattern": "^Alice$"},
           "owner_name": {"type": "string", "pattern": "^Alice$"},
-          "modifier_id": null,
-          "modifier_name": null,
+          "modifier_id": {"type": "null"},
+          "modifier_name": {"type": "null"},
           "trashed": {"type": "boolean", "enum": [false]}
       }
     }
@@ -340,8 +340,8 @@ Feature: retrieve file information of a single file, using the file ID
           "name": {"type": "string", "pattern": "^file.txt$"},
           "owner_id": {"type": "string", "pattern": "^Alice$"},
           "owner_name": {"type": "string", "pattern": "^Alice$"},
-          "modifier_id": null,
-          "modifier_name": null,
+          "modifier_id": {"type": "null"},
+          "modifier_name": {"type": "null"},
           "trashed": {"type": "boolean", "enum": [false]}
       }
     }
@@ -375,8 +375,8 @@ Feature: retrieve file information of a single file, using the file ID
           "name": {"type": "string", "pattern": "^file.txt$"},
           "owner_id": {"type": "string", "pattern": "^Alice$"},
           "owner_name": {"type": "string", "pattern": "^Alice$"},
-          "modifier_id": null,
-          "modifier_name": null,
+          "modifier_id": {"type": "null"},
+          "modifier_name": {"type": "null"},
           "trashed": {"type": "boolean", "enum": [false]}
       }
     }
@@ -411,8 +411,8 @@ Feature: retrieve file information of a single file, using the file ID
           "name": {"type": "string", "pattern": "^renamed.txt$"},
           "owner_id": {"type": "string", "pattern": "^Alice$"},
           "owner_name": {"type": "string", "pattern": "^Alice$"},
-          "modifier_id": null,
-          "modifier_name": null,
+          "modifier_id": {"type": "null"},
+          "modifier_name": {"type": "null"},
           "trashed": {"type": "boolean", "enum": [false]}
       }
     }
@@ -446,8 +446,8 @@ Feature: retrieve file information of a single file, using the file ID
           "name": {"type": "string", "pattern": "^moved-out.txt$"},
           "owner_id": {"type": "string", "pattern": "^Brian$"},
           "owner_name": {"type": "string", "pattern": "^Brian$"},
-          "modifier_id": null,
-          "modifier_name": null
+          "modifier_id": {"type": "null"},
+          "modifier_name": {"type": "null"}
       }
     }
    """
@@ -773,8 +773,8 @@ Feature: retrieve file information of a single file, using the file ID
           "statuscode" : {"type" : "number", "enum": [200]},
           "size" : {"type" : "integer", "enum": [12]},
           "name": {"type": "string", "pattern": "^file.txt$"},
-          "modifier_id": null,
-          "modifier_name": null
+          "modifier_id": {"type": "null"},
+          "modifier_name": {"type": "null"}
       }
     }
    """
@@ -820,8 +820,8 @@ Feature: retrieve file information of a single file, using the file ID
           "mimetype": {"type": "string", "pattern": "^httpd\/unix-directory$"},
           "owner_id": {"type": "string", "pattern": "^Alice$"},
           "owner_name": {"type": "string", "pattern": "^Alice Hansen$"},
-          "modifier_id": null,
-          "modifier_name": null,
+          "modifier_id": {"type": "null"},
+          "modifier_name": {"type": "null"},
           "trashed": {"type": "boolean", "enum": [false]}
       }
     }
@@ -866,8 +866,8 @@ Feature: retrieve file information of a single file, using the file ID
           "mimetype": {"type": "string", "pattern": "^text\/plain$"},
           "owner_id": {"type": "string", "pattern": "^Alice$"},
           "owner_name": {"type": "string", "pattern": "^Alice Hansen$"},
-          "modifier_id": null,
-          "modifier_name": null,
+          "modifier_id": {"type": "null"},
+          "modifier_name": {"type": "null"},
           "trashed": {"type": "boolean", "enum": [false]}
       }
     }
@@ -904,8 +904,8 @@ Feature: retrieve file information of a single file, using the file ID
           "name": {"type": "string", "pattern": "^file.txt$"},
           "owner_id": {"type": "string", "pattern": "^Alice$"},
           "owner_name": {"type": "string", "pattern": "^Alice Hansen$"},
-          "modifier_id": null,
-          "modifier_name": null
+          "modifier_id": {"type": "null"},
+          "modifier_name": {"type": "null"}
       }
     }
    """

--- a/tests/acceptance/features/api/getFileinfoByFileIDAPI.feature
+++ b/tests/acceptance/features/api/getFileinfoByFileIDAPI.feature
@@ -827,3 +827,85 @@ Feature: retrieve file information of a single file, using the file ID
     }
    """
 
+
+  Scenario: get modifier of a file changed through a public link
+    Given user "Alice" has been created with display-name "Alice Hansen"
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "some data" to "/folder/file.txt"
+    And user "Alice" has shared folder "/folder" with the public
+    And the public has uploaded file "file.txt" with content "changed content" to last created public link
+    When user "Alice" gets the information of the file "/folder/file.txt"
+    Then the HTTP status code should be "200"
+    And the data of the response should match
+    """"
+    {
+    "type": "object",
+    "required": [
+        "status",
+        "statuscode",
+        "id",
+        "size",
+        "name",
+        "mtime",
+        "ctime",
+        "mimetype",
+        "owner_id",
+        "owner_name",
+        "modifier_id",
+        "modifier_name",
+        "trashed"
+      ],
+      "properties": {
+          "status": {"type": "string", "pattern": "^OK$"},
+          "statuscode" : {"type" : "number", "enum": [200]},
+          "id" : {"type" : "integer", "minimum": 1, "maximum": 99999},
+          "size" : {"type" : "integer", "enum": [15] },
+          "mtime" : {"type" : "integer"},
+          "ctime" : {"type" : "integer", "enum": [0]},
+          "name": {"type": "string", "pattern": "^file.txt$"},
+          "mimetype": {"type": "string", "pattern": "^text\/plain$"},
+          "owner_id": {"type": "string", "pattern": "^Alice$"},
+          "owner_name": {"type": "string", "pattern": "^Alice Hansen$"},
+          "modifier_id": null,
+          "modifier_name": null,
+          "trashed": {"type": "boolean", "enum": [false]}
+      }
+    }
+   """
+
+
+  Scenario: get modifier of a file changed through a public link after a real change
+    Given user "Alice" has been created with display-name "Alice Hansen"
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "some data" to "/folder/file.txt"
+    And user "Alice" has uploaded file with content "change" to "/folder/file.txt"
+    And user "Alice" has shared folder "/folder" with the public
+    And the public has uploaded file "file.txt" with content "changed content" to last created public link
+    When user "Alice" gets the information of the file "/folder/file.txt"
+    Then the HTTP status code should be "200"
+    And the data of the response should match
+    """"
+    {
+    "type": "object",
+    "required": [
+        "status",
+        "statuscode",
+        "size",
+        "name",
+        "owner_id",
+        "owner_name",
+        "modifier_id",
+        "modifier_name"
+      ],
+      "properties": {
+          "status": {"type": "string", "pattern": "^OK$"},
+          "statuscode" : {"type" : "number", "enum": [200]},
+          "size" : {"type" : "integer", "enum": [15] },
+          "name": {"type": "string", "pattern": "^file.txt$"},
+          "owner_id": {"type": "string", "pattern": "^Alice$"},
+          "owner_name": {"type": "string", "pattern": "^Alice Hansen$"},
+          "modifier_id": null,
+          "modifier_name": null
+      }
+    }
+   """

--- a/tests/acceptance/features/api/getFileinfoByFileIDAPI.feature
+++ b/tests/acceptance/features/api/getFileinfoByFileIDAPI.feature
@@ -20,6 +20,8 @@ Feature: retrieve file information of a single file, using the file ID
         "mimetype",
         "owner_id",
         "owner_name",
+        "modifier_id",
+        "modifier_name",
         "trashed"
       ],
       "properties": {
@@ -33,6 +35,8 @@ Feature: retrieve file information of a single file, using the file ID
           "mimetype": {"type": "string", "pattern": "^text\/plain$"},
           "owner_id": {"type": "string", "pattern": "^Alice$"},
           "owner_name": {"type": "string", "pattern": "^Alice$"},
+          "modifier_id": null,
+          "modifier_name": null,
           "trashed": {"type": "boolean", "enum": [false]}
       }
     }
@@ -59,6 +63,8 @@ Feature: retrieve file information of a single file, using the file ID
         "mimetype",
         "owner_id",
         "owner_name",
+        "modifier_id",
+        "modifier_name",
         "trashed"
       ],
       "properties": {
@@ -72,6 +78,8 @@ Feature: retrieve file information of a single file, using the file ID
           "mimetype": {"type": "string", "pattern": "^text\/plain$"},
           "owner_id": {"type": "string", "pattern": "^Alice$"},
           "owner_name": {"type": "string", "pattern": "^Alice$"},
+          "modifier_id": null,
+          "modifier_name": null,
           "trashed": {"type": "boolean", "enum": [false]}
       }
     }
@@ -98,6 +106,8 @@ Feature: retrieve file information of a single file, using the file ID
         "mimetype",
         "owner_id",
         "owner_name",
+        "modifier_id",
+        "modifier_name",
         "trashed"
       ],
       "properties": {
@@ -111,6 +121,8 @@ Feature: retrieve file information of a single file, using the file ID
           "mimetype": {"type": "string", "pattern": "^text\/plain$"},
           "owner_id": {"type": "string", "pattern": "^Alice$"},
           "owner_name": {"type": "string", "pattern": "^Alice$"},
+          "modifier_id": null,
+          "modifier_name": null,
           "trashed": {"type": "boolean", "enum": [true]}
       }
     }
@@ -138,6 +150,8 @@ Feature: retrieve file information of a single file, using the file ID
         "mimetype",
         "owner_id",
         "owner_name",
+        "modifier_id",
+        "modifier_name",
         "trashed"
       ],
       "properties": {
@@ -151,6 +165,8 @@ Feature: retrieve file information of a single file, using the file ID
           "mimetype": {"type": "string", "pattern": "^text\/plain$"},
           "owner_id": {"type": "string", "pattern": "^Alice$"},
           "owner_name": {"type": "string", "pattern": "^Alice$"},
+          "modifier_id": null,
+          "modifier_name": null,
           "trashed": {"type": "boolean", "enum": [true]}
       }
     }
@@ -180,6 +196,8 @@ Feature: retrieve file information of a single file, using the file ID
           "mimetype",
           "owner_id",
           "owner_name",
+          "modifier_id",
+          "modifier_name",
           "trashed"
         ]
       },
@@ -212,6 +230,8 @@ Feature: retrieve file information of a single file, using the file ID
           "mimetype",
           "owner_id",
           "owner_name",
+          "modifier_id",
+          "modifier_name",
           "trashed"
         ]
       },
@@ -239,6 +259,8 @@ Feature: retrieve file information of a single file, using the file ID
         "name",
         "owner_id",
         "owner_name",
+        "modifier_id",
+        "modifier_name",
         "trashed"
       ],
       "properties": {
@@ -247,6 +269,8 @@ Feature: retrieve file information of a single file, using the file ID
           "name": {"type": "string", "pattern": "^file.txt$"},
           "owner_id": {"type": "string", "pattern": "^Alice$"},
           "owner_name": {"type": "string", "pattern": "^Alice$"},
+          "modifier_id": null,
+          "modifier_name": null,
           "trashed": {"type": "boolean", "enum": [false]}
       }
     }
@@ -270,6 +294,8 @@ Feature: retrieve file information of a single file, using the file ID
         "name",
         "owner_id",
         "owner_name",
+        "modifier_id",
+        "modifier_name",
         "trashed"
       ],
       "properties": {
@@ -278,6 +304,8 @@ Feature: retrieve file information of a single file, using the file ID
           "name": {"type": "string", "pattern": "^file.txt$"},
           "owner_id": {"type": "string", "pattern": "^Alice$"},
           "owner_name": {"type": "string", "pattern": "^Alice$"},
+          "modifier_id": null,
+          "modifier_name": null,
           "trashed": {"type": "boolean", "enum": [false]}
       }
     }
@@ -302,6 +330,8 @@ Feature: retrieve file information of a single file, using the file ID
         "name",
         "owner_id",
         "owner_name",
+        "modifier_id",
+        "modifier_name",
         "trashed"
       ],
       "properties": {
@@ -310,6 +340,8 @@ Feature: retrieve file information of a single file, using the file ID
           "name": {"type": "string", "pattern": "^file.txt$"},
           "owner_id": {"type": "string", "pattern": "^Alice$"},
           "owner_name": {"type": "string", "pattern": "^Alice$"},
+          "modifier_id": null,
+          "modifier_name": null,
           "trashed": {"type": "boolean", "enum": [false]}
       }
     }
@@ -333,6 +365,8 @@ Feature: retrieve file information of a single file, using the file ID
         "name",
         "owner_id",
         "owner_name",
+        "modifier_id",
+        "modifier_name",
         "trashed"
       ],
       "properties": {
@@ -341,6 +375,8 @@ Feature: retrieve file information of a single file, using the file ID
           "name": {"type": "string", "pattern": "^file.txt$"},
           "owner_id": {"type": "string", "pattern": "^Alice$"},
           "owner_name": {"type": "string", "pattern": "^Alice$"},
+          "modifier_id": null,
+          "modifier_name": null,
           "trashed": {"type": "boolean", "enum": [false]}
       }
     }
@@ -365,6 +401,8 @@ Feature: retrieve file information of a single file, using the file ID
         "name",
         "owner_id",
         "owner_name",
+        "modifier_id",
+        "modifier_name",
         "trashed"
       ],
       "properties": {
@@ -373,6 +411,8 @@ Feature: retrieve file information of a single file, using the file ID
           "name": {"type": "string", "pattern": "^renamed.txt$"},
           "owner_id": {"type": "string", "pattern": "^Alice$"},
           "owner_name": {"type": "string", "pattern": "^Alice$"},
+          "modifier_id": null,
+          "modifier_name": null,
           "trashed": {"type": "boolean", "enum": [false]}
       }
     }
@@ -396,14 +436,18 @@ Feature: retrieve file information of a single file, using the file ID
         "statuscode",
         "name",
         "owner_id",
-        "owner_name"
+        "owner_name",
+        "modifier_id",
+        "modifier_name"
       ],
       "properties": {
           "status": {"type": "string", "pattern": "^OK$"},
           "statuscode" : {"type" : "number",  "enum": [200] },
           "name": {"type": "string", "pattern": "^moved-out.txt$"},
           "owner_id": {"type": "string", "pattern": "^Brian$"},
-          "owner_name": {"type": "string", "pattern": "^Brian$"}
+          "owner_name": {"type": "string", "pattern": "^Brian$"},
+          "modifier_id": null,
+          "modifier_name": null
       }
     }
    """
@@ -427,6 +471,8 @@ Feature: retrieve file information of a single file, using the file ID
           "mimetype",
           "owner_id",
           "owner_name",
+          "modifier_id",
+          "modifier_name",
           "trashed"
         ]
       },

--- a/tests/acceptance/features/api/getFileinfoByFileIDAPI.feature
+++ b/tests/acceptance/features/api/getFileinfoByFileIDAPI.feature
@@ -484,7 +484,7 @@ Feature: retrieve file information of a single file, using the file ID
    """
 
   Scenario: get modifier when same user uploads and overwrites a file
-    Given user "Alice" has been created
+    Given user "Alice" has been created with display-name "Alice Hansen"
     And user "Alice" has uploaded file with content "some data" to "file.txt"
     And user "Alice" has uploaded file with content "changed data" to "file.txt"
     When user "Alice" gets the information of last created file
@@ -513,9 +513,9 @@ Feature: retrieve file information of a single file, using the file ID
           "ctime" : {"type" : "integer", "enum": [0]},
           "name": {"type": "string", "pattern": "^file.txt$"},
           "owner_id": {"type": "string", "pattern": "^Alice$"},
-          "owner_name": {"type": "string", "pattern": "^Alice$"},
+          "owner_name": {"type": "string", "pattern": "^Alice Hansen"},
           "modifier_id": {"type": "string", "pattern": "^Alice$"},
-          "modifier_name": {"type": "string", "pattern": "^Alice$"}
+          "modifier_name": {"type": "string", "pattern": "^Alice Hansen"}
       }
     }
    """
@@ -523,8 +523,8 @@ Feature: retrieve file information of a single file, using the file ID
 
   Scenario Outline: get modifier in a chain of shares
     Given user "Alice" has been created
-    And user "Brian" has been created
-    And user "Chandra" has been created
+    And user "Brian" has been created with display-name "Brian Peters"
+    And user "Chandra" has been created with display-name "Chandra Thapa"
     And user "Alice" has uploaded file with content "some data" to "file.txt"
     And user "Alice" has shared file "file.txt" with user "Brian"
     And user "Brian" has shared file "file.txt" with user "Chandra"
@@ -555,23 +555,23 @@ Feature: retrieve file information of a single file, using the file ID
           "ctime" : {"type" : "integer", "enum": [0]},
           "name": {"type": "string", "pattern": "^file.txt$"},
           "owner_id": {"type": "string", "pattern": "^Alice$"},
-          "owner_name": {"type": "string", "pattern": "^Alice$"},
+          "owner_name": {"type": "string", "pattern": "^Alice"},
           "modifier_id": {"type": "string", "pattern": "^<modifier>"},
-          "modifier_name": {"type": "string", "pattern": "^<modifier>"}
+          "modifier_name": {"type": "string", "pattern": "^<modifier-display-name>"}
       }
     }
    """
     Examples:
-      | modifier | retriever |
-      | Alice    | Alice     |
-      | Brian    | Alice     |
-      | Chandra  | Alice     |
-      | Alice    | Brian     |
-      | Brian    | Brian     |
-      | Chandra  | Brian     |
-      | Alice    | Chandra   |
-      | Brian    | Chandra   |
-      | Chandra  | Chandra   |
+      | modifier | modifier-display-name | retriever | comment                                              |
+      | Alice    | Alice                 | Alice     | display-name should be username if not specially set |
+      | Brian    | Brian Peters          | Alice     |                                                      |
+      | Chandra  | Chandra Thapa         | Alice     |                                                      |
+      | Alice    | Alice                 | Brian     |                                                      |
+      | Brian    | Brian Peters          | Brian     |                                                      |
+      | Chandra  | Chandra Thapa         | Brian     |                                                      |
+      | Alice    | Alice                 | Chandra   |                                                      |
+      | Brian    | Brian Peters          | Chandra   |                                                      |
+      | Chandra  | Chandra Thapa         | Chandra   |                                                      |
 
 
   Scenario: get modifier in a chain of shares when there are multiple modifiers

--- a/tests/acceptance/features/api/getFileinfoByFileIDAPI.feature
+++ b/tests/acceptance/features/api/getFileinfoByFileIDAPI.feature
@@ -482,3 +482,299 @@ Feature: retrieve file information of a single file, using the file ID
       }
     }
    """
+
+  Scenario: get modifier when same user uploads and overwrites a file
+    Given user "Alice" has been created
+    And user "Alice" has uploaded file with content "some data" to "file.txt"
+    And user "Alice" has uploaded file with content "changed data" to "file.txt"
+    When user "Alice" gets the information of last created file
+    Then the HTTP status code should be "200"
+    And the data of the response should match
+    """"
+    {
+    "type": "object",
+    "required": [
+        "status",
+        "statuscode",
+        "size",
+        "name",
+        "mtime",
+        "ctime",
+        "owner_id",
+        "owner_name",
+        "modifier_id",
+        "modifier_name"
+      ],
+      "properties": {
+          "status": {"type": "string", "pattern": "^OK$"},
+          "statuscode" : {"type" : "number", "enum": [200]},
+          "size" : {"type" : "integer", "enum": [12]},
+          "mtime" : {"type" : "integer"},
+          "ctime" : {"type" : "integer", "enum": [0]},
+          "name": {"type": "string", "pattern": "^file.txt$"},
+          "owner_id": {"type": "string", "pattern": "^Alice$"},
+          "owner_name": {"type": "string", "pattern": "^Alice$"},
+          "modifier_id": {"type": "string", "pattern": "^Alice$"},
+          "modifier_name": {"type": "string", "pattern": "^Alice$"}
+      }
+    }
+   """
+
+
+  Scenario Outline: get modifier in a chain of shares
+    Given user "Alice" has been created
+    And user "Brian" has been created
+    And user "Chandra" has been created
+    And user "Alice" has uploaded file with content "some data" to "file.txt"
+    And user "Alice" has shared file "file.txt" with user "Brian"
+    And user "Brian" has shared file "file.txt" with user "Chandra"
+    And user "<modifier>" has uploaded file with content "changed data" to "file.txt"
+    When user "<retriever>" gets the information of last created file
+    Then the HTTP status code should be "200"
+    And the data of the response should match
+    """"
+    {
+    "type": "object",
+    "required": [
+        "status",
+        "statuscode",
+        "size",
+        "name",
+        "mtime",
+        "ctime",
+        "owner_id",
+        "owner_name",
+        "modifier_id",
+        "modifier_name"
+      ],
+      "properties": {
+          "status": {"type": "string", "pattern": "^OK$"},
+          "statuscode" : {"type" : "number", "enum": [200]},
+          "size" : {"type" : "integer", "enum": [12]},
+          "mtime" : {"type" : "integer"},
+          "ctime" : {"type" : "integer", "enum": [0]},
+          "name": {"type": "string", "pattern": "^file.txt$"},
+          "owner_id": {"type": "string", "pattern": "^Alice$"},
+          "owner_name": {"type": "string", "pattern": "^Alice$"},
+          "modifier_id": {"type": "string", "pattern": "^<modifier>"},
+          "modifier_name": {"type": "string", "pattern": "^<modifier>"}
+      }
+    }
+   """
+    Examples:
+      | modifier | retriever |
+      | Alice    | Alice     |
+      | Brian    | Alice     |
+      | Chandra  | Alice     |
+      | Alice    | Brian     |
+      | Brian    | Brian     |
+      | Chandra  | Brian     |
+      | Alice    | Chandra   |
+      | Brian    | Chandra   |
+      | Chandra  | Chandra   |
+
+
+  Scenario: get modifier in a chain of shares when there are multiple modifiers
+    Given user "Alice" has been created
+    And user "Brian" has been created
+    And user "Chandra" has been created
+    And user "Dipak" has been created
+    And user "Alice" has uploaded file with content "some data" to "file.txt"
+    And user "Alice" has shared file "file.txt" with user "Brian"
+    And user "Brian" has shared file "file.txt" with user "Chandra"
+    And user "Alice" has shared file "file.txt" with user "Dipak"
+    And user "Brian" has uploaded file with content "from B 0" to "file.txt"
+    And user "Chandra" has uploaded file with content "from C 00" to "file.txt"
+    And user "Dipak" has uploaded file with content "from D 000" to "file.txt"
+    When user "Alice" gets the information of last created file
+    Then the HTTP status code should be "200"
+    And the data of the response should match
+    """"
+    {
+    "type": "object",
+    "required": [
+        "status",
+        "statuscode",
+        "size",
+        "name",
+        "mtime",
+        "ctime",
+        "owner_id",
+        "owner_name",
+        "modifier_id",
+        "modifier_name"
+      ],
+      "properties": {
+          "status": {"type": "string", "pattern": "^OK$"},
+          "statuscode" : {"type" : "number", "enum": [200]},
+          "size" : {"type" : "integer", "enum": [10]},
+          "mtime" : {"type" : "integer"},
+          "ctime" : {"type" : "integer", "enum": [0]},
+          "name": {"type": "string", "pattern": "^file.txt$"},
+          "owner_id": {"type": "string", "pattern": "^Alice$"},
+          "owner_name": {"type": "string", "pattern": "^Alice$"},
+          "modifier_id": {"type": "string", "pattern": "^Dipak"},
+          "modifier_name": {"type": "string", "pattern": "^Dipak"}
+      }
+    }
+   """
+
+
+  Scenario: get modifier in a chain of shares when there are multiple modifiers (sharing and modification mixed)
+    Given user "Alice" has been created
+    And user "Brian" has been created
+    And user "Chandra" has been created
+    And user "Dipak" has been created
+    And user "Alice" has uploaded file with content "some data" to "file.txt"
+    And user "Alice" has shared file "file.txt" with user "Brian"
+    And user "Brian" has uploaded file with content "from B 0" to "file.txt"
+    And user "Brian" has shared file "file.txt" with user "Chandra"
+    And user "Chandra" has uploaded file with content "from C 00" to "file.txt"
+    And user "Alice" has shared file "file.txt" with user "Dipak"
+    And user "Dipak" has uploaded file with content "from D 000" to "file.txt"
+    When user "Alice" gets the information of last created file
+    Then the HTTP status code should be "200"
+    And the data of the response should match
+    """"
+    {
+    "type": "object",
+    "required": [
+        "status",
+        "statuscode",
+        "size",
+        "name",
+        "mtime",
+        "ctime",
+        "owner_id",
+        "owner_name",
+        "modifier_id",
+        "modifier_name"
+      ],
+      "properties": {
+          "status": {"type": "string", "pattern": "^OK$"},
+          "statuscode" : {"type" : "number", "enum": [200]},
+          "size" : {"type" : "integer", "enum": [10]},
+          "mtime" : {"type" : "integer"},
+          "ctime" : {"type" : "integer", "enum": [0]},
+          "name": {"type": "string", "pattern": "^file.txt$"},
+          "owner_id": {"type": "string", "pattern": "^Alice$"},
+          "owner_name": {"type": "string", "pattern": "^Alice$"},
+          "modifier_id": {"type": "string", "pattern": "^Dipak"},
+          "modifier_name": {"type": "string", "pattern": "^Dipak"}
+      }
+    }
+   """
+
+
+  Scenario: get modifier after various renaming
+    Given user "Alice" has been created
+    And user "Brian" has been created
+    And user "Chandra" has been created
+    And user "Dipak" has been created
+    And user "Alice" has uploaded file with content "some data" to "file.txt"
+    And user "Alice" has shared file "file.txt" with user "Brian"
+    And user "Brian" has shared file "file.txt" with user "Chandra"
+    And user "Alice" has shared file "file.txt" with user "Dipak"
+    And user "Dipak" has uploaded file with content "changed data" to "file.txt"
+    And user "Alice" has renamed file "file.txt" to "Alices-file.txt"
+    And user "Brian" has renamed file "file.txt" to "Brians-file.txt"
+    And user "Chandra" has renamed file "file.txt" to "Chandras-file.txt"
+    When user "Alice" gets the information of last created file
+    Then the HTTP status code should be "200"
+    And the data of the response should match
+    """"
+    {
+    "type": "object",
+    "required": [
+        "status",
+        "statuscode",
+        "size",
+        "name",
+        "modifier_id",
+        "modifier_name"
+      ],
+      "properties": {
+          "status": {"type": "string", "pattern": "^OK$"},
+          "statuscode" : {"type" : "number", "enum": [200]},
+          "size" : {"type" : "integer", "enum": [12]},
+          "name": {"type": "string", "pattern": "^Alices-file.txt$"},
+          "modifier_id": {"type": "string", "pattern": "^Dipak"},
+          "modifier_name": {"type": "string", "pattern": "^Dipak"}
+      }
+    }
+   """
+
+
+  Scenario: get modifier after various moving
+    Given user "Alice" has been created
+    And user "Brian" has been created
+    And user "Chandra" has been created
+    And user "Dipak" has been created
+    And user "Alice" has uploaded file with content "some data" to "file.txt"
+    And user "Alice" has created folder "/Alice-folder"
+    And user "Brian" has created folder "/Brian-folder"
+    And user "Chandra" has created folder "/Chandra-folder"
+    And user "Alice" has shared file "file.txt" with user "Brian"
+    And user "Brian" has shared file "file.txt" with user "Chandra"
+    And user "Alice" has shared file "file.txt" with user "Dipak"
+    And user "Dipak" has uploaded file with content "changed data" to "file.txt"
+    And user "Alice" has moved file "file.txt" to "/Alice-folder/file.txt"
+    And user "Brian" has moved file "file.txt" to "/Brian-folder/file.txt"
+    And user "Chandra" has moved file "file.txt" to "/Chandra-folder/file.txt"
+    When user "Alice" gets the information of last created file
+    Then the HTTP status code should be "200"
+    And the data of the response should match
+    """"
+    {
+    "type": "object",
+    "required": [
+        "status",
+        "statuscode",
+        "size",
+        "name",
+        "modifier_id",
+        "modifier_name"
+      ],
+      "properties": {
+          "status": {"type": "string", "pattern": "^OK$"},
+          "statuscode" : {"type" : "number", "enum": [200]},
+          "size" : {"type" : "integer", "enum": [12]},
+          "name": {"type": "string", "pattern": "^file.txt$"},
+          "modifier_id": {"type": "string", "pattern": "^Dipak"},
+          "modifier_name": {"type": "string", "pattern": "^Dipak"}
+      }
+    }
+   """
+
+
+  Scenario: get modifier after the modifier was deleted
+    Given user "Alice" has been created
+    And user "Brian" has been created
+    And user "Alice" has uploaded file with content "some data" to "file.txt"
+    And user "Alice" has shared file "file.txt" with user "Brian"
+    And user "Brian" has uploaded file with content "changed data" to "file.txt"
+    And user "Brian" has been deleted
+    When user "Alice" gets the information of last created file
+    Then the HTTP status code should be "200"
+    And the data of the response should match
+    """"
+    {
+    "type": "object",
+    "required": [
+        "status",
+        "statuscode",
+        "size",
+        "name",
+        "modifier_id",
+        "modifier_name"
+      ],
+      "properties": {
+          "status": {"type": "string", "pattern": "^OK$"},
+          "statuscode" : {"type" : "number", "enum": [200]},
+          "size" : {"type" : "integer", "enum": [12]},
+          "name": {"type": "string", "pattern": "^file.txt$"},
+          "modifier_id": {"type": "string", "pattern": "^Brian"},
+          "modifier_name": {"type": "string", "pattern": "^Brian"}
+      }
+    }
+   """

--- a/tests/acceptance/features/api/getFileinfoByFileIDAPI.feature
+++ b/tests/acceptance/features/api/getFileinfoByFileIDAPI.feature
@@ -773,8 +773,8 @@ Feature: retrieve file information of a single file, using the file ID
           "statuscode" : {"type" : "number", "enum": [200]},
           "size" : {"type" : "integer", "enum": [12]},
           "name": {"type": "string", "pattern": "^file.txt$"},
-          "modifier_id": {"type": "string", "pattern": "^Brian"},
-          "modifier_name": {"type": "string", "pattern": "^Brian"}
+          "modifier_id": null,
+          "modifier_name": null
       }
     }
    """

--- a/tests/acceptance/features/api/getFileinfoByFileIDAPI.feature
+++ b/tests/acceptance/features/api/getFileinfoByFileIDAPI.feature
@@ -778,3 +778,52 @@ Feature: retrieve file information of a single file, using the file ID
       }
     }
    """
+
+
+  Scenario: get modifier of a folder
+    Given user "Alice" has been created with display-name "Alice Hansen"
+    And user "Brian" has been created
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "some data" to "/folder/file.txt"
+    And user "Alice" has shared folder "/folder" with user "Brian"
+    And user "Brian" has uploaded file with content "changed data" to "/folder/file.txt"
+    And user "Brian" has uploaded file with content "data" to "/folder/new-file.txt"
+    When user "Alice" gets the information of the folder "/folder"
+    Then the HTTP status code should be "200"
+    And the data of the response should match
+    """"
+    {
+    "type": "object",
+    "required": [
+        "status",
+        "statuscode",
+        "id",
+        "size",
+        "name",
+        "mtime",
+        "ctime",
+        "mimetype",
+        "owner_id",
+        "owner_name",
+        "modifier_id",
+        "modifier_name",
+        "trashed"
+      ],
+      "properties": {
+          "status": {"type": "string", "pattern": "^OK$"},
+          "statuscode" : {"type" : "number", "enum": [200]},
+          "id" : {"type" : "integer", "minimum": 1, "maximum": 99999},
+          "size" : {"type" : "integer", "enum": [16] },
+          "mtime" : {"type" : "integer"},
+          "ctime" : {"type" : "integer", "enum": [0]},
+          "name": {"type": "string", "pattern": "^folder$"},
+          "mimetype": {"type": "string", "pattern": "^httpd\/unix-directory$"},
+          "owner_id": {"type": "string", "pattern": "^Alice$"},
+          "owner_name": {"type": "string", "pattern": "^Alice Hansen$"},
+          "modifier_id": null,
+          "modifier_name": null,
+          "trashed": {"type": "boolean", "enum": [false]}
+      }
+    }
+   """
+

--- a/tests/acceptance/features/api/getFilesinfoByFileIDsAPI.feature
+++ b/tests/acceptance/features/api/getFilesinfoByFileIDsAPI.feature
@@ -2,7 +2,7 @@ Feature: retrieve information of multiple files using the file IDs
 
   Scenario: get information of four files, one own, one received as share, one trashed, one not accessible
     Given user "Alice" has been created
-    And user "Brian" has been created
+    And user "Brian" has been created with display-name "Brian Adams"
     And user "Alice" has uploaded file with content "some data" to "file.txt"
     And user "Brian" has uploaded file with content "some data" to "fromBrian.txt"
     And user "Alice" has uploaded file with content "more data" to "trashed.txt"
@@ -87,7 +87,7 @@ Feature: retrieve information of multiple files using the file IDs
               "name": {"type": "string", "pattern": "^fromBrian.txt$"},
               "mimetype": {"type": "string", "pattern": "^text\/plain$"},
               "owner_id": {"type": "string", "pattern": "^Brian$"},
-              "owner_name": {"type": "string", "pattern": "^Brian$"},
+              "owner_name": {"type": "string", "pattern": "^Brian Adams$"},
               "modifier_id": null,
               "modifier_name": null,
               "trashed": {"type": "boolean", "enum": [false]}

--- a/tests/acceptance/features/api/getFilesinfoByFileIDsAPI.feature
+++ b/tests/acceptance/features/api/getFilesinfoByFileIDsAPI.feature
@@ -55,8 +55,8 @@ Feature: retrieve information of multiple files using the file IDs
               "mimetype": {"type": "string", "pattern": "^text\/plain$"},
               "owner_id": {"type": "string", "pattern": "^Alice$"},
               "owner_name": {"type": "string", "pattern": "^Alice$"},
-              "modifier_id": null,
-              "modifier_name": null,
+              "modifier_id": {"type": "null"},
+              "modifier_name": {"type": "null"},
               "trashed": {"type": "boolean", "enum": [false]}
             }
           },
@@ -88,8 +88,8 @@ Feature: retrieve information of multiple files using the file IDs
               "mimetype": {"type": "string", "pattern": "^text\/plain$"},
               "owner_id": {"type": "string", "pattern": "^Brian$"},
               "owner_name": {"type": "string", "pattern": "^Brian Adams$"},
-              "modifier_id": null,
-              "modifier_name": null,
+              "modifier_id": {"type": "null"},
+              "modifier_name": {"type": "null"},
               "trashed": {"type": "boolean", "enum": [false]}
             }
           },
@@ -121,8 +121,8 @@ Feature: retrieve information of multiple files using the file IDs
               "mimetype": {"type": "string", "pattern": "^text\/plain$"},
               "owner_id": {"type": "string", "pattern": "^Alice$"},
               "owner_name": {"type": "string", "pattern": "^Alice$"},
-              "modifier_id": null,
-              "modifier_name": null,
+              "modifier_id": {"type": "null"},
+              "modifier_name": {"type": "null"},
               "trashed": {"type": "boolean", "enum": [true]}
             }
           },

--- a/tests/acceptance/features/api/getFilesinfoByFileIDsAPI.feature
+++ b/tests/acceptance/features/api/getFilesinfoByFileIDsAPI.feature
@@ -40,6 +40,8 @@ Feature: retrieve information of multiple files using the file IDs
               "mimetype",
               "owner_id",
               "owner_name",
+              "modifier_id",
+              "modifier_name",
               "trashed"
             ],
             "properties": {
@@ -53,6 +55,8 @@ Feature: retrieve information of multiple files using the file IDs
               "mimetype": {"type": "string", "pattern": "^text\/plain$"},
               "owner_id": {"type": "string", "pattern": "^Alice$"},
               "owner_name": {"type": "string", "pattern": "^Alice$"},
+              "modifier_id": null,
+              "modifier_name": null,
               "trashed": {"type": "boolean", "enum": [false]}
             }
           },
@@ -69,6 +73,8 @@ Feature: retrieve information of multiple files using the file IDs
               "mimetype",
               "owner_id",
               "owner_name",
+              "modifier_id",
+              "modifier_name",
               "trashed"
             ],
             "properties": {
@@ -82,6 +88,8 @@ Feature: retrieve information of multiple files using the file IDs
               "mimetype": {"type": "string", "pattern": "^text\/plain$"},
               "owner_id": {"type": "string", "pattern": "^Brian$"},
               "owner_name": {"type": "string", "pattern": "^Brian$"},
+              "modifier_id": null,
+              "modifier_name": null,
               "trashed": {"type": "boolean", "enum": [false]}
             }
           },
@@ -98,6 +106,8 @@ Feature: retrieve information of multiple files using the file IDs
               "mimetype",
               "owner_id",
               "owner_name",
+              "modifier_id",
+              "modifier_name",
               "trashed"
             ],
             "properties": {
@@ -111,6 +121,8 @@ Feature: retrieve information of multiple files using the file IDs
               "mimetype": {"type": "string", "pattern": "^text\/plain$"},
               "owner_id": {"type": "string", "pattern": "^Alice$"},
               "owner_name": {"type": "string", "pattern": "^Alice$"},
+              "modifier_id": null,
+              "modifier_name": null,
               "trashed": {"type": "boolean", "enum": [true]}
             }
           },
@@ -130,6 +142,8 @@ Feature: retrieve information of multiple files using the file IDs
                 "mimetype",
                 "owner_id",
                 "owner_name",
+                "modifier_id",
+                "modifier_name",
                 "trashed"
               ]
             },
@@ -154,6 +168,8 @@ Feature: retrieve information of multiple files using the file IDs
                 "mimetype",
                 "owner_id",
                 "owner_name",
+                "modifier_id",
+                "modifier_name",
                 "trashed"
               ]
             },

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -77,6 +77,16 @@ class FeatureContext implements Context {
 	}
 
 	/**
+	 * @Given user :user has been deleted
+	 */
+	public function userHasBeenDeleted(string $user):void {
+		$this->sendOCSRequest(
+			'/cloud/users/' . $user, 'DELETE', $this->getAdminUsername()
+		);
+		$this->theHttpStatusCodeShouldBe(204);
+	}
+
+	/**
 	 * @Given user :user has uploaded file with content :content to :destination
 	 */
 	public function userHasUploadedFileWithContentTo(
@@ -148,7 +158,7 @@ class FeatureContext implements Context {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has renamed (?:file|folder) "([^"]*)" to "([^"]*)"$/
+	 * @Given /^user "([^"]*)" has (?:renamed|moved) (?:file|folder) "([^"]*)" to "([^"]*)"$/
 	 */
 	public function userHasRenamedFile(string $user, string $src, string $dst):void {
 		$davPath = self::getDavPath($user);

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -225,6 +225,19 @@ class FeatureContext implements Context {
 	}
 
 	/**
+	 * @When user :user gets the information of the file :fileName
+	 * @When user :user gets the information of the folder :fileName
+	 */
+	public function userGetsTheInformationOfFileWithName(string $user, string $fileName): void {
+		$fileId = $this->getIdOfElement($user, $fileName);
+		$this->response = $this->sendOCSRequest(
+			'/apps/integration_openproject/fileinfo/' . $fileId,
+			'GET',
+			$user
+		);
+	}
+
+	/**
 	 * @When user :user gets the information of all files created in this scenario
 	 */
 	public function userGetsTheInformationOfAllCreatedFiles(string $user): void {
@@ -310,11 +323,15 @@ class FeatureContext implements Context {
 			[],
 			$content
 		);
+		return $this->getIdOfElement($user, $destination);
+	}
+
+	private function getIdOfElement(string $user, string $element): int {
 		$propfindResponse = $this->makeDavRequest(
 			$user,
 			$this->regularUserPassword,
 			"PROPFIND",
-			$destination,
+			$element,
 			null,
 			'<?xml version="1.0"?>
 					<d:propfind  xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns" xmlns:nc="http://nextcloud.org/ns" xmlns:ocs="http://open-collaboration-services.org/ns">
@@ -331,7 +348,6 @@ class FeatureContext implements Context {
 		);
 		return (int)(string)$responseXmlObject->xpath('//oc:fileid')[0];
 	}
-
 	/**
 	 * @param string $path
 	 * @param string $method

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -190,7 +190,7 @@ class FeatureContext implements Context {
 			$shareId = $shareData->ocs->data->id;
 			$this->lastCreatedPublicLink = $shareData->ocs->data->token;
 			$this->response = $this->sendOCSRequest(
-				'/apps/files_sharing/api/v1/shares/' . $shareId ,
+				'/apps/files_sharing/api/v1/shares/' . $shareId,
 				'PUT',
 				$sharer,
 				$fixPublicLinkPermBody

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -62,18 +62,28 @@ class FeatureContext implements Context {
 	/**
 	 * @Given user :user has been created
 	 */
-	public function userHasBeenCreated(string $user):void {
+	public function userHasBeenCreated(string $user, string $displayName = null):void {
 		// delete the user if it exists
 		$this->sendOCSRequest(
 			'/cloud/users/' . $user, 'DELETE', $this->getAdminUsername()
 		);
 		$userAttributes['userid'] = $user;
 		$userAttributes['password'] = $this->getRegularUserPassword();
+		if ($displayName !== null) {
+			$userAttributes['displayName'] = $displayName;
+		}
 
 		$this->response = $this->sendOCSRequest(
 			'/cloud/users', 'POST', $this->getAdminUsername(), $userAttributes
 		);
 		$this->theHttpStatusCodeShouldBe(200);
+	}
+
+	/**
+	 * @Given user :user has been created with display-name :displayName
+	 */
+	public function userHasBeenCreatedWithDisplayName(string $user, string $displayName):void {
+		$this->userHasBeenCreated($user, $displayName);
 	}
 
 	/**

--- a/tests/lib/Controller/FilesControllerTest.php
+++ b/tests/lib/Controller/FilesControllerTest.php
@@ -3,12 +3,31 @@
 namespace OCA\OpenProject\Controller;
 
 use OCA\Files_Trashbin\Trash\ITrashManager;
+use OCP\Activity\IManager;
 use OCP\Files\Config\ICachedMountFileInfo;
 use OCP\Files\Node;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\IL10N;
+use OCP\ILogger;
 use OCP\IRequest;
+use OCP\IUserManager;
+use OCP\RichObjectStrings\IValidator;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use function PHPUnit\Framework\assertSame;
+
+/**
+ * overriding the class_exists method, so that the unit tests always pass,
+ * no matter if the activity app is enabled or not
+ */
+function class_exists(string $className): bool {
+	if ($className === '\OCA\Activity\Data') {
+		return false;
+	} else {
+		return \class_exists($className);
+	}
+}
 
 class FilesControllerTest extends TestCase {
 
@@ -103,7 +122,9 @@ class FilesControllerTest extends TestCase {
 				"size" => 200245,
 				"owner_name" => "Test User",
 				"owner_id" => "3df8ff78-49cb-4d60-8d8b-171b29591fd3",
-				'trashed' => false
+				'trashed' => false,
+				'modifier_name' => null,
+				'modifier_id' => null
 			],
 			$result->getData()
 		);
@@ -455,7 +476,9 @@ class FilesControllerTest extends TestCase {
 					'size' => 200245,
 					'owner_name' => 'Test User',
 					'owner_id' => '3df8ff78-49cb-4d60-8d8b-171b29591fd3',
-					'trashed' => false
+					'trashed' => false,
+					'modifier_name' => null,
+					'modifier_id' => null
 				],
 				3 => [
 					'status' => 'OK',
@@ -468,7 +491,9 @@ class FilesControllerTest extends TestCase {
 					'size' => 200245,
 					'owner_name' => 'Test User',
 					'owner_id' => '3df8ff78-49cb-4d60-8d8b-171b29591fd3',
-					'trashed' => false
+					'trashed' => false,
+					'modifier_name' => null,
+					'modifier_id' => null
 				]
 			],
 			$result->getData()
@@ -518,7 +543,9 @@ class FilesControllerTest extends TestCase {
 		"size" => 200245,
 		"owner_name" => "Test User",
 		"owner_id" => "3df8ff78-49cb-4d60-8d8b-171b29591fd3",
-		"trashed" => true
+		"trashed" => true,
+		'modifier_name' => null,
+		'modifier_id' => null
 	];
 
 	/**
@@ -535,7 +562,9 @@ class FilesControllerTest extends TestCase {
 		'size' => 200245,
 		'owner_name' => 'Test User',
 		'owner_id' => '3df8ff78-49cb-4d60-8d8b-171b29591fd3',
-		'trashed' => false
+		'trashed' => false,
+		'modifier_name' => null,
+		'modifier_id' => null
 	];
 
 	/**
@@ -552,7 +581,9 @@ class FilesControllerTest extends TestCase {
 		'size' => 200245,
 		'owner_name' => 'Test User',
 		'owner_id' => '3df8ff78-49cb-4d60-8d8b-171b29591fd3',
-		'trashed' => false
+		'trashed' => false,
+		'modifier_name' => null,
+		'modifier_id' => null
 	];
 
 	/**
@@ -592,7 +623,14 @@ class FilesControllerTest extends TestCase {
 			$storageMock,
 			$trashManagerMock,
 			$userSessionMock,
-			$mountProviderCollectionMock
+			$mountProviderCollectionMock,
+			$this->createMock(IManager::class),
+			$this->createMock(IDBConnection::class),
+			$this->createMock(IValidator::class),
+			$this->createMock(ILogger::class),
+			$this->createMock(IL10N::class),
+			$this->createMock(IConfig::class),
+			$this->createMock(IUserManager::class)
 		);
 	}
 


### PR DESCRIPTION
use the activity app to get the latest modifier.
Only content changes of a file will be regarded as modifications, move, rename etc. not.
fields that are returned: `modifier_id` and `modifier_name`
In case the modifier could not be found (e.g. activity app is not installed, last modifier is deleted, public modified last, ...) `null` is returned

for details see API tests

fixes https://community.openproject.org/projects/nextcloud-integration/work_packages/43302