### PR TITLE
[OP#44486] Remove the hard coded color from button text

### DIFF
--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -699,7 +699,6 @@ export default {
 			font-weight: 400 !important;
 			font-size: 14px !important;
 			line-height: 20px !important;
-			color: #333333 !important;
 		}
 	}
 	.form-actions {


### PR DESCRIPTION
Related work-package: [OP#44486](https://community.openproject.org/projects/nextcloud-integration/work_packages/44486/activity?query_id=3513)

In firefox when the browser was in a dark theme the text in the button were not readable
![Screenshot from 2022-12-13 15-07-00](https://user-images.githubusercontent.com/41103328/207280145-bf7a4ff3-f8d8-4c08-bdef-67a7b7816fd3.png)

This PR removes the hard-coded color so that the nextcloud default color is used which works across all the browsers and themes

## After the fix
![Screenshot from 2022-12-13 15-10-00](https://user-images.githubusercontent.com/41103328/207280485-f64adba3-5048-4e01-9ee5-d78993ab97d1.png)
