### PR TITLE
[#43418] Unlink icon button is dark in the dark mode

### DIFF
--- a/src/views/ProjectsTab.vue
+++ b/src/views/ProjectsTab.vue
@@ -326,7 +326,6 @@ export default {
 		}
 		&--unlinkactionbutton {
 			margin: 4px;
-			filter: contrast(0) brightness(0);
 			visibility: hidden;
 		}
 	}


### PR DESCRIPTION
There was an invert css leftover. Without this, the dark/light mode color should be ok.

Resolves: https://community.openproject.org/work_packages/43418

Signed-off-by: Kiran Parajuli <kiranparajuli589@gmail.com>
