### PR TITLE
chore: update the app version inside the package.json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "integration_openproject",
-	"version": "0.0.1",
+	"version": "2.0.2",
 	"description": "OpenProject integration",
 	"main": "index.js",
 	"directories": {


### PR DESCRIPTION
Noticed while building the webpack for the app:
```console
/home/kiran/.nvm/versions/node/v16.16.0/bin/npm run build

> integration_openproject@0.0.1 build
> NODE_ENV=production webpack --progress --config webpack.js

Building integration_openproject 0.0.1 

asset integration_openproject-dashboard.js 1.16 MiB [emitted] [minimized] [big] (name: dashboard) 2 related assets
asset integration_openproject-projectTab.js 1.02 MiB [emitted] [minimized] [big] (name: openproject-tab) 2 related assets
asset integration_openproject-adminSettings.js 435 KiB [emitted] [minimized] [big] (name: adminSettings) 2 related assets
asset integration_openproject-personalSettings.js 384 KiB [emitted] [minimized] [big] (name: personalSettings) 2 related assets
asset integration_openproject-fileActions.js 142 KiB [emitted] [minimized] (name: fileActions) 2 related assets
```

The app version is taken from the package JSON which was not updated.

With this PR, the version pin inside the package JSON is updated.

---
Signed-off-by: Kiran Parajuli <kiranparajuli589@gmail.com>
