### PR TITLE
[OP#45462]Fix revocation while the default settings changed

### DIFF
--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -200,13 +200,28 @@ class ConfigController extends Controller {
 				);
 			}
 		}
+		$runningFullReset = (
+
+			$oldClientSecret &&
+
+			$oldClientId &&
+
+			key_exists('openproject_client_id', $values) &&
+
+			key_exists('openproject_client_secret', $values) &&
+
+			$values['openproject_client_id'] === null &&
+
+			$values['openproject_client_secret'] === null
+
+		);
 		$this->config->deleteAppValue(Application::APP_ID, 'oPOAuthTokenRevokeStatus');
 		if (
 			// when the OP client information has changed
 			((key_exists('client_id', $values) && $values['client_id'] !== $oldClientId) ||
 			(key_exists('client_secret', $values) && $values['client_secret'] !== $oldClientSecret)) ||
 			// when the OP client information is for reset
-			($oldClientSecret && $oldClientId && $values['client_id'] === null && $values['client_secret'] === null)
+			$runningFullReset
 		) {
 			$this->userManager->callForAllUsers(function (IUser $user) use (
 				$oldOpenProjectOauthUrl, $oldClientId, $oldClientSecret

--- a/tests/lib/Controller/ConfigControllerTest.php
+++ b/tests/lib/Controller/ConfigControllerTest.php
@@ -822,6 +822,8 @@ class ConfigControllerTest extends TestCase {
 					'client_id' => null,
 					'client_secret' => null,
 					'oauth_instance_url' => null,
+					'default_enable_navigation' => false,
+					'default_enable_unified_search' => false,
 				],
 				false,
 				'reset'
@@ -831,6 +833,8 @@ class ConfigControllerTest extends TestCase {
 					'client_id' => 'client_id_changed',
 					'client_secret' => 'client_secret_changed',
 					'oauth_instance_url' => 'http://localhost:3000',
+					'default_enable_navigation' => true,
+					'default_enable_unified_search' => true,
 				],
 				true,
 				'change'
@@ -852,6 +856,8 @@ class ConfigControllerTest extends TestCase {
 			'client_id' => 'some_old_client_id',
 			'client_secret' => 'some_old_client_secret',
 			'oauth_instance_url' => 'http://localhost:3000',
+			'default_enable_navigation' => true,
+			'default_enable_unified_search' => true,
 		];
 		$userTokens = [
 			'admin' => 'admin_token',
@@ -894,7 +900,7 @@ class ConfigControllerTest extends TestCase {
 					'',
 					$newConfig['client_id'],
 					$newConfig['client_secret'],
-					$newConfig['oauth_instance_url'],
+					$newConfig['oauth_instance_url']
 				);
 		} else {
 			$configMock
@@ -928,6 +934,8 @@ class ConfigControllerTest extends TestCase {
 				['integration_openproject', 'client_id', $newConfig['client_id']],
 				['integration_openproject', 'client_secret', $newConfig['client_secret']],
 				['integration_openproject', 'oauth_instance_url', $newConfig['oauth_instance_url']],
+				['integration_openproject', 'default_enable_navigation', $newConfig['default_enable_navigation']],
+				['integration_openproject', 'default_enable_unified_search', $newConfig['default_enable_unified_search']],
 				['integration_openproject', 'oPOAuthTokenRevokeStatus', 'success']
 			);
 		$configMock


### PR DESCRIPTION
Revocation of the OAuth credentials on openProject side was triggered whenever the admin changed the default settings, This PR fixes that issue.
OP#45462 Related work package https://community.openproject.org/projects/nextcloud-integration/work_packages/45462/github?query_id=3513