### PR TITLE
New public endpoint returning the user id and the authorization header

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -15,6 +15,7 @@ return [
 		['name' => 'config#setConfig', 'url' => '/config', 'verb' => 'PUT'],
 		['name' => 'config#setAdminConfig', 'url' => '/admin-config', 'verb' => 'PUT'],
 		['name' => 'config#autoOauthCreation', 'url' => '/nc-oauth', 'verb' => 'POST'],
+		['name' => 'config#checkConfig', 'url' => '/check-config', 'verb' => 'GET'],
 
 		['name' => 'directDownload#directDownload', 'url' => '/direct/{token}/{fileName}', 'verb' => 'GET'],
 

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -334,4 +334,18 @@ class ConfigController extends Controller {
 			$this->config->deleteAppValue(Application::APP_ID, 'nc_oauth_client_id');
 		}
 	}
+
+	/**
+	 * @NoCSRFRequired
+	 * @NoAdminRequired
+	 * @PublicPage
+	 *
+	 * @return DataResponse
+	 */
+	public function checkConfig(): DataResponse {
+		return new DataResponse([
+			'user_id' => $this->userId ?? '',
+			'authorization_header' => $_SERVER['HTTP_AUTHORIZATION'],
+		]);
+	}
 }


### PR DESCRIPTION
Observed behaviour:
* when using basic auth with invalid credentials, the request does not reach the app controller and we get a 401 response with `{"message":""}` in the body
* successful basic auth: `{"user_id":"USER_ID","authorization_header":"Basic anVsaWVuOk9yYW4nZV9jbG91sA=="}`
* passing an invalid bearer token with `Authorization: Bearer INVALID_TOKEN`: we get `{"user_id":"","authorization_header":"Bearer INVALID_TOKEN"}`
* passing a valid token, we get `{"user_id":"USER_ID","authorization_header":"Bearer VALID_TOKEN"}`

https://community.openproject.org/wp/43473