### PR TITLE
OP#43843 fix app icon for notifications

### DIFF
--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -106,7 +106,7 @@ class Notifier implements INotifier {
 						'instance' => $richSubjectInstance,
 					]
 				)
-				->setIcon($this->url->getAbsoluteURL($this->url->imagePath(Application::APP_ID, 'app.svg')));
+				->setIcon($this->url->getAbsoluteURL($this->url->imagePath(Application::APP_ID, 'app-dark.svg')));
 			return $notification;
 
 		default:


### PR DESCRIPTION
`app.svg` is white in the light mode and dark in the dark-mode, so its basically invisible in the notifications dropdown
![image](https://user-images.githubusercontent.com/2425577/186143912-fdaecff4-7a36-41f0-b0a7-5b3c3bb9af4f.png)

`app-dark.svg` does the opposite
![image](https://user-images.githubusercontent.com/2425577/186143986-ab1ec184-a380-4a31-9f7c-4e3885e631bc.png)
![image](https://user-images.githubusercontent.com/2425577/186144030-7169c79e-3bb5-4d0f-96e7-9dc6d411c451.png)

fixes https://community.openproject.org/projects/nextcloud-integration/work_packages/43843
