### PR TITLE
Add Sabre plugin to whitelist the OP instance in the CORS headers

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -23,6 +23,9 @@ For more information on how to set up and use the OpenProject application, pleas
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>OpenProject</namespace>
+	<types>
+		<dav/>
+	</types>
 	<documentation>
 		<user>https://openproject.org/docs/user-guide/nextcloud-integration/</user>
 		<admin>https://openproject.org/docs/system-admin-guide/integrations/nextcloud/</admin>

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -12,6 +12,7 @@ namespace OCA\OpenProject\AppInfo;
 use Closure;
 use OCA\Files\Event\LoadSidebar;
 use OCA\OpenProject\Listener\LoadSidebarScript;
+use OCA\OpenProject\Listener\SabrePublicPluginListener;
 use OCA\OpenProject\Sabre\CorsPlugin;
 use OCP\IConfig;
 use OCP\IL10N;
@@ -19,6 +20,7 @@ use OCP\INavigationManager;
 use OCP\IURLGenerator;
 use OCP\IUserSession;
 use OCP\SabrePluginEvent;
+use OCP\SabrePublicPluginEvent;
 use OCP\Util;
 
 use OCP\AppFramework\App;
@@ -62,6 +64,11 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(
 			LoadSidebar::class,
 			LoadSidebarScript::class
+		);
+
+		$context->registerEventListener(
+			SabrePublicPluginEvent::class,
+			SabrePublicPluginListener::class
 		);
 	}
 

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -12,11 +12,13 @@ namespace OCA\OpenProject\AppInfo;
 use Closure;
 use OCA\Files\Event\LoadSidebar;
 use OCA\OpenProject\Listener\LoadSidebarScript;
+use OCA\OpenProject\Sabre\CorsPlugin;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\INavigationManager;
 use OCP\IURLGenerator;
 use OCP\IUserSession;
+use OCP\SabrePluginEvent;
 use OCP\Util;
 
 use OCP\AppFramework\App;
@@ -69,6 +71,11 @@ class Application extends App implements IBootstrap {
 		$dispatcher = $context->getAppContainer()->get(IEventDispatcher::class);
 		$dispatcher->addListener('OCA\Files::loadAdditionalScripts', function () {
 			Util::addScript(Application::APP_ID, 'integration_openproject-fileActions');
+		});
+
+		$config = $this->config;
+		$dispatcher->addListener('OCA\DAV\Connector\Sabre::addPlugin', function (SabrePluginEvent $event) use ($config) {
+			$event->getServer()->addPlugin(new CorsPlugin($config));
 		});
 	}
 

--- a/lib/Listener/SabrePublicPluginListener.php
+++ b/lib/Listener/SabrePublicPluginListener.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2022 Julien Veyssier <eneiluj@posteo.net>
+ *
+ * @author Julien Veyssier <eneiluj@posteo.net>
+ *
+ * @license GNU Affero General Public License v3.0 or later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\OpenProject\Listener;
+
+use OCA\Files\Event\LoadSidebar;
+use OCA\OpenProject\AppInfo\Application;
+use OCA\OpenProject\Sabre\CorsPlugin;
+use OCA\OpenProject\Service\OpenProjectAPIService;
+use OCP\AppFramework\Services\IInitialState;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\IConfig;
+use OCP\IRequest;
+use OCP\IUserSession;
+use OCP\SabrePublicPluginEvent;
+use OCP\Util;
+
+class SabrePublicPluginListener implements IEventListener {
+
+	/**
+	 * @var CorsPlugin
+	 */
+	private $corsPlugin;
+
+	public function __construct(CorsPlugin $corsPlugin) {
+		$this->corsPlugin = $corsPlugin;
+	}
+
+	public function handle(Event $event): void {
+		error_log('LISTENER');
+		if (!($event instanceof SabrePublicPluginEvent)) {
+			return;
+		}
+
+		$event->getServer()->addPlugin($this->corsPlugin);
+	}
+}

--- a/lib/Sabre/CorsPlugin.php
+++ b/lib/Sabre/CorsPlugin.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\OpenProject\Sabre;
+
+use OCA\OpenProject\AppInfo\Application;
+use OCP\IConfig;
+use Sabre\DAV\Server;
+use Sabre\DAV\ServerPlugin;
+use Sabre\HTTP\RequestInterface;
+use Sabre\HTTP\ResponseInterface;
+use Sabre\HTTP\Sapi;
+
+/**
+ * inspired by https://gitlab.tugraz.at/dbp/nextcloud/webapppassword/-/blob/master/lib/Connector/Sabre/CorsPlugin.php
+ */
+class CorsPlugin extends ServerPlugin {
+	/**
+	 * @var string
+	 */
+	private $allowedOrigin;
+
+	public function __construct(IConfig $config) {
+		$this->allowedOrigin = $config->getAppValue(Application::APP_ID, 'oauth_instance_url');
+	}
+
+	/**
+	 * @param Server $server
+	 * @return void
+	 */
+	public function initialize(\Sabre\DAV\Server $server): void {
+		$server->on('beforeMethod:*', [$this, 'setCorsHeaders'], 5);
+	}
+
+	/**
+	 * @return void|bool
+	 */
+	public function setCorsHeaders(RequestInterface $request, ResponseInterface $response) {
+		if ($response->hasHeader('access-control-allow-origin')) {
+			return;
+		}
+
+		$origin = $request->getHeader('origin');
+		if (empty($origin) || $origin !== $this->allowedOrigin) {
+			return;
+		}
+
+		$response->addHeader('access-control-allow-origin', $origin);
+		$response->addHeader('access-control-allow-methods', $request->getHeader('access-control-request-method'));
+		$response->addHeader('access-control-allow-headers', $request->getHeader('access-control-request-headers'));
+		$response->addHeader('access-control-expose-headers', 'etag, dav');
+		$response->addHeader('access-control-allow-credentials', 'true');
+
+		if ($request->getMethod() === 'OPTIONS' && empty($request->getHeader('authorization'))) {
+			$response->setStatus(204);
+			Sapi::sendResponse($response);
+
+			return false;
+		}
+	}
+}


### PR DESCRIPTION
Add a Sabre plugin that changes the DAV response headers on some conditions. This is how the https://github.com/digital-blueprint/webapppassword app does it.

:warning: We need https://github.com/nextcloud/server/pull/35621 for this PR to work with requests to `/public.php/webdav`.
Otherwise it just works with requests to `/remote.php/dav/files`.
