### PR TITLE
 [OP#44482] pass in the OpenProject URL as state to the ProjectsTab

### DIFF
--- a/lib/Listener/LoadSidebarScript.php
+++ b/lib/Listener/LoadSidebarScript.php
@@ -103,5 +103,9 @@ class LoadSidebarScript implements IEventListener {
 		$this->initialStateService->provideInitialState(
 			'oauth-connection-error-message', $this->oauthConnectionErrorMessage
 		);
+		$this->initialStateService->provideInitialState(
+			'openproject-url',
+			$this->config->getAppValue(Application::APP_ID, 'oauth_instance_url')
+		);
 	}
 }

--- a/src/views/ProjectsTab.vue
+++ b/src/views/ProjectsTab.vue
@@ -99,6 +99,7 @@ export default {
 		oauthConnectionResult: loadState('integration_openproject', 'oauth-connection-result'),
 		isAdminConfigOk: loadState('integration_openproject', 'admin-config-status'),
 		color: null,
+		openprojectUrl: loadState('integration_openproject', 'openproject-url'),
 	}),
 	computed: {
 		isLoading() {
@@ -167,19 +168,9 @@ export default {
 			})
 		},
 		async routeToTheWorkPackage(workpackageId, projectId) {
-			let response
-			let openprojectUrl
-			try {
-				response = await axios.get(generateUrl('/apps/integration_openproject/url'))
-			} catch (e) {
-				response = e.response
-			}
-			this.checkForErrorCode(response.status)
-			if (response.status === 200) {
-				openprojectUrl = response.data.replace(/\/+$/, '')
-				const workpackageUrl = openprojectUrl + '/projects/' + projectId + '/work_packages/' + workpackageId
-				window.open(workpackageUrl)
-			}
+			const openprojectUrl = this.openprojectUrl.replace(/\/+$/, '')
+			const workpackageUrl = openprojectUrl + '/projects/' + projectId + '/work_packages/' + workpackageId
+			window.open(workpackageUrl)
 		},
 		unlink(workpackageId, fileId) {
 			OC.dialogs.confirmDestructive(

--- a/tests/jest/views/ProjectsTab.spec.js
+++ b/tests/jest/views/ProjectsTab.spec.js
@@ -471,16 +471,12 @@ describe('ProjectsTab.vue', () => {
 	})
 	describe('when the work package is clicked', () => {
 		it('opens work package in open project', async () => {
-			axios.get
-				.mockImplementationOnce(() => Promise.resolve({
-					status: 200,
-					data: 'http://openproject',
-				}))
 			window.open = jest.fn()
 			wrapper = mountWrapper()
 			await wrapper.setData({
 				workpackages: workPackagesSearchResponse,
 				fileInfo: { id: 1234 },
+				openprojectUrl: 'http://openproject',
 			})
 			await localVue.nextTick()
 			await wrapper.find(linkedWorkpackageSelector).trigger('click')


### PR DESCRIPTION
I don't see a reason why we should query the backend to find out the OpenProject URL, it does not change for different files or workpackage connections. It is much cheaper to pass it in by a state and using it.
Also it solves the problem with Firefox blocking the `window.open()` request as popup. Because the `window.open()` call now comes directly after the user interaction, Firefox does not block it.
For more details of how Firefox handles popups see: https://support.mozilla.org/en-US/kb/pop-blocker-settings-exceptions-troubleshooting?redirectslug=Pop-up+blocker&redirectlocale=en-US

fixes https://community.openproject.org/projects/nextcloud-integration/work_packages/44482