### PR TITLE
Bump max NC version to 26, adjust CI action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     name: CI
     strategy:
       matrix:
-        nextcloudVersion: [ stable22, stable23, stable24, stable25 ]
+        nextcloudVersion: [ stable22, stable23, stable24, stable25, master ]
         phpVersion: [ 7.4, 8.0, 8.1 ]
         exclude:
           - nextcloudVersion: stable22

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -3,8 +3,8 @@
 	<id>integration_openproject</id>
 	<name>OpenProject Integration</name>
 	<summary>Link Nextcloud files to OpenProject work packages</summary>
-	<description><![CDATA[This application enables seamless integration with open source project management and collaboration software OpenProject. 
-	
+	<description><![CDATA[This application enables seamless integration with open source project management and collaboration software OpenProject.
+
 On the Nextcloud end, it allows users to:
 
 * Link files and folders with work packages in OpenProject
@@ -35,7 +35,7 @@ For more information on how to set up and use the OpenProject application, pleas
 	<screenshot>https://github.com/nextcloud/integration_openproject/raw/master/img/screenshot1.png</screenshot>
 	<screenshot>https://github.com/nextcloud/integration_openproject/raw/master/img/screenshot2.png</screenshot>
 	<dependencies>
-		<nextcloud min-version="22" max-version="25"/>
+		<nextcloud min-version="22" max-version="26"/>
 	</dependencies>
 	<background-jobs>
 		<job>OCA\OpenProject\BackgroundJob\CheckNotifications</job>


### PR DESCRIPTION
We can already bump the max NC version to let CI catch incompatibility issues ASAP.