### PR TITLE
mirror OpenProject notifications to Nextcloud

### DIFF
--- a/lib/BackgroundJob/CheckNotifications.php
+++ b/lib/BackgroundJob/CheckNotifications.php
@@ -47,7 +47,7 @@ class CheckNotifications extends TimedJob {
 								LoggerInterface $logger) {
 		parent::__construct($time);
 		// Every 15 minutes
-		$this->setInterval(60 * 15);
+		$this->setInterval(10);
 
 		$this->openprojectAPIService = $openprojectAPIService;
 		$this->logger = $logger;

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -98,7 +98,6 @@ class ConfigController extends Controller {
 		$this->config->deleteUserValue($userId, Application::APP_ID, 'user_id');
 		$this->config->deleteUserValue($userId, Application::APP_ID, 'user_name');
 		$this->config->deleteUserValue($userId, Application::APP_ID, 'refresh_token');
-		$this->config->deleteUserValue($userId, Application::APP_ID, 'last_notification_check');
 	}
 
 	/**

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -119,7 +119,7 @@ class Notifier implements INotifier {
 				'path' => '',
 				'link' => $p['link'],
 			];
-			$message = $p['projectTitle'] . ' ';
+			$message = $p['projectTitle'] . ' - ';
 			foreach ($p['reasons'] as $reason) {
 				$message .= $reason . ',';
 			}

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -132,7 +132,7 @@ class Notifier implements INotifier {
 			$message = rtrim($message, ',');
 			$markAsReadAction = $notification->createAction();
 			$markAsReadAction->setLabel('mark_as_read')
-			->setParsedLabel($l->t('Mark as read in OpenProject'))
+			->setParsedLabel($l->t('Mark as read'))
 			->setPrimary(true)
 			->setLink($this->url->linkToRouteAbsolute(
 				'integration_openproject.openProjectAPI.markNotificationAsRead',

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -85,29 +85,6 @@ class Notifier implements INotifier {
 		$l = $this->factory->get('integration_openproject', $languageCode);
 
 		switch ($notification->getSubject()) {
-		case 'new_open_tickets':
-			$p = $notification->getSubjectParameters();
-			$nbNotifications = (int) ($p['nbNotifications'] ?? 0);
-			$content = $l->t('OpenProject activity');
-			$richSubjectInstance = [
-				'type' => 'file',
-				'id' => 0,
-				'name' => $p['link'],
-				'path' => '',
-				'link' => $p['link'],
-			];
-
-			$notification->setParsedSubject($content)
-				->setParsedMessage('--')
-				->setLink($p['link'] ?? '')
-				->setRichMessage(
-					$l->n('You have %s new notification in {instance}', 'You have %s new notifications in {instance}', $nbNotifications, [$nbNotifications]),
-					[
-						'instance' => $richSubjectInstance,
-					]
-				)
-				->setIcon($this->url->getAbsoluteURL($this->url->imagePath(Application::APP_ID, 'app-dark.svg')));
-			return $notification;
 		case 'op_notification':
 			$p = $notification->getSubjectParameters();
 

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -130,6 +130,15 @@ class Notifier implements INotifier {
 				$message .= $actor . ',';
 			}
 			$message = rtrim($message, ',');
+			$markAsReadAction = $notification->createAction();
+			$markAsReadAction->setLabel('mark_as_read')
+			->setParsedLabel($l->t('Mark as read in OpenProject'))
+			->setPrimary(true)
+			->setLink($this->url->linkToRouteAbsolute(
+				'integration_openproject.openProjectAPI.markNotificationAsRead',
+				['id' => $p['wpId']]),
+				'DELETE'
+			);
 
 			$notification->setParsedSubject('(' . $p['count']. ') ' . $p['resourceTitle'])
 				->setParsedMessage('--')
@@ -140,6 +149,7 @@ class Notifier implements INotifier {
 						'instance' => $richSubjectInstance,
 					]
 				)
+				->addParsedAction($markAsReadAction)
 				->setIcon($this->url->getAbsoluteURL($this->url->imagePath(Application::APP_ID, 'app-dark.svg')));
 			return $notification;
 

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -136,7 +136,7 @@ class Notifier implements INotifier {
 			->setPrimary(true)
 			->setLink($this->url->linkToRouteAbsolute(
 				'integration_openproject.openProjectAPI.markNotificationAsRead',
-				['id' => $p['wpId']]),
+				['workpackageId' => $p['wpId']]),
 				'DELETE'
 			);
 

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -108,6 +108,33 @@ class Notifier implements INotifier {
 				)
 				->setIcon($this->url->getAbsoluteURL($this->url->imagePath(Application::APP_ID, 'app-dark.svg')));
 			return $notification;
+		case 'op_notification':
+			$p = $notification->getSubjectParameters();
+
+			// see https://github.com/nextcloud/server/issues/1706 for docs
+			$richSubjectInstance = [
+				'type' => 'file',
+				'id' => 0,
+				'name' => $p['link'],
+				'path' => '',
+				'link' => $p['link'],
+			];
+			$message = $p['projectTitle'] . ' ';
+			foreach ($p['reasons'] as $reason) {
+				$message .= $reason . ',';
+			}
+			$message = rtrim($message, ',');
+			$notification->setParsedSubject('(' . $p['count']. ') ' . $p['resourceTitle'])
+				->setParsedMessage('--')
+				->setLink($p['link'] ?? '')
+				->setRichMessage(
+					$message,
+					[
+						'instance' => $richSubjectInstance,
+					]
+				)
+				->setIcon($this->url->getAbsoluteURL($this->url->imagePath(Application::APP_ID, 'app-dark.svg')));
+			return $notification;
 
 		default:
 			// Unknown subject => Unknown notification => throw

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -124,6 +124,13 @@ class Notifier implements INotifier {
 				$message .= $reason . ',';
 			}
 			$message = rtrim($message, ',');
+			$message .= ' ' . $l->t('by') . ' ';
+
+			foreach ($p['actors'] as $actor) {
+				$message .= $actor . ',';
+			}
+			$message = rtrim($message, ',');
+
 			$notification->setParsedSubject('(' . $p['count']. ') ' . $p['resourceTitle'])
 				->setParsedMessage('--')
 				->setLink($p['link'] ?? '')

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -164,6 +164,7 @@ class OpenProjectAPIService {
 					$wpId = preg_replace('/.*\//','', $n['_links']['resource']['href']);
 					if (!array_key_exists($wpId, $aggregatedNotifications)) {
 						$aggregatedNotifications[$wpId] = [
+							'wpId' => $wpId,
 							'resourceTitle' => $n['_links']['resource']['title'],
 							'projectTitle' => $n['_links']['project']['title'],
 							'count' => 1,

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -243,7 +243,10 @@ class OpenProjectAPIService {
 		$result = $this->request($userId, 'notifications', $params);
 		if (isset($result['error'])) {
 			return $result;
-		} elseif (!isset($result['_embedded']['elements'])) {
+		} elseif (
+			!isset($result['_embedded']['elements']) ||
+			!isset($result['_embedded']['elements'][0]['_links'])
+		) {
 			return ['error' => 'Malformed response'];
 		}
 

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -180,6 +180,12 @@ class OpenProjectAPIService {
 					$aggregatedNotifications[$wpId]['reasons'][] = $n['reason'];
 					$aggregatedNotifications[$wpId]['actors'][] = $n['_links']['actor']['title'];
 				}
+				$manager = $this->notificationManager;
+				$notification = $manager->createNotification();
+				$notification->setApp(Application::APP_ID)
+					->setUser($userId);
+				$manager->markProcessed($notification);
+
 				foreach ($aggregatedNotifications as $n) {
 					$n['reasons'] = array_unique($n['reasons']);
 					$n['actors'] = array_unique($n['actors']);

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -177,9 +177,11 @@ class OpenProjectAPIService {
 						$aggregatedNotifications[$wpId]['count']++;
 					}
 					$aggregatedNotifications[$wpId]['reasons'][] = $n['reason'];
+					$aggregatedNotifications[$wpId]['actors'][] = $n['_links']['actor']['title'];
 				}
 				foreach ($aggregatedNotifications as $n) {
 					$n['reasons'] = array_unique($n['reasons']);
+					$n['actors'] = array_unique($n['actors']);
 					// TODO can we use https://github.com/nextcloud/notifications/blob/master/docs/notification-workflow.md#defer-and-flush ?
 					$this->sendNCNotification($userId, 'op_notification', $n);
 				}

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -147,7 +147,7 @@ class OpenProjectAPIService {
 			$aggregatedNotifications = [];
 			if (!isset($notifications['error']) && count($notifications) > 0) {
 				foreach ($notifications as $n) {
-					$wpId = preg_replace('/.*\//','', $n['_links']['resource']['href']);
+					$wpId = preg_replace('/.*\//', '', $n['_links']['resource']['href']);
 					if (!array_key_exists($wpId, $aggregatedNotifications)) {
 						$aggregatedNotifications[$wpId] = [
 							'wpId' => $wpId,

--- a/tests/lib/Controller/ConfigControllerTest.php
+++ b/tests/lib/Controller/ConfigControllerTest.php
@@ -702,7 +702,7 @@ class ConfigControllerTest extends TestCase {
 
 		if ($deleteUserValues === true) {
 			$configMock
-				->expects($this->exactly(12)) // 6 times for each user
+				->expects($this->exactly(10)) // 5 times for each user
 				->method('deleteUserValue')
 				->withConsecutive(
 					['admin', 'integration_openproject', 'token'],
@@ -710,13 +710,11 @@ class ConfigControllerTest extends TestCase {
 					['admin', 'integration_openproject', 'user_id'],
 					['admin', 'integration_openproject', 'user_name'],
 					['admin', 'integration_openproject', 'refresh_token'],
-					['admin', 'integration_openproject', 'last_notification_check'],
 					[$this->user1->getUID(), 'integration_openproject', 'token'],
 					[$this->user1->getUID(), 'integration_openproject', 'login'],
 					[$this->user1->getUID(), 'integration_openproject', 'user_id'],
 					[$this->user1->getUID(), 'integration_openproject', 'user_name'],
 					[$this->user1->getUID(), 'integration_openproject', 'refresh_token'],
-					[$this->user1->getUID(), 'integration_openproject', 'last_notification_check'],
 				);
 		} else {
 			$configMock

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -492,7 +492,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$providerResponse
 			->setStatus(Http::STATUS_OK)
 			->addHeader('Content-Type', 'application/json')
-			->setBody(["_embedded" => ["elements" => [['some' => 'data']]]]);
+			->setBody(["_embedded" => ["elements" => [['_links' => 'data']]]]);
 
 		$this->builder
 			->uponReceiving('a GET request to /notifications')
@@ -502,7 +502,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$result = $this->service->getNotifications(
 			'testUser'
 		);
-		$this->assertSame([['some' => 'data']], $result);
+		$this->assertSame([['_links' => 'data']], $result);
 	}
 
 	/**


### PR DESCRIPTION
part of https://community.openproject.org/projects/nextcloud-integration/work_packages/42323

All current notifications of OpenProject should be mirrored to Nextcloud.
The view is similar to the notification center in OpenProject where the notifications are aggregated by work-package.
Every time the notifications are fetched again from OpenProject, the Nextcloud notifications are dismissed and recreated according to what is the current status in OpenProject.
The Nextcloud dismiss button has basically no functionality, but through the "Mart as Read" button the user can mark all notifications of that work-package as read and they will not be displayed neither in Nextcloud nor in OpenProject

![image](https://user-images.githubusercontent.com/2425577/195079874-daeb9f10-c029-4070-af97-2eed2e47f49f.png)
