### PR TITLE
[OP#44504] sort workpackages only by date

### DIFF
--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -289,7 +289,7 @@ class OpenProjectAPIService {
 	 */
 	private function searchRequest(string $userId, array $filters): array {
 		$resultsById = [];
-		$sortBy = [['status', 'asc'],['updatedAt', 'desc']];
+		$sortBy = [['updatedAt', 'desc']];
 		$filters[] = [
 			'linkable_to_storage_url' =>
 				['operator' => '=', 'values' => [urlencode($this->getBaseUrl())]]

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -403,7 +403,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 							'{"linkable_to_storage_url":'.
 								'{"operator":"=","values":["https%3A%2F%2Fnc.my-server.org"]}}'.
 							']',
-						'sortBy' => '[["status","asc"],["updatedAt","desc"]]',
+						'sortBy' => '[["updatedAt","desc"]]',
 					]
 			)
 			->willReturn($response);
@@ -426,7 +426,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 							'{"linkable_to_storage_url":'.
 								'{"operator":"=","values":["https%3A%2F%2Fnc.my-server.org"]}}'.
 							']',
-						'sortBy' => '[["status","asc"],["updatedAt","desc"]]',
+						'sortBy' => '[["updatedAt","desc"]]',
 					]
 				],
 			)
@@ -453,7 +453,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 								'{"operator":"=","values":["https%3A%2F%2Fnc.my-server.org"]}'.
 							'}'.
 						']',
-						'sortBy' => '[["status","asc"],["updatedAt","desc"]]',
+						'sortBy' => '[["updatedAt","desc"]]',
 					]
 			)
 			->willReturn(


### PR DESCRIPTION
To make it easier for the user to find workpackages sort them only by date, showing those that have been changed recently on the top.

fixes https://community.openproject.org/work_packages/44504
