### PR TITLE
[backport][ci] add `xdebug` for the phpunit tests coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           php-version: ${{ matrix.phpVersion }}
           tools: composer, phpunit
+          coverage: xdebug
 
       - name: Get composer cache directory
         id: composer-cache


### PR DESCRIPTION
backport of https://github.com/nextcloud/integration_openproject/pull/264 to the release 2.1 branch