### PR TITLE
Use pgsql of version 14 to avoid permission errors in the compose setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.9'
 
 services:
   db:
-    image: postgres:alpine
+    image: postgres:14
     restart: always
     volumes:
       - db:/var/lib/postgresql/data


### PR DESCRIPTION
# Description
The compose setup was failing due the following dB issue:
```console
integration_openproject-db-1         | 2022-11-22 06:22:18.959 UTC [156] ERROR:  permission denied for schema public at character 14
integration_openproject-db-1         | 2022-11-22 06:22:18.959 UTC [156] STATEMENT:  CREATE TABLE oc_migrations (app VARCHAR(255) NOT NULL, version VARCHAR(255) NOT NULL, PRIMARY KEY(app, version))
```

The latest psql docker image has this bug and is well described in the nextcloud issue https://github.com/nextcloud/docker/issues/1845

As a solution we can pin v14 for the docker image and use the sound service.

Related Reddit thread: https://www.reddit.com/r/selfhosted/comments/y4klsz/help_with_a_new_install_of_nextcloud_on_docker/

---
Signed-off-by: Kiran Parajuli <kiranparajuli589@gmail.com>
