### PR TITLE
[OP#44822] fix unit tests failing because of changes in NC 26

### DIFF
--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -32,6 +32,7 @@ use OCP\ILogger;
 use OCP\IURLGenerator;
 use OCP\IUserManager;
 use OCP\Notification\IManager;
+use OCP\Security\IRemoteHostValidator;
 use PhpPact\Consumer\InteractionBuilder;
 use PhpPact\Consumer\Model\ConsumerRequest;
 use PhpPact\Consumer\Model\ProviderResponse;
@@ -204,8 +205,17 @@ class OpenProjectAPIServiceTest extends TestCase {
 
 		$client = new GuzzleClient();
 
-		//changed from nextcloud 24
-		if (version_compare(OC_Util::getVersionString(), '24') >= 0) {
+		if (version_compare(OC_Util::getVersionString(), '26') >= 0) {
+			//changed from nextcloud 26
+			// @phpstan-ignore-next-line
+			$ocClient = new Client(
+				$this->createMock(IConfig::class),                             // @phpstan-ignore-line
+				$certificateManager,                                           // @phpstan-ignore-line
+				$client,                                                       // @phpstan-ignore-line
+				$this->createMock(IRemoteHostValidator::class)  // @phpstan-ignore-line
+			);
+		} elseif (version_compare(OC_Util::getVersionString(), '24') >= 0) {
+			//changed from nextcloud 24
 			// @phpstan-ignore-next-line
 			$ocClient = new Client(
 				$this->createMock(IConfig::class),                             // @phpstan-ignore-line

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -204,21 +204,27 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$certificateManager->method('getAbsoluteBundlePath')->willReturn('/');
 
 		$client = new GuzzleClient();
+		$clientConfigMock = $this->getMockBuilder(IConfig::class)->getMock();
+
+		$clientConfigMock
+			->method('getSystemValueBool')
+			->with('allow_local_remote_servers', false)
+			->willReturn(true);
 
 		if (version_compare(OC_Util::getVersionString(), '26') >= 0) {
 			//changed from nextcloud 26
 			// @phpstan-ignore-next-line
 			$ocClient = new Client(
-				$this->createMock(IConfig::class),                             // @phpstan-ignore-line
+				$clientConfigMock,                                             // @phpstan-ignore-line
 				$certificateManager,                                           // @phpstan-ignore-line
 				$client,                                                       // @phpstan-ignore-line
-				$this->createMock(IRemoteHostValidator::class)  // @phpstan-ignore-line
+				$this->createMock(IRemoteHostValidator::class)                 // @phpstan-ignore-line
 			);
 		} elseif (version_compare(OC_Util::getVersionString(), '24') >= 0) {
 			//changed from nextcloud 24
 			// @phpstan-ignore-next-line
 			$ocClient = new Client(
-				$this->createMock(IConfig::class),                             // @phpstan-ignore-line
+				$clientConfigMock,                                             // @phpstan-ignore-line
 				$certificateManager,                                           // @phpstan-ignore-line
 				$client,                                                       // @phpstan-ignore-line
 				$this->createMock(\OC\Http\Client\LocalAddressChecker::class)  // @phpstan-ignore-line
@@ -226,7 +232,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 		} else {
 			// @phpstan-ignore-next-line
 			$ocClient = new Client(
-				$this->createMock(IConfig::class),                             // @phpstan-ignore-line
+				$clientConfigMock,                                             // @phpstan-ignore-line
 				$this->createMock(ILogger::class),                             // @phpstan-ignore-line
 				$certificateManager,                                           // @phpstan-ignore-line
 				$client,                                                       // @phpstan-ignore-line


### PR DESCRIPTION
The local address checker was changed in https://github.com/nextcloud/server/pull/34852
This should not effect how we use it, because we only catch the exception, but the unit tests needed to be adjusted

fixes https://community.openproject.org/projects/nextcloud-integration/work_packages/44822