### PR TITLE
Use auto-release branch for automatic releases, drop the 'release' one

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [release]
+    branches: [auto-release]
 
 name: Publish release
 


### PR DESCRIPTION
Once this is merged, we can delete the "release" branch.

:warning: This commit needs to be in the branch which is then pushed in "auto-release", otherwise the action won't be triggered. Be careful because once merged, even if it's in master, it's not in any other branch.

If needed we can make other PRs bringing this change in other branches.