### PR TITLE
[OP#45409] rewrite the reason strings to be the same as in OP

### DIFF
--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -240,9 +240,21 @@ export default {
 		getSubline(n) {
 			let reasonsString = ''
 			n.reasons.forEach((value) => {
-				// dateAlert is the only string that is not humanly readable by itself
-				if (value === 'dateAlert') {
+				// rewrite the values that come from the API to be displayed
+				// the same as they are in OP
+				switch (value) {
+				case 'dateAlert':
 					value = 'Date alert'
+					break
+				case 'assigned':
+					value = 'assignee'
+					break
+				case 'responsible':
+					value = 'accountable'
+					break
+				case 'watched':
+					value = 'watcher'
+					break
 				}
 				reasonsString = reasonsString + ', ' + t('integration_openproject', value)
 			})

--- a/tests/jest/views/__snapshots__/Dashboard.spec.js.snap
+++ b/tests/jest/views/__snapshots__/Dashboard.spec.js.snap
@@ -8,7 +8,7 @@ Array [
     "id": "17",
     "mainText": "(6) Create wireframes for new landing page",
     "overlayIconUrl": "",
-    "subText": "Scrum project - assigned, mentioned, Date alert",
+    "subText": "Scrum project - assignee, mentioned, Date alert",
     "targetUrl": "http://openproject.org/notifications/details/17/activity/",
   },
   Object {
@@ -35,7 +35,7 @@ Array [
     "id": "36",
     "mainText": "(2) write a software",
     "overlayIconUrl": "",
-    "subText": "Dev-large - assigned",
+    "subText": "Dev-large - assignee",
     "targetUrl": "http://openproject.org/notifications/details/36/activity/",
   },
 ]


### PR DESCRIPTION
The strings for the reasons of notifications have been different in NC and OP because for most cases NC just showed what the API delivered. This PR changes the known strings and rewrites them to be the same as in OP

fixes https://community.openproject.org/notifications/details/45409
