### PR TITLE
[OP#44143] log errors when checking validity of OP URL

### DIFF
--- a/lib/Controller/OpenProjectAPIController.php
+++ b/lib/Controller/OpenProjectAPIController.php
@@ -27,6 +27,7 @@ use OCP\AppFramework\Controller;
 use OCA\OpenProject\Service\OpenProjectAPIService;
 use OCA\OpenProject\AppInfo\Application;
 use OCP\IURLGenerator;
+use Psr\Log\LoggerInterface;
 
 class OpenProjectAPIController extends Controller {
 
@@ -58,11 +59,17 @@ class OpenProjectAPIController extends Controller {
 	 */
 	private $urlGenerator;
 
+	/**
+	 * @var LoggerInterface
+	 */
+	private $logger;
+
 	public function __construct(string $appName,
 								IRequest $request,
 								IConfig $config,
 								OpenProjectAPIService $openprojectAPIService,
 								IURLGenerator $urlGenerator,
+								LoggerInterface $logger,
 								?string $userId) {
 		parent::__construct($appName, $request);
 		$this->openprojectAPIService = $openprojectAPIService;
@@ -71,6 +78,7 @@ class OpenProjectAPIController extends Controller {
 		$this->openprojectUrl = $config->getAppValue(Application::APP_ID, 'oauth_instance_url');
 		$this->config = $config;
 		$this->urlGenerator = $urlGenerator;
+		$this->logger = $logger;
 	}
 
 	/**
@@ -303,6 +311,10 @@ class OpenProjectAPIController extends Controller {
 	 */
 	public function isValidOpenProjectInstance(string $url): DataResponse {
 		if ($this->openprojectAPIService::validateURL($url) !== true) {
+			$this->logger->error(
+				"The OpenProject URL '$url' is invalid",
+				['app' => $this->appName]
+			);
 			return new DataResponse('invalid');
 		}
 		try {
@@ -332,8 +344,16 @@ class OpenProjectAPIController extends Controller {
 				return new DataResponse(true);
 			}
 		} catch (Exception $e) {
+			$this->logger->error(
+				"Could not connect to the OpenProject URL '$url'",
+				['app' => $this->appName, 'exception' => $e]
+			);
 			return new DataResponse(false);
 		}
+		$this->logger->error(
+			"Could not connect to the OpenProject URL '$url'",
+			['app' => $this->appName, 'data' => $body]
+		);
 		return new DataResponse(false);
 	}
 

--- a/tests/lib/Controller/OpenProjectAPIControllerTest.php
+++ b/tests/lib/Controller/OpenProjectAPIControllerTest.php
@@ -22,6 +22,7 @@ use OCP\IURLGenerator;
 use PHPUnit\Framework\TestCase;
 use Exception;
 use OCP\Files\NotFoundException;
+use Psr\Log\LoggerInterface;
 
 class OpenProjectAPIControllerTest extends TestCase {
 	/** @var IConfig $configMock */
@@ -34,6 +35,11 @@ class OpenProjectAPIControllerTest extends TestCase {
 	 * @var IURLGenerator
 	 */
 	private $urlGeneratorMock;
+
+	/**
+	 * @var LoggerInterface
+	 */
+	private $loggerMock;
 	/**
 	 * @return void
 	 * @before
@@ -41,6 +47,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 	public function setUpMocks(): void {
 		$this->requestMock = $this->createMock(IRequest::class);
 		$this->urlGeneratorMock = $this->createMock(IURLGenerator::class);
+		$this->loggerMock = $this->createMock(LoggerInterface::class);
 		$this->configMock = $this->getMockBuilder(IConfig::class)->getMock();
 		$this->configMock
 			->method('getAppValue')
@@ -82,6 +89,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 			$this->configMock,
 			$service,
 			$this->urlGeneratorMock,
+			$this->loggerMock,
 			'test',
 		);
 		$response = $controller->getNotifications();
@@ -101,6 +109,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 			$this->configMock,
 			$service,
 			$this->urlGeneratorMock,
+			$this->loggerMock,
 			'test'
 		);
 		$response = $controller->getNotifications();
@@ -125,6 +134,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 			$this->configMock,
 			$service,
 			$this->urlGeneratorMock,
+			$this->loggerMock,
 			'test'
 		);
 		$response = $controller->getNotifications();
@@ -152,6 +162,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 			$this->configMock,
 			$service,
 			$this->urlGeneratorMock,
+			$this->loggerMock,
 			'test'
 		);
 		$response = $controller->getOpenProjectAvatar('id', 'name');
@@ -186,6 +197,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 			$this->configMock,
 			$service,
 			$this->urlGeneratorMock,
+			$this->loggerMock,
 			'test'
 		);
 		$response = $controller->getOpenProjectAvatar('id', 'name');
@@ -236,6 +248,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 			$this->configMock,
 			$service,
 			$this->urlGeneratorMock,
+			$this->loggerMock,
 			'test'
 		);
 		$response = $controller->getSearchedWorkPackages($searchQuery, $fileId);
@@ -256,6 +269,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 			$this->configMock,
 			$service,
 			$this->urlGeneratorMock,
+			$this->loggerMock,
 			'test'
 		);
 		$response = $controller->getSearchedWorkPackages('test');
@@ -280,6 +294,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 			$this->configMock,
 			$service,
 			$this->urlGeneratorMock,
+			$this->loggerMock,
 			'test'
 		);
 		$response = $controller->getSearchedWorkPackages('test');
@@ -309,6 +324,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 			$this->configMock,
 			$service,
 			$this->urlGeneratorMock,
+			$this->loggerMock,
 			'test'
 		);
 		$response = $controller->getOpenProjectWorkPackageStatus('7');
@@ -331,6 +347,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 			$this->configMock,
 			$service,
 			$this->urlGeneratorMock,
+			$this->loggerMock,
 			'test'
 		);
 		$response = $controller->getOpenProjectWorkPackageStatus('7');
@@ -355,6 +372,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 			$this->configMock,
 			$service,
 			$this->urlGeneratorMock,
+			$this->loggerMock,
 			'test'
 		);
 		$response = $controller->getOpenProjectWorkPackageStatus('7');
@@ -382,6 +400,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 			$this->configMock,
 			$service,
 			$this->urlGeneratorMock,
+			$this->loggerMock,
 			'test'
 		);
 		$response = $controller->getOpenProjectWorkPackageType('3');
@@ -402,6 +421,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 			$this->configMock,
 			$service,
 			$this->urlGeneratorMock,
+			$this->loggerMock,
 			'test'
 		);
 		$response = $controller->getOpenProjectWorkPackageType('3');
@@ -426,6 +446,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 			$this->configMock,
 			$service,
 			$this->urlGeneratorMock,
+			$this->loggerMock,
 			'test'
 		);
 		$response = $controller->getOpenProjectWorkPackageType('3');
@@ -458,6 +479,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 			$this->configMock,
 			$service,
 			$this->urlGeneratorMock,
+			$this->loggerMock,
 			'test'
 		);
 		$response = $controller->getWorkPackageFileLinks(7);
@@ -483,6 +505,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 			$this->configMock,
 			$service,
 			$this->urlGeneratorMock,
+			$this->loggerMock,
 			'test'
 		);
 		$response = $controller->getWorkPackageFileLinks(7);
@@ -506,6 +529,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 			$this->configMock,
 			$service,
 			$this->urlGeneratorMock,
+			$this->loggerMock,
 			'test'
 		);
 		$response = $controller->getWorkPackageFileLinks(7);
@@ -530,6 +554,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 			$this->configMock,
 			$service,
 			$this->urlGeneratorMock,
+			$this->loggerMock,
 			'test'
 		);
 		$response = $controller->getWorkPackageFileLinks(7);
@@ -556,6 +581,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 			$this->configMock,
 			$service,
 			$this->urlGeneratorMock,
+			$this->loggerMock,
 			'test'
 		);
 		$response = $controller->deleteFileLink(7);
@@ -575,6 +601,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 			$this->configMock,
 			$service,
 			$this->urlGeneratorMock,
+			$this->loggerMock,
 			'test'
 		);
 		$response = $controller->deleteFileLink(7);
@@ -598,6 +625,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 			$this->configMock,
 			$service,
 			$this->urlGeneratorMock,
+			$this->loggerMock,
 			'test'
 		);
 		$response = $controller->deleteFileLink(7);
@@ -622,6 +650,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 			$this->configMock,
 			$service,
 			$this->urlGeneratorMock,
+			$this->loggerMock,
 			'test'
 		);
 		$response = $controller->deleteFileLink(7);
@@ -663,6 +692,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 			$this->configMock,
 			$service,
 			$this->urlGeneratorMock,
+			$this->loggerMock,
 			'test'
 		);
 		$result = $controller->isValidOpenProjectInstance('http://openproject.org');
@@ -744,6 +774,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 			$this->configMock,
 			$service,
 			$this->urlGeneratorMock,
+			$this->loggerMock,
 			'test'
 		);
 		$result = $controller->isValidOpenProjectInstance('http://openproject.org');
@@ -776,6 +807,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 			$this->configMock,
 			$service,
 			$this->urlGeneratorMock,
+			$this->loggerMock,
 			'test'
 		);
 		$result = $controller->isValidOpenProjectInstance($url);
@@ -829,6 +861,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 			$this->configMock,
 			$service,
 			$this->urlGeneratorMock,
+			$this->loggerMock,
 			'test'
 		);
 		$result = $controller->getOpenProjectOauthURLWithStateAndPKCE();


### PR DESCRIPTION
when setting up the connection the first time, the app checks if there is an OpenProject instance listening on that URL.
If no OpenProject could be detected it would be helpful for the admin to know some details.

fixes https://community.openproject.org/projects/nextcloud-integration/work_packages/44143

Possible log outputs are:
<details><summary>1. server does not reply at all</summary>

```json
{
  "reqId": "MewHTUNISn1qLuQTJqjd",
  "level": 3,
  "time": "2022-09-14T10:37:33+00:00",
  "remoteAddr": "127.0.0.1",
  "user": "admin",
  "app": "integration_openproject",
  "method": "POST",
  "url": "/nextcloud-server/index.php/apps/integration_openproject/is-valid-op-instance",
  "message": "Could not connect to the OpenProject URL 'http://localhost:3000'",
  "userAgent": "Mozilla/5.0 (X11; Linux x86_64; rv:104.0) Gecko/20100101 Firefox/104.0",
  "version": "24.0.5.1",
  "exception": {
    "Exception": "GuzzleHttp\\Exception\\ConnectException",
    "Message": "cURL error 7: Failed to connect to localhost port 3000 after 0 ms: Connection refused (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for http://localhost:3000/api/v3/",
    "Code": 0,
    "Trace": [
      {
        "file": "/home/artur/www/nextcloud-server/3rdparty/guzzlehttp/guzzle/src/Handler/CurlFactory.php",
        "line": 158,
        "function": "createRejection",
        "class": "GuzzleHttp\\Handler\\CurlFactory",
        "type": "::"
      },
      {
        "file": "/home/artur/www/nextcloud-server/3rdparty/guzzlehttp/guzzle/src/Handler/CurlFactory.php",
        "line": 110,
        "function": "finishError",
        "class": "GuzzleHttp\\Handler\\CurlFactory",
        "type": "::"
      },
      {
        "file": "/home/artur/www/nextcloud-server/3rdparty/guzzlehttp/guzzle/src/Handler/CurlHandler.php",
        "line": 47,
        "function": "finish",
        "class": "GuzzleHttp\\Handler\\CurlFactory",
        "type": "::"
      },
      .....
```
</details>

<details><summary>2. server replies but it's not OpenProject</summary>

```json
{
  "reqId": "Kr40ayyTPPmO89pYiPLS",
  "level": 3,
  "time": "2022-09-14T10:41:20+00:00",
  "remoteAddr": "127.0.0.1",
  "user": "admin",
  "app": "integration_openproject",
  "method": "POST",
  "url": "/nextcloud-server/index.php/apps/integration_openproject/is-valid-op-instance",
  "message": "Could not connect to the OpenProject URL 'https://chat.jankari.tech:8443'",
  "userAgent": "Mozilla/5.0 (X11; Linux x86_64; rv:104.0) Gecko/20100101 Firefox/104.0",
  "version": "24.0.5.1",
  "data": {
    "app": "integration_openproject",
    "data": "<!DOCTYPE html>\n<html>\n<head>\n  <link rel=\"stylesheet\" type=\"text/css\" class=\"__meteor-css__\" href=\"/7ffada2ee376523a0aabfc93ae484c627865fc4f.css?meteor_css_resource=true\">\n<meta charset=\"utf-8\" />\n\t<meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\" />\n\t<meta http-equiv=\"expires\" content=\"-1\" />\n\t<meta http-equiv=\"X-UA-Compatible\" content=\"IE=edge\" />\n\t<meta
......
```
</details>

<details><summary>3. self signed TLS certificate</summary>

```json
{
  "reqId": "SFpSqdnvq7IPtq6KVEVs",
  "level": 3,
  "time": "2022-09-14T10:43:15+00:00",
  "remoteAddr": "127.0.0.1",
  "user": "admin",
  "app": "integration_openproject",
  "method": "POST",
  "url": "/nextcloud-server/index.php/apps/integration_openproject/is-valid-op-instance",
  "message": "Could not connect to the OpenProject URL 'https://localhost/'",
  "userAgent": "Mozilla/5.0 (X11; Linux x86_64; rv:104.0) Gecko/20100101 Firefox/104.0",
  "version": "24.0.5.1",
  "exception": {
    "Exception": "GuzzleHttp\\Exception\\RequestException",
    "Message": "cURL error 60: SSL certificate problem: self-signed certificate (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for https://localhost//api/v3/",
    "Code": 0,
    "Trace": [
      {
        "file": "/home/artur/www/nextcloud-server/3rdparty/guzzlehttp/guzzle/src/Handler/CurlFactory.php",
        "line": 158,
        "function": "createRejection",
        "class": "GuzzleHttp\\Handler\\CurlFactory",
        "type": "::"
      },
      {
        "file": "/home/artur/www/nextcloud-server/3rdparty/guzzlehttp/guzzle/src/Handler/CurlFactory.php",
        "line": 110,
        "function": "finishError",
        "class": "GuzzleHttp\\Handler\\CurlFactory",
        "type": "::"
      },
.....
```
</details>

<details><summary>4. trying to access a HTTP server using HTTPS</summary>

```json
{
  "reqId": "v2qefStDEhk5H6fNXivO",
  "level": 3,
  "time": "2022-09-14T10:54:07+00:00",
  "remoteAddr": "127.0.0.1",
  "user": "admin",
  "app": "integration_openproject",
  "method": "POST",
  "url": "/nextcloud-server/index.php/apps/integration_openproject/is-valid-op-instance",
  "message": "Could not connect to the OpenProject URL 'https://localhost:3000'",
  "userAgent": "Mozilla/5.0 (X11; Linux x86_64; rv:104.0) Gecko/20100101 Firefox/104.0",
  "version": "24.0.5.1",
  "exception": {
    "Exception": "GuzzleHttp\\Exception\\ConnectException",
    "Message": "cURL error 35: error:0A00010B:SSL routines::wrong version number (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for https://localhost:3000/api/v3/",
    "Code": 0,
    "Trace": [
      {
        "file": "/home/artur/www/nextcloud-server/3rdparty/guzzlehttp/guzzle/src/Handler/CurlFactory.php",
        "line": 158,
        "function": "createRejection",
        "class": "GuzzleHttp\\Handler\\CurlFactory",
        "type": "::"
      },
      {
        "file": "/home/artur/www/nextcloud-server/3rdparty/guzzlehttp/guzzle/src/Handler/CurlFactory.php",
        "line": 110,
        "function": "finishError",
        "class": "GuzzleHttp\\Handler\\CurlFactory",
        "type": "::"
      },
....
````
</details>
