### PR TITLE
[#43550] rewrite folder mimetype to what OP expects

### DIFF
--- a/lib/Controller/FilesController.php
+++ b/lib/Controller/FilesController.php
@@ -17,6 +17,7 @@ use OCA\Activity\UserSettings;
 use OCA\Files_Trashbin\Trash\ITrashManager;
 use OCP\Activity\IManager;
 use OCP\Files\Config\IMountProviderCollection;
+use OCP\Files\FileInfo;
 use OCP\Files\IRootFolder;
 use OCP\IConfig;
 use OCP\IDBConnection;
@@ -182,6 +183,12 @@ class FilesController extends OCSController {
 				$modifierId = null;
 				$modifierName = null;
 			}
+			if ($file->getMimeType() === FileInfo::MIMETYPE_FOLDER) {
+				$mimeType = 'application/x-op-directory';
+			} else {
+				$mimeType = $file->getMimeType();
+			}
+
 			return [
 				'status' => 'OK',
 				'statuscode' => 200,
@@ -189,7 +196,7 @@ class FilesController extends OCSController {
 				'name' => basename($internalPath),
 				'mtime' => $file->getMTime(),
 				'ctime' => $file->getCreationTime(),
-				'mimetype' => $file->getMimetype(),
+				'mimetype' => $mimeType,
 				'size' => $file->getSize(),
 				'owner_name' => $owner->getDisplayName(),
 				'owner_id' => $owner->getUID(),

--- a/tests/acceptance/features/api/getFileinfoByFileIDAPI.feature
+++ b/tests/acceptance/features/api/getFileinfoByFileIDAPI.feature
@@ -817,7 +817,7 @@ Feature: retrieve file information of a single file, using the file ID
           "mtime" : {"type" : "integer"},
           "ctime" : {"type" : "integer", "enum": [0]},
           "name": {"type": "string", "pattern": "^folder$"},
-          "mimetype": {"type": "string", "pattern": "^httpd\/unix-directory$"},
+          "mimetype": {"type": "string", "pattern": "^application\/x-op-directory$"},
           "owner_id": {"type": "string", "pattern": "^Alice$"},
           "owner_name": {"type": "string", "pattern": "^Alice Hansen$"},
           "modifier_id": {"type": "null"},

--- a/tests/lib/Controller/FilesControllerTest.php
+++ b/tests/lib/Controller/FilesControllerTest.php
@@ -63,7 +63,7 @@ class FilesControllerTest extends TestCase {
 				],
 				'files/myFolder',
 				'myFolder',
-				'httpd/unix-directory'
+				'application/x-op-directory'
 			],
 			// getById returns a sub folder
 			[
@@ -72,7 +72,7 @@ class FilesControllerTest extends TestCase {
 				],
 				'files/myFolder/a-sub-folder',
 				'a-sub-folder',
-				'httpd/unix-directory'
+				'application/x-op-directory'
 			],
 			// getById returns the root folder
 			[
@@ -81,7 +81,7 @@ class FilesControllerTest extends TestCase {
 				],
 				'files',
 				'files',
-				'httpd/unix-directory'
+				'application/x-op-directory'
 			],
 		];
 	}
@@ -472,7 +472,7 @@ class FilesControllerTest extends TestCase {
 					'name' => 'a-sub-folder',
 					'mtime' => 1640008813,
 					'ctime' => 1639906930,
-					'mimetype' => 'httpd/unix-directory',
+					'mimetype' => 'application/x-op-directory',
 					'size' => 200245,
 					'owner_name' => 'Test User',
 					'owner_id' => '3df8ff78-49cb-4d60-8d8b-171b29591fd3',
@@ -487,7 +487,7 @@ class FilesControllerTest extends TestCase {
 					'name' => 'files',
 					'mtime' => 1640008813,
 					'ctime' => 1639906930,
-					'mimetype' => 'httpd/unix-directory',
+					'mimetype' => 'application/x-op-directory',
 					'size' => 200245,
 					'owner_name' => 'Test User',
 					'owner_id' => '3df8ff78-49cb-4d60-8d8b-171b29591fd3',


### PR DESCRIPTION
the default folder mimetype of NC is `httpd/unix-directory` see https://github.com/nextcloud/server/blob/8af40542379df1338a07ec1628147bb79a92be4f/lib/public/Files/FileInfo.php#L67 but in https://github.com/opf/openproject/pull/11109 OpenProject expects `application/x-op-directory`, so change the replace the mimetype
