### PR TITLE
[OP#42323] support dateAlert notifications from OP

### DIFF
--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -183,16 +183,19 @@ export default {
 						const userId = n._links?.actor?.href
 							? n._links.actor.href.replace(/.*\//, '')
 							: null
-						if (notifications[wpId].mostRecentActor === undefined) {
+						const title = n._links?.actor?.title
+							? n._links.actor.title
+							: null
+						if (notifications[wpId].mostRecentActor === undefined && userId !== null) {
 							notifications[wpId].mostRecentActor = {
-								title: n._links.actor.title,
+								title,
 								id: userId,
 								createdAt: n.createdAt,
 							}
-						} else if (userId !== notifications[wpId].mostRecentActor.id) {
+						} else if (userId !== null && userId !== notifications[wpId].mostRecentActor.id) {
 							if (Date.parse(n.createdAt) > Date.parse(notifications[wpId].mostRecentActor.createdAt)) {
 								notifications[wpId].mostRecentActor = {
-									title: n._links.actor.title,
+									title,
 									id: userId,
 									createdAt: n.createdAt,
 								}
@@ -224,18 +227,23 @@ export default {
 			return this.openprojectUrl + '/notifications/details/' + n.wpId + '/activity/'
 		},
 		getAuthorShortName(n) {
-			return n.mostRecentActor.title
+			return n.mostRecentActor?.title
 				? n.mostRecentActor.title
 				: undefined
 		},
 		getAuthorAvatarUrl(n) {
-			return n.mostRecentActor.id
-				? generateUrl('/apps/integration_openproject/avatar?') + encodeURIComponent('userId') + '=' + n.mostRecentActor.id + '&' + encodeURIComponent('userName') + '=' + n.mostRecentActor.title
-				: ''
+			const url = generateUrl('/apps/integration_openproject/avatar?')
+			return n.mostRecentActor?.id
+				? url + encodeURIComponent('userId') + '=' + n.mostRecentActor.id + '&' + encodeURIComponent('userName') + '=' + n.mostRecentActor.title
+				: url + encodeURIComponent('userName') + '='
 		},
 		getSubline(n) {
 			let reasonsString = ''
 			n.reasons.forEach((value) => {
+				// dateAlert is the only string that is not humanly readable by itself
+				if (value === 'dateAlert') {
+					value = 'Date alert'
+				}
 				reasonsString = reasonsString + ', ' + t('integration_openproject', value)
 			})
 			return n.projectTitle + ' - ' + reasonsString.replace(/^, /, '')

--- a/tests/jest/fixtures/notificationsResponse.json
+++ b/tests/jest/fixtures/notificationsResponse.json
@@ -254,5 +254,89 @@
 				"title": "Create wireframes for new landing page"
 			}
 		}
+	},
+	{
+		"_type": "Notification",
+		"id": 83,
+		"readIAN": false,
+		"reason": "dateAlert",
+		"createdAt": "2022-11-24T08:08:47Z",
+		"updatedAt": "2022-11-24T08:08:47Z",
+		"_embedded": {
+			"details": [
+				{
+					"_type": "Values::Property",
+					"property": "startDate",
+					"value": "2022-01-13",
+					"_links": {
+						"self": {
+							"href": "/api/v3/notifications/83/details/0"
+						},
+						"schema": {
+							"href": "/api/v3/values/schemas/startDate"
+						}
+					}
+				}
+			]
+		},
+		"_links": {
+			"self": {
+				"href": "/api/v3/notifications/83"
+			},
+			"readIAN": {
+				"href": "/api/v3/notifications/83/read_ian",
+				"method": "post"
+			},
+			"project": {
+				"href": "/api/v3/projects/1",
+				"title": "Demo project"
+			},
+			"resource": {
+				"href": "/api/v3/work_packages/24",
+				"title": "Choose a content management system"
+			}
+		}
+	},
+	{
+		"_type": "Notification",
+		"id": 81,
+		"readIAN": false,
+		"reason": "dateAlert",
+		"createdAt": "2022-11-23T06:10:38Z",
+		"updatedAt": "2022-11-24T08:00:12Z",
+		"_embedded": {
+			"details": [
+				{
+					"_type": "Values::Property",
+					"property": "dueDate",
+					"value": "2022-11-24",
+					"_links": {
+						"self": {
+							"href": "/api/v3/notifications/81/details/0"
+						},
+						"schema": {
+							"href": "/api/v3/values/schemas/dueDate"
+						}
+					}
+				}
+			]
+		},
+		"_links": {
+			"self": {
+				"href": "/api/v3/notifications/81"
+			},
+			"readIAN": {
+				"href": "/api/v3/notifications/81/read_ian",
+				"method": "post"
+			},
+			"project": {
+				"href": "/api/v3/projects/1",
+				"title": "Demo project"
+			},
+			"resource": {
+				"href": "/api/v3/work_packages/17",
+				"title": "Create wireframes for new landing page"
+			}
+		}
 	}
 ]

--- a/tests/jest/views/__snapshots__/Dashboard.spec.js.snap
+++ b/tests/jest/views/__snapshots__/Dashboard.spec.js.snap
@@ -6,9 +6,9 @@ Array [
     "avatarUrl": "http://localhost/apps/integration_openproject/avatar?userId=8&userName=Admin de DEV user",
     "avatarUsername": "Admin de DEV userz",
     "id": "17",
-    "mainText": "(5) Create wireframes for new landing page",
+    "mainText": "(6) Create wireframes for new landing page",
     "overlayIconUrl": "",
-    "subText": "Scrum project - assigned, mentioned",
+    "subText": "Scrum project - assigned, mentioned, Date alert",
     "targetUrl": "http://openproject.org/notifications/details/17/activity/",
   },
   Object {
@@ -19,6 +19,15 @@ Array [
     "overlayIconUrl": "",
     "subText": "Scrum project - mentioned",
     "targetUrl": "http://openproject.org/notifications/details/18/activity/",
+  },
+  Object {
+    "avatarUrl": "http://localhost/apps/integration_openproject/avatar?userName=",
+    "avatarUsername": "undefinedz",
+    "id": "24",
+    "mainText": "(1) Choose a content management system",
+    "overlayIconUrl": "",
+    "subText": "Demo project - Date alert",
+    "targetUrl": "http://openproject.org/notifications/details/24/activity/",
   },
   Object {
     "avatarUrl": "http://localhost/apps/integration_openproject/avatar?userId=8&userName=Admin de DEV user",


### PR DESCRIPTION
from the version 12.4 OpenProject sends out notifications based on the dates set in the WP. This PR supports those notifications now. Before date notifications broke the dashboard and would display wrongly in the notifications app, because they don't have a actor.

For now the dashboard shows a `?` if there is no actor, after #254 we can use a calendar icon for that

To test date based notifications this command can be used to generate them :
`rails runner 'Notification.create(recipient: User.find_by(lastname: "[LASTNAME OF USER TO CREATE NOTIFICATION FOR]"), reason: :[REASON], resource: WorkPackage.find([SOME ID]), project: WorkPackage.find([SOME SAME ID]).project)'`
valid values for `reason` are: `date_alert_start_date`, `date_alert_due_date` and `date_alert_date`
