### PR TITLE
[OP#44889] Add spacing in bell icon in dashboard

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -39,7 +39,7 @@ body.theme--dark .icon-openproject {
 	height: 24px; width: 24px;
 	background-size: 24px;
 	top: 3px;
-	left: 170px;
+	left: 180px;
 	background-image: url('../img/bell-ring.svg');
 }
 

--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -54,5 +54,5 @@ body.theme--dark .panel > .panel--header .icon-openproject::before {
 /*for NC <= v24 the icon needs less margin at left and zero at the top */
 .panel > .panel--header .nc-before-v24.icon-openproject::before {
 	top: 28%;
-	left: 180px;
+	left: 195px;
 }


### PR DESCRIPTION
In version 24 of the nextcloud, the spacing was missing  between the OpenProject and bell icon so this PR fixes that

# Stable 24
## Before
![Screenshot from 2022-12-08 09-53-18](https://user-images.githubusercontent.com/41103328/206355149-9fa64b94-4f57-4a5f-a306-e28d0aedbe5d.png)


## After

![Screenshot from 2022-12-08 09-53-39](https://user-images.githubusercontent.com/41103328/206355155-97d388b9-11ef-48a2-97ae-8cacc3a2d5ae.png)

The bell icon doesn't have spacing in current master either so it's fixed there too 
# master
## Before
![Screenshot from 2022-12-08 10-11-54](https://user-images.githubusercontent.com/41103328/206356787-64a64e21-9945-4349-a851-775229055eed.png)

## After
![Screenshot from 2022-12-08 10-12-15](https://user-images.githubusercontent.com/41103328/206356792-4f39945d-148b-4f6a-8c28-ba2c6cf02e7e.png)


Related work package: https://community.openproject.org/projects/nextcloud-integration/work_packages/44889/activity
