### PR TITLE
[OP#42323] set pageSize for notifications to 'unlimited'

### DIFF
--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -127,7 +127,8 @@ class OpenProjectAPIService {
 		];
 
 		$params = [
-			'filters' => \Safe\json_encode($filters),
+			'pageSize' => -1,
+			'filters' => \Safe\json_encode($filters)
 		];
 		$result = $this->request($userId, 'notifications', $params);
 		if (isset($result['error'])) {

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -492,7 +492,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$consumerRequest
 			->setMethod('GET')
 			->setPath($this->notificationsPath)
-			->setQuery("filters=" . \Safe\json_encode([[
+			->setQuery("pageSize=-1&filters=" . \Safe\json_encode([[
 				'readIAN' =>
 					['operator' => '=', 'values' => ['f']]
 			]]))


### PR DESCRIPTION
Without setting anything in the request URL the pageSize will be whatever is set in Administration=>System Settings=>General as	`Objects per page options`

Setting it to `-1` should solve the problem described in https://community.openproject.org/work_packages/42323/activity#activity-40
