### PR TITLE
[#43473] add index.php always to the redirect URL

### DIFF
--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -236,15 +236,12 @@ class ConfigController extends Controller {
 		}
 
 		if ($clientID && $validClientSecret && $validCodeVerifier && $configState !== '' && $configState === $state) {
-			$redirectUri = $this->urlGenerator->getAbsoluteURL(
-				'/index.php/apps/' . Application::APP_ID . '/oauth-redirect'
-			);
 			$openprojectUrl = $this->config->getAppValue(Application::APP_ID, 'oauth_instance_url');
 			$result = $this->openprojectAPIService->requestOAuthAccessToken($openprojectUrl, [
 				'client_id' => $clientID,
 				'client_secret' => $clientSecret,
 				'code' => $code,
-				'redirect_uri' => $redirectUri,
+				'redirect_uri' => openprojectAPIService::getOauthRedirectUrl($this->urlGenerator),
 				'grant_type' => 'authorization_code',
 				'code_verifier' => $codeVerifier
 			], 'POST');

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -236,15 +236,15 @@ class ConfigController extends Controller {
 		}
 
 		if ($clientID && $validClientSecret && $validCodeVerifier && $configState !== '' && $configState === $state) {
-			$redirect_uri = $this->urlGenerator->linkToRouteAbsolute(
-				Application::APP_ID . '.config.oauthRedirect'
+			$redirectUri = $this->urlGenerator->getAbsoluteURL(
+				'/index.php/apps/' . Application::APP_ID . '/oauth-redirect'
 			);
 			$openprojectUrl = $this->config->getAppValue(Application::APP_ID, 'oauth_instance_url');
 			$result = $this->openprojectAPIService->requestOAuthAccessToken($openprojectUrl, [
 				'client_id' => $clientID,
 				'client_secret' => $clientSecret,
 				'code' => $code,
-				'redirect_uri' => $redirect_uri,
+				'redirect_uri' => $redirectUri,
 				'grant_type' => 'authorization_code',
 				'code_verifier' => $codeVerifier
 			], 'POST');

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -589,7 +589,9 @@ class OpenProjectAPIService {
 		}
 		$clientID = $config->getAppValue(Application::APP_ID, 'client_id');
 		$oauthUrl = $config->getAppValue(Application::APP_ID, 'oauth_instance_url');
-		$redirectUri = $urlGenerator->linkToRouteAbsolute(Application::APP_ID . '.config.oauthRedirect');
+		$redirectUri = $urlGenerator->getAbsoluteURL(
+			'/index.php/apps/' . Application::APP_ID . '/oauth-redirect'
+		);
 
 		// remove trailing slash from the oauthUrl if present
 		if (substr($oauthUrl, -1) === '/') {

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -589,9 +589,6 @@ class OpenProjectAPIService {
 		}
 		$clientID = $config->getAppValue(Application::APP_ID, 'client_id');
 		$oauthUrl = $config->getAppValue(Application::APP_ID, 'oauth_instance_url');
-		$redirectUri = $urlGenerator->getAbsoluteURL(
-			'/index.php/apps/' . Application::APP_ID . '/oauth-redirect'
-		);
 
 		// remove trailing slash from the oauthUrl if present
 		if (substr($oauthUrl, -1) === '/') {
@@ -601,8 +598,14 @@ class OpenProjectAPIService {
 		return $oauthUrl .
 			'/oauth/authorize' .
 			'?client_id=' . $clientID .
-			'&redirect_uri=' . urlencode($redirectUri) .
+			'&redirect_uri=' . urlencode(self::getOauthRedirectUrl($urlGenerator)) .
 			'&response_type=code';
+	}
+
+	public static function getOauthRedirectUrl(IURLGenerator $urlGenerator): string {
+		return $urlGenerator->getAbsoluteURL(
+			'/index.php/apps/' . Application::APP_ID . '/oauth-redirect'
+		);
 	}
 
 	/**

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -919,8 +919,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 
 		$url = $this->createMock(IURLGenerator::class);
 		$url->expects($this->once())
-			->method('linkToRouteAbsolute')
-			->with('integration_openproject.config.oauthRedirect')
+			->method('getAbsoluteURL')
 			->willReturn('http://nextcloud.org/index.php/oauth-redirect');
 		$result = $this->service::getOpenProjectOauthURL($configMock, $url);
 		$this->assertSame(


### PR DESCRIPTION
NC needs always to send index.php  in the redirect url, even if it runs currently without, because OP always expects the URLs to include index.php

this depends on https://github.com/opf/openproject/pull/11086