### PR TITLE
run CI with stable25 branch of NC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     name: CI
     strategy:
       matrix:
-        nextcloudVersion: [ stable22, stable23, stable24, master ]
+        nextcloudVersion: [ stable22, stable23, stable24, stable25 ]
         phpVersion: [ 7.4, 8.0, 8.1 ]
         exclude:
           - nextcloudVersion: stable22


### PR DESCRIPTION
the master branch on NC got bumped to version 26, the activity app does not support that. For now we should run the tests with the stable25 branch
