### PR TITLE
allow non admin user to mark notifications as read

### DIFF
--- a/lib/Controller/OpenProjectAPIController.php
+++ b/lib/Controller/OpenProjectAPIController.php
@@ -207,6 +207,7 @@ class OpenProjectAPIController extends Controller {
 	}
 
 	/**
+	 * @NoAdminRequired
 	 * @param int $workpackageId
 	 * @return DataResponse
 	 */


### PR DESCRIPTION
without this change only admins are allowed to use the endpoint, this does not make sense and lead to https://github.com/nextcloud/integration_openproject/pull/256#issuecomment-1298094150
