### PR TITLE
[OP#43669] Enhance html/css for the personal settings section

### DIFF
--- a/src/components/PersonalSettings.vue
+++ b/src/components/PersonalSettings.vue
@@ -15,37 +15,26 @@
 		</div>
 		<br>
 		<div v-if="connected" class="openproject-prefs--form">
-			<input id="openproject-prefs--link"
-				type="checkbox"
-				class="checkbox"
-				:checked="state.navigation_enabled"
-				@input="onNavigationChange">
-			<label for="openproject-prefs--link">
-				{{ t('integration_openproject', 'Enable navigation link') }}
-			</label>
-			<br><br>
-			<input id="openproject-prefs--u-search"
-				type="checkbox"
-				class="checkbox"
-				:checked="state.search_enabled"
+			<CheckBox v-model="state.navigation_enabled"
+				input-id="openproject-prefs-link"
+				:label="t('integration_openproject', 'Enable navigation link')"
+				@input="onNavigationChange" />
+			<CheckBox v-model="state.search_enabled"
+				input-id="openproject-prefs--u-search"
+				:label="t('integration_openproject', 'Enable unified search for tickets')"
 				@input="onSearchChange">
-			<label for="openproject-prefs--u-search">
-				{{ t('integration_openproject', 'Enable unified search for tickets') }}
-			</label>
-			<p v-if="state.search_enabled" class="openproject-prefs--hint">
-				<InformationVariant />
-				{{ t('integration_openproject', 'Warning, everything you type in the search bar will be sent to your OpenProject instance.') }}
-			</p>
-			<br v-else>
-			<br>
-			<input id="openproject-prefs--notifications"
-				type="checkbox"
-				class="checkbox"
-				:checked="state.notification_enabled"
-				@input="onNotificationChange">
-			<label for="openproject-prefs--notifications">
-				{{ t('integration_openproject', 'Enable notifications for activity in my work packages') }}
-			</label>
+				<template #hint>
+					<p v-if="state.search_enabled" class="openproject-prefs--hint">
+						<InformationVariant />
+						{{ t('integration_openproject', 'Warning, everything you type in the search bar will be sent to your OpenProject instance.') }}
+					</p>
+					<br v-else>
+				</template>
+			</CheckBox>
+			<CheckBox v-model="state.notification_enabled"
+				input-id="openproject-prefs--notifications"
+				:label="t('integration_openproject', 'Enable notifications for activity in my work packages')"
+				@input="onNotificationChange" />
 		</div>
 		<OAuthConnectButton v-else :is-admin-config-ok="state.admin_config_ok" />
 	</div>
@@ -62,6 +51,7 @@ import { showSuccess, showError } from '@nextcloud/dialogs'
 import '@nextcloud/dialogs/styles/toast.scss'
 import SettingsTitle from '../components/settings/SettingsTitle'
 import OAuthConnectButton from './OAuthConnectButton'
+import CheckBox from './settings/CheckBox'
 import { translate as t } from '@nextcloud/l10n'
 import { checkOauthConnectionResult } from '../utils'
 import Button from '@nextcloud/vue/dist/Components/Button'
@@ -70,7 +60,7 @@ export default {
 	name: 'PersonalSettings',
 
 	components: {
-		SettingsTitle, OAuthConnectButton, Button, CloseIcon, CheckIcon, InformationVariant,
+		SettingsTitle, OAuthConnectButton, Button, CloseIcon, CheckIcon, InformationVariant, CheckBox,
 	},
 
 	data() {
@@ -99,16 +89,13 @@ export default {
 			this.state.token = ''
 			this.saveOptions({ token: this.state.token, token_type: '' })
 		},
-		onNotificationChange(e) {
-			this.state.notification_enabled = e.target.checked
+		onNotificationChange() {
 			this.saveOptions({ notification_enabled: this.state.notification_enabled ? '1' : '0' })
 		},
-		onSearchChange(e) {
-			this.state.search_enabled = e.target.checked
+		onSearchChange() {
 			this.saveOptions({ search_enabled: this.state.search_enabled ? '1' : '0' })
 		},
-		onNavigationChange(e) {
-			this.state.navigation_enabled = e.target.checked
+		onNavigationChange() {
 			this.saveOptions({ navigation_enabled: this.state.navigation_enabled ? '1' : '0' })
 		},
 		saveOptions(values) {

--- a/src/components/PersonalSettings.vue
+++ b/src/components/PersonalSettings.vue
@@ -1,49 +1,53 @@
 <template>
-	<div id="openproject_prefs" class="section">
+	<div class="openproject-prefs section">
 		<SettingsTitle />
-		<div id="openproject-content">
-			<div id="toggle-openproject-navigation-link">
-				<input id="openproject-link"
-					type="checkbox"
-					class="checkbox"
-					:checked="state.navigation_enabled"
-					@input="onNavigationChange">
-				<label for="openproject-link">{{ t('integration_openproject', 'Enable navigation link') }}</label>
-			</div>
-			<br><br>
-			<div v-if="connected" class="openproject-grid-form">
-				<label class="openproject-connected">
-					<CheckIcon class="openproject-connected-checkmark" :size="20" />
-					{{ t('integration_openproject', 'Connected as {user}', { user: state.user_name }) }}
-				</label><br>
-				<Button id="openproject-rm-cred" @click="onLogoutClick">
-					<template #icon>
-						<CloseIcon :size="23" />
-					</template>
-					{{ t('integration_openproject', 'Disconnect from OpenProject') }}
-				</Button>
-			</div>
-			<div v-if="connected" id="openproject-search-block">
-				<input id="search-openproject"
-					type="checkbox"
-					class="checkbox"
-					:checked="state.search_enabled"
-					@input="onSearchChange">
-				<label for="search-openproject">{{ t('integration_openproject', 'Enable unified search for tickets') }}</label>
-				<br><br>
-				<p v-if="state.search_enabled" class="settings-hint">
-					<InformationVariant />
-					{{ t('integration_openproject', 'Warning, everything you type in the search bar will be sent to your OpenProject instance.') }}
-				</p>
-				<input id="notification-openproject"
-					type="checkbox"
-					class="checkbox"
-					:checked="state.notification_enabled"
-					@input="onNotificationChange">
-				<label for="notification-openproject">{{ t('integration_openproject', 'Enable notifications for activity in my work packages') }}</label>
-			</div>
-			<OAuthConnectButton v-else :is-admin-config-ok="state.admin_config_ok" />
+		<div v-if="connected" class="openproject-prefs--connected">
+			<label>
+				<CheckIcon :size="20" />
+				{{ t('integration_openproject', 'Connected as {user}', { user: state.user_name }) }}
+			</label>
+			<Button class="openproject-prefs--disconnect" @click="onLogoutClick">
+				<template #icon>
+					<CloseIcon :size="23" />
+				</template>
+				{{ t('integration_openproject', 'Disconnect from OpenProject') }}
+			</Button>
 		</div>
+		<br>
+		<div v-if="connected" class="openproject-prefs--form">
+			<input id="openproject-prefs--link"
+				type="checkbox"
+				class="checkbox"
+				:checked="state.navigation_enabled"
+				@input="onNavigationChange">
+			<label for="openproject-prefs--link">
+				{{ t('integration_openproject', 'Enable navigation link') }}
+			</label>
+			<br><br>
+			<input id="openproject-prefs--u-search"
+				type="checkbox"
+				class="checkbox"
+				:checked="state.search_enabled"
+				@input="onSearchChange">
+			<label for="openproject-prefs--u-search">
+				{{ t('integration_openproject', 'Enable unified search for tickets') }}
+			</label>
+			<p v-if="state.search_enabled" class="openproject-prefs--hint">
+				<InformationVariant />
+				{{ t('integration_openproject', 'Warning, everything you type in the search bar will be sent to your OpenProject instance.') }}
+			</p>
+			<br v-else>
+			<br>
+			<input id="openproject-prefs--notifications"
+				type="checkbox"
+				class="checkbox"
+				:checked="state.notification_enabled"
+				@input="onNotificationChange">
+			<label for="openproject-prefs--notifications">
+				{{ t('integration_openproject', 'Enable notifications for activity in my work packages') }}
+			</label>
+		</div>
+		<OAuthConnectButton v-else :is-admin-config-ok="state.admin_config_ok" />
 	</div>
 </template>
 
@@ -143,58 +147,27 @@ export default {
 </script>
 
 <style scoped lang="scss">
-#openproject-search-block {
-	margin-top: 30px;
-}
-
-.openproject-grid-form label {
-	line-height: 38px;
-}
-
-.openproject-grid-form input {
-	width: 100%;
-}
-
-.openproject-grid-form {
-	max-width: 600px;
-	display: grid;
-	grid-template: 1fr / 1fr 1fr;
-	button .icon {
-		margin-bottom: -1px;
+.openproject-prefs {
+	&--connected {
+		padding-block: 1rem;
+		label {
+			display: flex;
+			align-items: center;
+			padding-bottom: .5rem;
+		}
+		.check-icon {
+			padding-right: .2rem;
+			color: var(--color-success);
+		}
 	}
-}
-
-.openproject-connected {
-	display: flex;
-}
-
-.openproject-connected-checkmark {
-	padding-right: 8px;
-	color: var(--color-success);
-}
-
-.settings-hint {
-	display: flex;
-}
-
-#openproject_prefs .icon {
-	display: inline-block;
-	width: 32px;
-}
-
-#openproject_prefs .grid-form .icon {
-	margin-bottom: -3px;
-}
-
-#openproject-content {
-	margin-left: 40px;
-}
-
-#openproject-search-block .icon {
-	width: 22px;
-}
-
-#openproject-content .oauth-connect--message {
-	text-align: left !important;
+	&--hint {
+		display: flex;
+		align-items: center;
+		padding-top: 1rem;
+	}
+	.oauth-connect--message {
+		text-align: left;
+		padding: 0;
+	}
 }
 </style>

--- a/src/components/PersonalSettings.vue
+++ b/src/components/PersonalSettings.vue
@@ -6,7 +6,7 @@
 				<CheckIcon :size="20" />
 				{{ t('integration_openproject', 'Connected as {user}', { user: state.user_name }) }}
 			</label>
-			<Button class="openproject-prefs--disconnect" @click="onLogoutClick">
+			<Button class="openproject-prefs--disconnect" @click="disconnectFromOP()">
 				<template #icon>
 					<CloseIcon :size="23" />
 				</template>
@@ -18,11 +18,11 @@
 			<CheckBox v-model="state.navigation_enabled"
 				input-id="openproject-prefs-link"
 				:label="t('integration_openproject', 'Enable navigation link')"
-				@input="onNavigationChange" />
+				@input="saveForm()" />
 			<CheckBox v-model="state.search_enabled"
 				input-id="openproject-prefs--u-search"
 				:label="t('integration_openproject', 'Enable unified search for tickets')"
-				@input="onSearchChange">
+				@input="saveForm()">
 				<template #hint>
 					<p v-if="state.search_enabled" class="openproject-prefs--hint">
 						<InformationVariant />
@@ -34,7 +34,7 @@
 			<CheckBox v-model="state.notification_enabled"
 				input-id="openproject-prefs--notifications"
 				:label="t('integration_openproject', 'Enable notifications for activity in my work packages')"
-				@input="onNotificationChange" />
+				@input="saveForm()" />
 		</div>
 		<OAuthConnectButton v-else :is-admin-config-ok="state.admin_config_ok" />
 	</div>
@@ -85,18 +85,17 @@ export default {
 	},
 
 	methods: {
-		onLogoutClick() {
+		disconnectFromOP() {
 			this.state.token = ''
 			this.saveOptions({ token: this.state.token, token_type: '' })
 		},
-		onNotificationChange() {
-			this.saveOptions({ notification_enabled: this.state.notification_enabled ? '1' : '0' })
-		},
-		onSearchChange() {
-			this.saveOptions({ search_enabled: this.state.search_enabled ? '1' : '0' })
-		},
-		onNavigationChange() {
-			this.saveOptions({ navigation_enabled: this.state.navigation_enabled ? '1' : '0' })
+		saveForm() {
+			const opts = {
+				notification_enabled: this.state.notification_enabled ? '1' : '0',
+				search_enabled: this.state.search_enabled ? '1' : '0',
+				navigation_enabled: this.state.navigation_enabled ? '1' : '0',
+			}
+			this.saveOptions(opts)
 		},
 		saveOptions(values) {
 			const req = {
@@ -125,7 +124,7 @@ export default {
 						+ ': ' + msg
 					)
 				})
-				.then(() => {
+				.finally(() => {
 					this.loading = false
 				})
 		},

--- a/src/components/settings/CheckBox.vue
+++ b/src/components/settings/CheckBox.vue
@@ -1,0 +1,42 @@
+<template>
+	<div class="form-check-input">
+		<input :id="inputId"
+			:value="value"
+			type="checkbox"
+			class="checkbox"
+			:checked="value"
+			@click="$emit('click', $event)"
+			@input="$emit('input', $event.target.checked)"
+			@change="$emit('change', $event.target.checked)"
+			@focus="$emit('focus', $event)"
+			@blur="$emit('blur', $event)">
+		<label :for="inputId">
+			{{ label }}
+		</label>
+		<slot name="hint" />
+	</div>
+</template>
+<script>
+export default {
+	name: 'CheckBox',
+	props: {
+		value: {
+			default: false,
+			type: Boolean,
+		},
+		inputId: {
+			type: String,
+			required: true,
+		},
+		label: {
+			type: String,
+			required: true,
+		},
+	},
+}
+</script>
+<style lang="scss" scoped>
+.form-check-input {
+	margin-bottom: 1rem;
+}
+</style>

--- a/tests/jest/components/PersonalSettings.spec.js
+++ b/tests/jest/components/PersonalSettings.spec.js
@@ -16,9 +16,9 @@ initialState.loadState = jest.fn(() => {
 describe('PersonalSettings.vue', () => {
 	describe('oAuth', () => {
 		const oAuthButtonSelector = 'oauthconnectbutton-stub'
-		const oAuthDisconnectButtonSelector = '#openproject-rm-cred'
-		const connectedAsLabenSelector = '.openproject-connected'
-		const searchBlockSelector = '#openproject-search-block'
+		const oAuthDisconnectButtonSelector = '.openproject-prefs--disconnect'
+		const connectedAsLabelSelector = '.openproject-prefs--connected label'
+		const personalSettingsFormSelector = '.openproject-prefs--form'
 		let wrapper
 		beforeEach(() => {
 			wrapper = shallowMount(PersonalSettings, {
@@ -55,8 +55,8 @@ describe('PersonalSettings.vue', () => {
 				it('oAuth connect button is displayed', () => {
 					expect(wrapper.find(oAuthButtonSelector).exists()).toBeTruthy()
 				})
-				it('search settings are not displayed', () => {
-					expect(wrapper.find(searchBlockSelector).exists()).toBeFalsy()
+				it('personal settings form is not displayed', () => {
+					expect(wrapper.find(personalSettingsFormSelector).exists()).toBeFalsy()
 				})
 				it('oAuth disconnect button is not displayed', () => {
 					expect(wrapper.find(oAuthDisconnectButtonSelector).exists()).toBeFalsy()
@@ -75,10 +75,10 @@ describe('PersonalSettings.vue', () => {
 					expect(wrapper.find(oAuthDisconnectButtonSelector).exists()).toBeTruthy()
 				})
 				it('connected as label is displayed', () => {
-					expect(wrapper.find(connectedAsLabenSelector).text()).toBe('Connected as {user}')
+					expect(wrapper.find(connectedAsLabelSelector).text()).toBe('Connected as {user}')
 				})
-				it('oAuth search settings are displayed', () => {
-					expect(wrapper.find(searchBlockSelector).exists()).toBeTruthy()
+				it('personal settings form is displayed', () => {
+					expect(wrapper.find(personalSettingsFormSelector).exists()).toBeTruthy()
 				})
 			})
 		})


### PR DESCRIPTION
### Description
- Enhance HTML/CSS for the personal settings section, more similar with other personal sections
- Use a component for the Checkbox Input so that can be reused inside admin settings for default personal configs
- Grouped the form items together
- Refactor unit tests


### Related
Part of https://community.openproject.org/projects/nextcloud-integration/work_packages/43669

###

Before:

![Screenshot from 2022-08-24 15-13-33](https://user-images.githubusercontent.com/39373750/186383528-122ddcbd-9c33-4da6-9574-231b49c644a0.png)

After:

![Screenshot from 2022-08-24 15-24-21](https://user-images.githubusercontent.com/39373750/186386021-72aee3eb-7240-435e-8b74-ae2ce2a6eac6.png)



---
Signed-off-by: Kiran Parajuli <kiranparajuli589@gmail.com>
