### PR TITLE
[#43667] move OP personal settings to own category

### DIFF
--- a/lib/Settings/Personal.php
+++ b/lib/Settings/Personal.php
@@ -80,7 +80,7 @@ class Personal implements ISettings {
 	}
 
 	public function getSection(): string {
-		return 'connected-accounts';
+		return 'openproject';
 	}
 
 	public function getPriority(): int {

--- a/lib/Settings/PersonalSection.php
+++ b/lib/Settings/PersonalSection.php
@@ -26,7 +26,7 @@ class PersonalSection implements IIconSection {
 	 * @returns string
 	 */
 	public function getID(): string {
-		return 'connected-accounts'; //or a generic id if feasible
+		return 'openproject'; //or a generic id if feasible
 	}
 
 	/**
@@ -36,7 +36,7 @@ class PersonalSection implements IIconSection {
 	 * @return string
 	 */
 	public function getName(): string {
-		return $this->l->t('Connected accounts');
+		return $this->l->t('OpenProject');
 	}
 
 	/**
@@ -52,6 +52,6 @@ class PersonalSection implements IIconSection {
 	 * @return ?string The relative path to a an icon describing the section
 	 */
 	public function getIcon(): ?string {
-		return $this->urlGenerator->imagePath('core', 'categories/integration.svg');
+		return $this->urlGenerator->imagePath('integration_openproject', 'app-dark.svg');
 	}
 }


### PR DESCRIPTION
Description: moved OpenProject personal settings to a dedicated category

Related issue: https://community.openproject.org/work_packages/43667

---
Signed-off-by: Kiran Parajuli <kiranparajuli589@gmail.com>
