### PR TITLE
[OP#44934] initialize variables

### DIFF
--- a/lib/Listener/LoadSidebarScript.php
+++ b/lib/Listener/LoadSidebarScript.php
@@ -51,11 +51,11 @@ class LoadSidebarScript implements IEventListener {
 	/**
 	 * @var string "error"|"success"|""
 	 */
-	private $oauthConnectionResult;
+	private $oauthConnectionResult = '';
 	/**
 	 * @var string
 	 */
-	private $oauthConnectionErrorMessage;
+	private $oauthConnectionErrorMessage = '';
 
 	public function __construct(
 		IInitialState $initialStateService,


### PR DESCRIPTION
`provideInitialState` does not like it when the value is `null` and shows a log entry in that case. The fix is very simply, just initialize the variables with an empty string, that is anyway a good programming practice.