### PR TITLE
[css] remove the hard-coded color values or the search bar component

### DIFF
--- a/src/components/tab/SearchInput.vue
+++ b/src/components/tab/SearchInput.vue
@@ -191,9 +191,8 @@ export default {
 <style lang="scss">
 #searchBar {
 	padding: 10px;
-	position: -webkit-sticky; /* Safari */
 	position: sticky;
-	background-color: white;
+	position: -webkit-sticky; /* Safari */
 	z-index: 1;
 	top: 0;
 	.searchInput {
@@ -202,7 +201,6 @@ export default {
 	.stateMsg {
 		padding: 30px;
 		text-align: center;
-		color: #6d6d6d;
 	}
 	.multiselect {
 		.multiselect__content-wrapper {
@@ -216,17 +214,4 @@ export default {
 		}
 	}
 }
-
-body.theme--dark, body[data-theme-dark] {
-	#searchBar {
-		background-color: #171717;
-	}
-}
-
-body[data-theme-dark-highcontrast] {
-	#searchBar {
-		background-color: black;
-	}
-}
-
 </style>


### PR DESCRIPTION
## Description
There was a white _bg_ in the search bar while I was on the dark mode which I noticed while testing some other PR.
With this PR, the _hardcoded_ color values are cleaned so that the default NC _bg_ system will work in our search component.

## Screenshots
Before:
![Screenshot from 2022-11-02 12-31-37](https://user-images.githubusercontent.com/39373750/199419585-9502cd2d-3aea-4cc1-a2c2-116a5743de1e.png)

After:
![Screenshot from 2022-11-02 12-31-44](https://user-images.githubusercontent.com/39373750/199419672-db54d979-2578-4183-a842-3b9e4d2745b8.png)

---
Signed-off-by: Kiran Parajuli <kiranparajuli589@gmail.com>
