### PR TITLE
[OP#44485]Enable Reset Button only when any integration setting is set by admin

### DIFF
--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -163,7 +163,7 @@
 		</div>
 		<Button id="reset-all-app-settings-btn"
 			type="error"
-			:disabled="!isIntegrationComplete"
+			:disabled="isResetButtonDisabled"
 			@click="resetAllAppValuesConfirmation">
 			<template #icon>
 				<RestoreIcon :size="20" />
@@ -315,6 +315,9 @@ export default {
 				 && this.isOPOAuthFormComplete
 				 && this.isNcOAuthFormComplete)
 		},
+		isResetButtonDisabled() {
+			return !(this.state.client_id || this.state.client_secret || this.state.oauth_instance_url);
+		}
 	},
 	created() {
 		this.init()

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -163,6 +163,7 @@
 		</div>
 		<Button id="reset-all-app-settings-btn"
 			type="error"
+			:disabled="!isIntegrationComplete"
 			@click="resetAllAppValuesConfirmation">
 			<template #icon>
 				<RestoreIcon :size="20" />

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -316,8 +316,8 @@ export default {
 				 && this.isNcOAuthFormComplete)
 		},
 		isResetButtonDisabled() {
-			return !(this.state.client_id || this.state.client_secret || this.state.oauth_instance_url);
-		}
+			return !(this.state.client_id || this.state.client_secret || this.state.oauth_instance_url)
+		},
 	},
 	created() {
 		this.init()


### PR DESCRIPTION
### Description
During `Oauth` configuration between 2 apps, even when admin has not configured any setting the `reset` button is enabled. This PR disable it until any of the configuration is set.

### Related issue and fixes:
https://community.openproject.org/projects/nextcloud-integration/work_packages/44485/activity?query_id=3513

UI Before changes: When no setting is set by admin
![Screenshot from 2022-11-14 16-30-36](https://user-images.githubusercontent.com/46086950/201640904-33f3a5b7-6ef4-41bb-b52a-c0e4a0f4f636.png)


UI After changes: When a setting is set by admin

![Screenshot from 2022-11-14 16-30-48](https://user-images.githubusercontent.com/46086950/201641069-38826e5b-0e83-4892-81f4-5df459fe89ed.png)

