### PR TITLE
[ci] add `xdebug` for the phpunit tests coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           php-version: ${{ matrix.phpVersion }}
           tools: composer, phpunit
+          coverage: pcov
 
       - name: Get composer cache directory
         id: composer-cache
@@ -114,44 +115,44 @@ jobs:
           delete-old-comments: true
           title: "JS Code Coverage"
 
-      - name: Convert PHP cobertura coverage to lcov
-        if: ${{ github.event_name == 'pull_request' && matrix.nextcloudVersion == 'master' && matrix.phpVersion == '7.4' }}
-        uses: danielpalme/ReportGenerator-GitHub-Action@5.0.3
-        with:
-          reports: './coverage/php/cobertura.xml' # REQUIRED # The coverage reports that should be parsed (separated by semicolon). Globbing is supported.
-          targetdir: './coverage/php' # REQUIRED # The directory where the generated report should be saved.
-          reporttypes: 'lcov' # The output formats and scope (separated by semicolon) Values: Badges, Clover, Cobertura, CsvSummary, Html, HtmlChart, HtmlInline, HtmlInline_AzurePipelines, HtmlInline_AzurePipelines_Dark, HtmlSummary, JsonSummary, Latex, LatexSummary, lcov, MarkdownSummary, MHtml, PngChart, SonarQube, TeamCitySummary, TextSummary, Xml, XmlSummary
-          sourcedirs: '' # Optional directories which contain the corresponding source code (separated by semicolon). The source directories are used if coverage report contains classes without path information.
-          historydir: '' # Optional directory for storing persistent coverage information. Can be used in future reports to show coverage evolution.
-          plugins: '' # Optional plugin files for custom reports or custom history storage (separated by semicolon).
-          assemblyfilters: '+*' # Optional list of assemblies that should be included or excluded in the report. Exclusion filters take precedence over inclusion filters. Wildcards are allowed.
-          classfilters: '+*' # Optional list of classes that should be included or excluded in the report. Exclusion filters take precedence over inclusion filters. Wildcards are allowed.
-          filefilters: '+*' # Optional list of files that should be included or excluded in the report. Exclusion filters take precedence over inclusion filters. Wildcards are allowed.
-          verbosity: 'Verbose' # The verbosity level of the log messages. Values: Verbose, Info, Warning, Error, Off
-          title: '' # Optional title.
-          tag: '${{ github.run_number }}_${{ github.run_id }}' # Optional tag or build version.
-          customSettings: '' # Optional custom settings (separated by semicolon). See: https://github.com/danielpalme/ReportGenerator/wiki/Settings.
-          toolpath: 'reportgeneratortool' # Default directory for installing the dotnet tool.
+      # - name: Convert PHP cobertura coverage to lcov
+      #   if: ${{ github.event_name == 'pull_request' && matrix.nextcloudVersion == 'master' && matrix.phpVersion == '7.4' }}
+      #   uses: danielpalme/ReportGenerator-GitHub-Action@5.0.3
+      #   with:
+      #     reports: './coverage/php/cobertura.xml' # REQUIRED # The coverage reports that should be parsed (separated by semicolon). Globbing is supported.
+      #     targetdir: './coverage/php' # REQUIRED # The directory where the generated report should be saved.
+      #     reporttypes: 'lcov' # The output formats and scope (separated by semicolon) Values: Badges, Clover, Cobertura, CsvSummary, Html, HtmlChart, HtmlInline, HtmlInline_AzurePipelines, HtmlInline_AzurePipelines_Dark, HtmlSummary, JsonSummary, Latex, LatexSummary, lcov, MarkdownSummary, MHtml, PngChart, SonarQube, TeamCitySummary, TextSummary, Xml, XmlSummary
+      #     sourcedirs: '' # Optional directories which contain the corresponding source code (separated by semicolon). The source directories are used if coverage report contains classes without path information.
+      #     historydir: '' # Optional directory for storing persistent coverage information. Can be used in future reports to show coverage evolution.
+      #     plugins: '' # Optional plugin files for custom reports or custom history storage (separated by semicolon).
+      #     assemblyfilters: '+*' # Optional list of assemblies that should be included or excluded in the report. Exclusion filters take precedence over inclusion filters. Wildcards are allowed.
+      #     classfilters: '+*' # Optional list of classes that should be included or excluded in the report. Exclusion filters take precedence over inclusion filters. Wildcards are allowed.
+      #     filefilters: '+*' # Optional list of files that should be included or excluded in the report. Exclusion filters take precedence over inclusion filters. Wildcards are allowed.
+      #     verbosity: 'Verbose' # The verbosity level of the log messages. Values: Verbose, Info, Warning, Error, Off
+      #     title: '' # Optional title.
+      #     tag: '${{ github.run_number }}_${{ github.run_id }}' # Optional tag or build version.
+      #     customSettings: '' # Optional custom settings (separated by semicolon). See: https://github.com/danielpalme/ReportGenerator/wiki/Settings.
+      #     toolpath: 'reportgeneratortool' # Default directory for installing the dotnet tool.
 
-      - name: PHP Code Coverage Summary Report
-        if: ${{ github.event_name == 'pull_request' && matrix.nextcloudVersion == 'master' && matrix.phpVersion == '7.4' }}
-        uses: romeovs/lcov-reporter-action@v0.3.1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          lcov-file: ./coverage/php/lcov.info
-          delete-old-comments: true
-          title: "PHP Code Coverage"
+      # - name: PHP Code Coverage Summary Report
+      #   if: ${{ github.event_name == 'pull_request' && matrix.nextcloudVersion == 'master' && matrix.phpVersion == '7.4' }}
+      #   uses: romeovs/lcov-reporter-action@v0.3.1
+      #   with:
+      #     github-token: ${{ secrets.GITHUB_TOKEN }}
+      #     lcov-file: ./coverage/php/lcov.info
+      #     delete-old-comments: true
+      #     title: "PHP Code Coverage"
 
-      - name: JS coverage check
-        if: ${{ github.event_name == 'pull_request' && matrix.nextcloudVersion == 'master' && matrix.phpVersion == '7.4' }}
-        uses: VeryGoodOpenSource/very_good_coverage@v1.2.0
-        with:
-          min_coverage: '59'
-          path: './coverage/jest/lcov.info'
+      # - name: JS coverage check
+      #   if: ${{ github.event_name == 'pull_request' && matrix.nextcloudVersion == 'master' && matrix.phpVersion == '7.4' }}
+      #   uses: VeryGoodOpenSource/very_good_coverage@v1.2.0
+      #   with:
+      #     min_coverage: '59'
+      #     path: './coverage/jest/lcov.info'
 
-      - name: PHP coverage check
-        if: ${{ github.event_name == 'pull_request' && matrix.nextcloudVersion == 'master' && matrix.phpVersion == '7.4' }}
-        uses: VeryGoodOpenSource/very_good_coverage@v1.2.0
-        with:
-          min_coverage: '57'
-          path: './coverage/php/lcov.info'
+      # - name: PHP coverage check
+      #   if: ${{ github.event_name == 'pull_request' && matrix.nextcloudVersion == 'master' && matrix.phpVersion == '7.4' }}
+      #   uses: VeryGoodOpenSource/very_good_coverage@v1.2.0
+      #   with:
+      #     min_coverage: '57'
+      #     path: './coverage/php/lcov.info'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           php-version: ${{ matrix.phpVersion }}
           tools: composer, phpunit
-          coverage: pcov
+          coverage: xdebug
 
       - name: Get composer cache directory
         id: composer-cache
@@ -115,44 +115,44 @@ jobs:
           delete-old-comments: true
           title: "JS Code Coverage"
 
-      # - name: Convert PHP cobertura coverage to lcov
-      #   if: ${{ github.event_name == 'pull_request' && matrix.nextcloudVersion == 'master' && matrix.phpVersion == '7.4' }}
-      #   uses: danielpalme/ReportGenerator-GitHub-Action@5.0.3
-      #   with:
-      #     reports: './coverage/php/cobertura.xml' # REQUIRED # The coverage reports that should be parsed (separated by semicolon). Globbing is supported.
-      #     targetdir: './coverage/php' # REQUIRED # The directory where the generated report should be saved.
-      #     reporttypes: 'lcov' # The output formats and scope (separated by semicolon) Values: Badges, Clover, Cobertura, CsvSummary, Html, HtmlChart, HtmlInline, HtmlInline_AzurePipelines, HtmlInline_AzurePipelines_Dark, HtmlSummary, JsonSummary, Latex, LatexSummary, lcov, MarkdownSummary, MHtml, PngChart, SonarQube, TeamCitySummary, TextSummary, Xml, XmlSummary
-      #     sourcedirs: '' # Optional directories which contain the corresponding source code (separated by semicolon). The source directories are used if coverage report contains classes without path information.
-      #     historydir: '' # Optional directory for storing persistent coverage information. Can be used in future reports to show coverage evolution.
-      #     plugins: '' # Optional plugin files for custom reports or custom history storage (separated by semicolon).
-      #     assemblyfilters: '+*' # Optional list of assemblies that should be included or excluded in the report. Exclusion filters take precedence over inclusion filters. Wildcards are allowed.
-      #     classfilters: '+*' # Optional list of classes that should be included or excluded in the report. Exclusion filters take precedence over inclusion filters. Wildcards are allowed.
-      #     filefilters: '+*' # Optional list of files that should be included or excluded in the report. Exclusion filters take precedence over inclusion filters. Wildcards are allowed.
-      #     verbosity: 'Verbose' # The verbosity level of the log messages. Values: Verbose, Info, Warning, Error, Off
-      #     title: '' # Optional title.
-      #     tag: '${{ github.run_number }}_${{ github.run_id }}' # Optional tag or build version.
-      #     customSettings: '' # Optional custom settings (separated by semicolon). See: https://github.com/danielpalme/ReportGenerator/wiki/Settings.
-      #     toolpath: 'reportgeneratortool' # Default directory for installing the dotnet tool.
+      - name: Convert PHP cobertura coverage to lcov
+        if: ${{ github.event_name == 'pull_request' && matrix.nextcloudVersion == 'master' && matrix.phpVersion == '7.4' }}
+        uses: danielpalme/ReportGenerator-GitHub-Action@5.0.3
+        with:
+          reports: './coverage/php/cobertura.xml' # REQUIRED # The coverage reports that should be parsed (separated by semicolon). Globbing is supported.
+          targetdir: './coverage/php' # REQUIRED # The directory where the generated report should be saved.
+          reporttypes: 'lcov' # The output formats and scope (separated by semicolon) Values: Badges, Clover, Cobertura, CsvSummary, Html, HtmlChart, HtmlInline, HtmlInline_AzurePipelines, HtmlInline_AzurePipelines_Dark, HtmlSummary, JsonSummary, Latex, LatexSummary, lcov, MarkdownSummary, MHtml, PngChart, SonarQube, TeamCitySummary, TextSummary, Xml, XmlSummary
+          sourcedirs: '' # Optional directories which contain the corresponding source code (separated by semicolon). The source directories are used if coverage report contains classes without path information.
+          historydir: '' # Optional directory for storing persistent coverage information. Can be used in future reports to show coverage evolution.
+          plugins: '' # Optional plugin files for custom reports or custom history storage (separated by semicolon).
+          assemblyfilters: '+*' # Optional list of assemblies that should be included or excluded in the report. Exclusion filters take precedence over inclusion filters. Wildcards are allowed.
+          classfilters: '+*' # Optional list of classes that should be included or excluded in the report. Exclusion filters take precedence over inclusion filters. Wildcards are allowed.
+          filefilters: '+*' # Optional list of files that should be included or excluded in the report. Exclusion filters take precedence over inclusion filters. Wildcards are allowed.
+          verbosity: 'Verbose' # The verbosity level of the log messages. Values: Verbose, Info, Warning, Error, Off
+          title: '' # Optional title.
+          tag: '${{ github.run_number }}_${{ github.run_id }}' # Optional tag or build version.
+          customSettings: '' # Optional custom settings (separated by semicolon). See: https://github.com/danielpalme/ReportGenerator/wiki/Settings.
+          toolpath: 'reportgeneratortool' # Default directory for installing the dotnet tool.
 
-      # - name: PHP Code Coverage Summary Report
-      #   if: ${{ github.event_name == 'pull_request' && matrix.nextcloudVersion == 'master' && matrix.phpVersion == '7.4' }}
-      #   uses: romeovs/lcov-reporter-action@v0.3.1
-      #   with:
-      #     github-token: ${{ secrets.GITHUB_TOKEN }}
-      #     lcov-file: ./coverage/php/lcov.info
-      #     delete-old-comments: true
-      #     title: "PHP Code Coverage"
+      - name: PHP Code Coverage Summary Report
+        if: ${{ github.event_name == 'pull_request' && matrix.nextcloudVersion == 'master' && matrix.phpVersion == '7.4' }}
+        uses: romeovs/lcov-reporter-action@v0.3.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          lcov-file: ./coverage/php/lcov.info
+          delete-old-comments: true
+          title: "PHP Code Coverage"
 
-      # - name: JS coverage check
-      #   if: ${{ github.event_name == 'pull_request' && matrix.nextcloudVersion == 'master' && matrix.phpVersion == '7.4' }}
-      #   uses: VeryGoodOpenSource/very_good_coverage@v1.2.0
-      #   with:
-      #     min_coverage: '59'
-      #     path: './coverage/jest/lcov.info'
+      - name: JS coverage check
+        if: ${{ github.event_name == 'pull_request' && matrix.nextcloudVersion == 'master' && matrix.phpVersion == '7.4' }}
+        uses: VeryGoodOpenSource/very_good_coverage@v1.2.0
+        with:
+          min_coverage: '59'
+          path: './coverage/jest/lcov.info'
 
-      # - name: PHP coverage check
-      #   if: ${{ github.event_name == 'pull_request' && matrix.nextcloudVersion == 'master' && matrix.phpVersion == '7.4' }}
-      #   uses: VeryGoodOpenSource/very_good_coverage@v1.2.0
-      #   with:
-      #     min_coverage: '57'
-      #     path: './coverage/php/lcov.info'
+      - name: PHP coverage check
+        if: ${{ github.event_name == 'pull_request' && matrix.nextcloudVersion == 'master' && matrix.phpVersion == '7.4' }}
+        uses: VeryGoodOpenSource/very_good_coverage@v1.2.0
+        with:
+          min_coverage: '57'
+          path: './coverage/php/lcov.info'


### PR DESCRIPTION
**Description:** Started using `xdebug` for coverage analysis. The same is used for me in my local machine. Only `xdebug` or `pcov` is supported by https://github.com/shivammathur/setup-php#signal_strength-coverage-support. So after using the `xdebug` tool, the php code coverage are back.

**Related:** https://community.openproject.org/projects/nextcloud-integration/work_packages/44746

---
Signed-off-by: Kiran Parajuli <kiranparajuli589@gmail.com>
