### PR TITLE
[OP#44493] don't allow URLs that are redirected in the setup phase

### DIFF
--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -349,18 +349,21 @@ class OpenProjectAPIService {
 	 * @param string $endPoint
 	 * @param array<mixed> $params
 	 * @param string $method
+	 * @param array<mixed> $options further options to be given to Guzzle see https://docs.guzzlephp.org/en/stable/request-options.html
 	 * @return array{error: string} | IResponse
 	 */
 	public function rawRequest(string $accessToken, string $openprojectUrl,
-							   string $endPoint, array $params = [], string $method = 'GET') {
+							   string $endPoint, array $params = [],
+							   string $method = 'GET',
+							   array $options = []
+	) {
 		$url = $openprojectUrl . '/api/v3/' . $endPoint;
-		$options = [
-			'headers' => [
-				'Authorization' => 'Bearer ' . $accessToken,
-				'User-Agent' => 'Nextcloud OpenProject integration',
-			]
-		];
-
+		if (!isset($options['headers']['Authorization'])) {
+			$options['headers']['Authorization'] = 'Bearer ' . $accessToken;
+		}
+		if (!isset($options['headers']['User-Agent'])) {
+			$options['headers']['User-Agent'] = 'Nextcloud OpenProject integration';
+		}
 		if (count($params) > 0) {
 			if ($method === 'GET') {
 				// manage array parameters
@@ -379,10 +382,14 @@ class OpenProjectAPIService {
 				if (isset($params['body'])) {
 					$options['body'] = $params['body'];
 				}
-				$options['headers']['Content-Type'] = 'application/json';
+				if (!isset($options['headers']['Content-Type'])) {
+					$options['headers']['Content-Type'] = 'application/json';
+				}
 			}
 		} elseif ($method === 'DELETE') {
-			$options['headers']['Content-Type'] = 'application/json';
+			if (!isset($options['headers']['Content-Type'])) {
+				$options['headers']['Content-Type'] = 'application/json';
+			}
 		}
 
 		if ($method === 'GET') {

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -513,6 +513,16 @@ export default {
 					)
 					break
 				}
+				case 'redirected':
+				{
+					const location = response.data.details
+					this.openProjectNotReachableErrorMessage = t(
+						'integration_openproject',
+						'The given URL redirects to \'{location}\'. Please do not use a URL that leads to a redirect.',
+						{ location }
+					)
+					break
+				}
 				case 'unexpected_error':
 				case 'network_error':
 				case 'request_exception':

--- a/tests/jest/components/AdminSettings.spec.js
+++ b/tests/jest/components/AdminSettings.spec.js
@@ -326,6 +326,13 @@ describe('AdminSettings.vue', () => {
 						},
 						expectedDetailsMessage: null,
 					},
+					{
+						data: {
+							result: 'redirected',
+							details: 'https://openproject.org/',
+						},
+						expectedDetailsMessage: null,
+					},
 				])('should set the input to error state and display correct message when the url is invalid', async (testCase) => {
 					dialogs.showError.mockImplementationOnce()
 					jest.spyOn(axios, 'post')

--- a/tests/jest/components/__snapshots__/AdminSettings.spec.js.snap
+++ b/tests/jest/components/__snapshots__/AdminSettings.spec.js.snap
@@ -280,6 +280,23 @@ exports[`AdminSettings.vue server host url form edit mode submit button should s
 </div>
 `;
 
+exports[`AdminSettings.vue server host url form edit mode submit button should set the input to error state and display correct message when the url is invalid 9`] = `
+<div class="text-input pb-1">
+  <div class="text-input-label">
+    OpenProject host *
+  </div>
+  <div class="text-input-input-wrapper"><input id="openproject-oauth-instance" type="text" readonly="readonly" placeholder="https://www.my-openproject.com" class="text-input-error text-input-readonly">
+    <!---->
+  </div>
+  <div>
+    <div>
+      <div class="text-input-error-message">The given URL redirects to '{location}'. Please do not use a URL that leads to a redirect.</div>
+      <!---->
+    </div>
+  </div>
+</div>
+`;
+
 exports[`AdminSettings.vue server host url form view mode and completed state reset button should be visible when the form is in completed state 1`] = `
 <button data-v-a8d79470="" type="button" data-test-id="reset-server-host-btn" class="button-vue button-vue--icon-and-text button-vue--vue-secondary"><span data-v-a8d79470="" class="button-vue__wrapper"><span data-v-a8d79470="" class="button-vue__icon"><span aria-hidden="true" role="img" class="material-design-icon pencil-icon" data-v-a8d79470=""><svg fill="currentColor" width="20" height="20" viewBox="0 0 24 24" class="material-design-icon__svg"><path d="M20.71,7.04C21.1,6.65 21.1,6 20.71,5.63L18.37,3.29C18,2.9 17.35,2.9 16.96,3.29L15.12,5.12L18.87,8.87M3,17.25V21H6.75L17.81,9.93L14.06,6.18L3,17.25Z"><!----></path></svg></span></span> <span data-v-a8d79470="" class="button-vue__text">
 				Edit server information

--- a/tests/lib/Controller/OpenProjectAPIControllerTest.php
+++ b/tests/lib/Controller/OpenProjectAPIControllerTest.php
@@ -711,6 +711,67 @@ class OpenProjectAPIControllerTest extends TestCase {
 	}
 
 
+	public function testIsValidOpenProjectInstanceRedirect(): void {
+		$response = $this->getMockBuilder(IResponse::class)->getMock();
+		$response->method('getStatusCode')->willReturn(302);
+		$response->method('getHeader')
+			->with('Location')
+			->willReturn('https://openproject.org/api/v3/');
+		$service = $this->getMockBuilder(OpenProjectAPIService::class)
+			->disableOriginalConstructor()
+			->onlyMethods(['rawRequest'])
+			->getMock();
+		$service
+			->method('rawRequest')
+			->willReturn($response);
+		$controller = new OpenProjectAPIController(
+			'integration_openproject',
+			$this->requestMock,
+			$this->configMock,
+			$service,
+			$this->urlGeneratorMock,
+			$this->loggerMock,
+			'test'
+		);
+		$result = $controller->isValidOpenProjectInstance('http://openproject.org');
+		$this->assertSame(
+			[ 'result' => 'redirected', 'details' => 'https://openproject.org/'],
+			$result->getData()
+		);
+	}
+
+	public function testIsValidOpenProjectInstanceRedirectNoLocationHeader(): void {
+		$response = $this->getMockBuilder(IResponse::class)->getMock();
+		$response->method('getStatusCode')->willReturn(302);
+		$response->method('getHeader')
+			->with('Location')
+			->willReturn('');
+		$service = $this->getMockBuilder(OpenProjectAPIService::class)
+			->disableOriginalConstructor()
+			->onlyMethods(['rawRequest'])
+			->getMock();
+		$service
+			->method('rawRequest')
+			->willReturn($response);
+		$controller = new OpenProjectAPIController(
+			'integration_openproject',
+			$this->requestMock,
+			$this->configMock,
+			$service,
+			$this->urlGeneratorMock,
+			$this->loggerMock,
+			'test'
+		);
+		$result = $controller->isValidOpenProjectInstance('http://openproject.org');
+		$this->assertSame(
+			[
+				'result' => 'unexpected_error',
+				'details' => 'received a redirect status code (302) but no "Location" header'
+			],
+			$result->getData()
+		);
+	}
+
 	/**
 	 * @return array<mixed>
 	 */


### PR DESCRIPTION
In the setup phase URLs that are redirected should not be used. If an URL is redirected the admin should use the real URL

![image](https://user-images.githubusercontent.com/2425577/196927105-1c69c698-d8e1-4e2e-ba79-11aa382204f1.png)

But if a sys-admin sets up a redirect after the configuration is done (e.g. for maintenance purposes) that redirect should be used and followed.

fixes https://community.openproject.org/work_packages/44493
