### PR TITLE
[OP#45465] Feature/prepare direct upload api

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ To set up or update the integration following data needs to be provided:
 	The response from the above curl request
 	```json
 	{
-		"nextcloud_oauth_client_name": <openproject-client>,
+		"nextcloud_oauth_client_name": "<openproject-client>",
 		"openproject_redirect_uri": "http://<openproject_instance_url>/oauth_clients/<nextcloud_client_id>/callback",
-		"nextcloud_client_id": <nextcloud_client_id>,
-		"nextcloud_client_secret": <nextcloud_client_secret>,
+		"nextcloud_client_id": "<nextcloud_client_id>",
+		"nextcloud_client_secret": "<nextcloud_client_secret>",
 		"openproject_revocation_status": <openproject_revocation_status>
 	}
 	```
@@ -68,10 +68,10 @@ To set up or update the integration following data needs to be provided:
 	The response from the above curl request
 	```json
 	{
-		"nextcloud_oauth_client_name": <openproject-client>,
+		"nextcloud_oauth_client_name": "<openproject-client>",
 		"openproject_redirect_uri": "http://<openproject_instance_url>/oauth_clients/<nextcloud_client_id>/callback",
-		"nextcloud_client_id": <nextcloud_client_id>,
-		"nextcloud_client_secret": <nextcloud_client_secret>,
+		"nextcloud_client_id": "<nextcloud_client_id>",
+		"nextcloud_client_secret": "<nextcloud_client_secret>",
 		"openproject_revocation_status": <openproject_revocation_status>
 	}
 	```
@@ -343,6 +343,22 @@ Now you can watch for the app code changes using the following command and start
 cd $HOME/development/custom_apps/integration_openproject
 npm run watch
 ```
+
+## Direct upload
+There's an end-point `direct-upload` available which can be used for direct-upload. There's two steps to direct upload first we need to get the `token` which is then used for direct upload.
+
+1. **Preparation for direct upload**
+   Send the `GET` request to `direct-upload` end-point with the parameter `folder_id` of the destination folder.
+   ```console
+		curl -u USER:PASSWD http://<nextcloud_host>/index.php/apps/integration_openproject/direct-upload?folder_id=<folder_id>
+   ```
+   The response from the above curl request will be
+   ```json
+   {
+	   "token": "<token>",
+	   "expires_on": <some_timestamp>
+   }
+   ```
 
 ### Release:
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -19,7 +19,7 @@ On the OpenProject end, users are able to:
 
 For more information on how to set up and use the OpenProject application, please refer to [integration setup guide](https://www.openproject.org/docs/system-admin-guide/integrations/nextcloud/) for administrators and [the user guide](https://www.openproject.org/docs/user-guide/nextcloud-integration/).
 	]]></description>
-	<version>2.2.1</version>
+	<version>2.1.1</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>OpenProject</namespace>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -19,7 +19,7 @@ On the OpenProject end, users are able to:
 
 For more information on how to set up and use the OpenProject application, please refer to [integration setup guide](https://www.openproject.org/docs/system-admin-guide/integrations/nextcloud/) for administrators and [the user guide](https://www.openproject.org/docs/user-guide/nextcloud-integration/).
 	]]></description>
-	<version>2.1.1</version>
+	<version>2.2.1</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>OpenProject</namespace>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -19,7 +19,7 @@ On the OpenProject end, users are able to:
 
 For more information on how to set up and use the OpenProject application, please refer to [integration setup guide](https://www.openproject.org/docs/system-admin-guide/integrations/nextcloud/) for administrators and [the user guide](https://www.openproject.org/docs/user-guide/nextcloud-integration/).
 	]]></description>
-	<version>2.1.1</version>
+	<version>2.3.0</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>OpenProject</namespace>

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -19,6 +19,8 @@ return [
 
 		['name' => 'directDownload#directDownload', 'url' => '/direct/{token}/{fileName}', 'verb' => 'GET'],
 
+		['name' => 'directUpload#prepareDirectUpload', 'url' => '/prepare-direct-upload', 'verb' => 'POST'],
+
 		['name' => 'config#setUpIntegration', 'url' => '/setup', 'verb' => 'POST'],
 		['name' => 'config#resetIntegration', 'url' => '/setup', 'verb' => 'DELETE'],
 		['name' => 'config#updateIntegration', 'url' => '/setup', 'verb' => 'PATCH'],

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -19,7 +19,7 @@ return [
 
 		['name' => 'directDownload#directDownload', 'url' => '/direct/{token}/{fileName}', 'verb' => 'GET'],
 
-		['name' => 'directUpload#prepareDirectUpload', 'url' => '/prepare-direct-upload', 'verb' => 'POST'],
+		['name' => 'directUpload#prepareDirectUpload', 'url' => '/direct-upload', 'verb' => 'GET'],
 
 		['name' => 'config#setUpIntegration', 'url' => '/setup', 'verb' => 'POST'],
 		['name' => 'config#resetIntegration', 'url' => '/setup', 'verb' => 'DELETE'],

--- a/lib/Controller/DirectUploadController.php
+++ b/lib/Controller/DirectUploadController.php
@@ -24,7 +24,6 @@
 
 namespace OCA\OpenProject\Controller;
 
-
 use OC\User\NoUserException;
 use OCA\OpenProject\Service\DirectUploadService;
 use OCP\AppFramework\Controller;
@@ -34,14 +33,12 @@ use OCP\DB\Exception;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
-use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserSession;
-use Psr\Log\LoggerInterface;
 use OCP\Files\FileInfo;
 
-class DirectUploadController extends Controller{
+class DirectUploadController extends Controller {
 	/**
 	 * @var string|null
 	 */
@@ -87,21 +84,25 @@ class DirectUploadController extends Controller{
 		try {
 			$userFolder = $this->rootFolder->getUserFolder($this->user->getUID());
 			$nodes = $userFolder->getById($folder_id);
+			if (empty($nodes)) {
+				return new DataResponse([
+					'error' => 'folder not found or not enough permissions'
+				], Http::STATUS_NOT_FOUND);
+			}
 			$node = array_shift($nodes);
 			$fileType = $node->getType();
 			if (
 				$node->isCreatable() &&
 				$fileType === FileInfo::TYPE_FOLDER
 			) {
-				$response = $this->directUploadService->getTokenForDirectUpload($folder_id,$this->userId);
+				$response = $this->directUploadService->getTokenForDirectUpload($folder_id, $this->userId);
 				return new DataResponse($response);
-			}
-			else {
+			} else {
 				return new DataResponse([
 					'error' => 'folder not found or not enough permissions'
 				], Http::STATUS_NOT_FOUND);
 			}
-		} catch (Exception|NoUserException|NotPermittedException|NotFoundException $e){
+		} catch (Exception|NoUserException|NotPermittedException|NotFoundException $e) {
 			return new DataResponse([
 				'error' => 'folder not found or not enough permissions'
 			], Http::STATUS_NOT_FOUND);

--- a/lib/Controller/DirectUploadController.php
+++ b/lib/Controller/DirectUploadController.php
@@ -24,30 +24,138 @@
 
 namespace OCA\OpenProject\Controller;
 
+use OC\Files\Node\File;
+use OCA\OAuth2\Controller\SettingsController;
 use OCA\OpenProject\Service\DirectUploadService;
+use OCA\OpenProject\Service\OauthService;
+use OCA\OpenProject\Service\OpenProjectAPIService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\DB\Exception;
+use OCP\Files\IRootFolder;
+use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IRequest;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
+use OCP\Constants;
+use OCP\Files\FileInfo;
 
-class DirectUploadController {
+class DirectUploadController extends Controller{
+	/**
+	 * @var IConfig
+	 */
+	private $config;
+	/**
+	 * @var IURLGenerator
+	 */
+	private $urlGenerator;
+	/**
+	 * @var IUserManager
+	 */
+	private $userManager;
 	/**
 	 * @var IL10N
 	 */
 	private $l;
+
+	/**
+	 * @var LoggerInterface
+	 */
+	private $logger;
+
+	/**
+	 * @var string|null
+	 */
+	private $userId;
+	/**
+	 * @var OauthService
+	 */
+	private $oauthService;
+
 	/**
 	 * @var DirectUploadService
 	 */
 	private $directUploadService;
 
+	/**
+	 * @var IUser|null
+	 */
+	private $user;
+	/**
+	/**
+	 * @var IRootFolder
+	 */
+	private $rootFolder;
 	public function __construct(string $appName,
 								IRequest $request,
+								IConfig $config,
+								IRootFolder $rootFolder,
+								IUserSession $userSession,
+								IURLGenerator $urlGenerator,
+								IUserManager $userManager,
+								LoggerInterface $logger,
+								OauthService $oauthService,
 								IL10N $l,
-								DirectUploadService $directUploadService) {
+								DirectUploadService $directUploadService,
+								?string $userId) {
 		parent::__construct($appName, $request);
+		$this->config = $config;
+		$this->urlGenerator = $urlGenerator;
+		$this->userManager = $userManager;
 		$this->l = $l;
+		$this->logger = $logger;
+		$this->userId = $userId;
+		$this->oauthService = $oauthService;
 		$this->directUploadService = $directUploadService;
+		$this->user = $userSession->getUser();
+		$this->rootFolder = $rootFolder;
 	}
 
-	public function prepareDirectUpload(int $fileId): string {
-		return "Hello world";
+	/**
+	 * receive oauth code and get oauth access token
+	 *
+	 * @NoCSRFRequired
+	 *
+	 * @param int $folder_id
+	 * @return DataResponse
+	 * @throws Exception
+	 */
+	public function prepareDirectUpload(int $folder_id):DataResponse {
+		$userFolder = $this->rootFolder->getUserFolder($this->user->getUID());
+		$files = $userFolder->getById($folder_id);
+		if (
+			is_array($files) &&
+			count($files) > 0 &&
+			$userFolder->getType($files[0]) === FileInfo::TYPE_FOLDER
+		) {
+			$permissions = $userFolder->getPermissions($files[0]);
+			if($permissions !== Constants::PERMISSION_DELETE && $permissions !== Constants::PERMISSION_UPDATE){
+				try{
+					$response = $this->directUploadService->setInfoInDB($folder_id,$this->userId);
+					return new DataResponse($response);
+				} catch (\Exception $e) {
+					return new DataResponse([
+						'error' => $this->l->t($e->getMessage())
+					], Http::STATUS_BAD_REQUEST);
+				}
+			}
+			else {
+				return new DataResponse([
+					'error' => 'not enough permissions'
+				], Http::STATUS_FORBIDDEN);
+			}
+
+		}
+		else {
+			return new DataResponse([
+				'error' => 'Folder not found'
+			], Http::STATUS_BAD_REQUEST);
+		}
+
 	}
 }

--- a/lib/Controller/DirectUploadController.php
+++ b/lib/Controller/DirectUploadController.php
@@ -24,15 +24,12 @@
 
 namespace OCA\OpenProject\Controller;
 
-use OC\User\NoUserException;
 use OCA\OpenProject\Service\DirectUploadService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\DB\Exception;
 use OCP\Files\IRootFolder;
-use OCP\Files\NotFoundException;
-use OCP\Files\NotPermittedException;
 use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserSession;
@@ -42,28 +39,30 @@ class DirectUploadController extends Controller {
 	/**
 	 * @var string|null
 	 */
-	private $userId;
+	private ?string $userId;
 
 	/**
 	 * @var DirectUploadService
 	 */
-	private $directUploadService;
+	private DirectUploadService $directUploadService;
 
 	/**
 	 * @var IUser|null
 	 */
-	private $user;
+	private ?IUser $user;
 
 	/**
 	 * @var IRootFolder
 	 */
-	private $rootFolder;
-	public function __construct(string $appName,
-								IRequest $request,
-								IRootFolder $rootFolder,
-								IUserSession $userSession,
-								DirectUploadService $directUploadService,
-								?string $userId) {
+	private IRootFolder $rootFolder;
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		IRootFolder $rootFolder,
+		IUserSession $userSession,
+		DirectUploadService $directUploadService,
+		?string $userId
+	) {
 		parent::__construct($appName, $request);
 		$this->userId = $userId;
 		$this->directUploadService = $directUploadService;
@@ -105,7 +104,7 @@ class DirectUploadController extends Controller {
 					'error' => 'folder not found or not enough permissions'
 				], Http::STATUS_NOT_FOUND);
 			}
-		} catch (Exception|NoUserException|NotPermittedException|NotFoundException $e) {
+		} catch (Exception $e) {
 			return new DataResponse([
 				'error' => 'folder not found or not enough permissions'
 			], Http::STATUS_NOT_FOUND);

--- a/lib/Controller/DirectUploadController.php
+++ b/lib/Controller/DirectUploadController.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * @copyright Copyright (c) 2022 Swikriti Tripathi <swikriti@jankaritech.com>
+ *
+ * @author Your name <swikriti@jankaritech.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\OpenProject\Controller;
+
+use OCA\OpenProject\Service\DirectUploadService;
+use OCP\IL10N;
+use OCP\IRequest;
+
+class DirectUploadController {
+	/**
+	 * @var IL10N
+	 */
+	private $l;
+	/**
+	 * @var DirectUploadService
+	 */
+	private $directUploadService;
+
+	public function __construct(string $appName,
+								IRequest $request,
+								IL10N $l,
+								DirectUploadService $directUploadService) {
+		parent::__construct($appName, $request);
+		$this->l = $l;
+		$this->directUploadService = $directUploadService;
+	}
+
+	public function prepareDirectUpload(int $fileId): string {
+		return "Hello world";
+	}
+}

--- a/lib/Controller/DirectUploadController.php
+++ b/lib/Controller/DirectUploadController.php
@@ -77,6 +77,9 @@ class DirectUploadController extends Controller {
 	 * @NoCSRFRequired
 	 * @NoAdminRequired
 	 *
+	 * This can be tested with:
+	 * curl -u USER:PASSWD http://my.nc.org/index.php/apps/integration_openproject/direct-upload?folder_id=<folder_id>
+	 *
 	 * @param int $folder_id
 	 * @return DataResponse
 	 */

--- a/lib/Migration/Version2002Date20221219170111.php
+++ b/lib/Migration/Version2002Date20221219170111.php
@@ -28,9 +28,7 @@ namespace OCA\OpenProject\Migration;
 
 use Closure;
 use Doctrine\DBAL\Schema\SchemaException;
-use OCA\OpenProject\AppInfo\Application;
 use OCP\DB\ISchemaWrapper;
-use OCP\IConfig;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
@@ -40,7 +38,7 @@ class Version2002Date20221219170111 extends SimpleMigrationStep {
 	/**
 	 * @param IOutput $output
 	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
-	 * @param array $options
+	 * @param array<string, string|null> $options
 	 * @return null|ISchemaWrapper
 	 * @throws SchemaException
 	 */

--- a/lib/Migration/Version2002Date20221219170111.php
+++ b/lib/Migration/Version2002Date20221219170111.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2022 Swikriti Tripathi <swikriti@jankaritech.com>
+ *
+ * @author Your name <swikriti@jankaritech.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\OpenProject\Migration;
+
+use Closure;
+use Doctrine\DBAL\Schema\SchemaException;
+use OCA\OpenProject\AppInfo\Application;
+use OCP\DB\ISchemaWrapper;
+use OCP\IConfig;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+
+class Version2002Date20221219170111 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 * @throws SchemaException
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if (!$schema->hasTable('directUpload')) {
+			$table = $schema->createTable('directUpload');
+			$table->addColumn('id', 'integer', [
+				'autoincrement' => true,
+				'notnull' => true,
+			]);
+			$table->addColumn('token', 'string', [
+				'notnull' => true,
+				'length' => 200
+			]);
+			$table->addColumn('created_at', 'datetime', [
+				'notnull' => true,
+				'length' => 200
+			]);
+			$table->addColumn('expires_on', 'datetime', [
+				'notnull' => true,
+				'length' => 200
+			]);
+			$table->addColumn('folder_id', 'int', [
+				'notnull' => true,
+				'length' => 200
+			]);
+			$table->addColumn('user_id', 'string', [
+				'notnull' => true,
+				'length' => 200,
+			]);
+
+			$table->setPrimaryKey(['id']);
+			$table->addIndex(['token'], 'directUpload_token_index');
+		}
+		return $schema;
+	}
+}

--- a/lib/Migration/Version2002Date20221219170111.php
+++ b/lib/Migration/Version2002Date20221219170111.php
@@ -66,7 +66,7 @@ class Version2002Date20221219170111 extends SimpleMigrationStep {
 				'notnull' => true,
 				'length' => 200
 			]);
-			$table->addColumn('folder_id', 'int', [
+			$table->addColumn('folder_id', 'integer', [
 				'notnull' => true,
 				'length' => 200
 			]);

--- a/lib/Migration/Version2300Date20221219170111.php
+++ b/lib/Migration/Version2300Date20221219170111.php
@@ -53,23 +53,23 @@ class Version2300Date20221219170111 extends SimpleMigrationStep {
 			]);
 			$table->addColumn('token', 'string', [
 				'notnull' => true,
-				'length' => 200
+				'length' => 64
 			]);
-			$table->addColumn('created_at', 'datetime', [
+			$table->addColumn('created_at', 'bigint', [
 				'notnull' => true,
-				'length' => 200
+				'unsigned' => true
 			]);
-			$table->addColumn('expires_on', 'datetime', [
+			$table->addColumn('expires_on', 'bigint', [
 				'notnull' => true,
-				'length' => 200
+				'unsigned' => true
 			]);
-			$table->addColumn('folder_id', 'integer', [
+			$table->addColumn('folder_id', 'bigint', [
 				'notnull' => true,
-				'length' => 200
+				'length' => 20,
 			]);
 			$table->addColumn('user_id', 'string', [
 				'notnull' => true,
-				'length' => 200,
+				'length' => 64,
 			]);
 
 			$table->setPrimaryKey(['id']);

--- a/lib/Migration/Version2300Date20221219170111.php
+++ b/lib/Migration/Version2300Date20221219170111.php
@@ -32,8 +32,7 @@ use OCP\DB\ISchemaWrapper;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
-
-class Version2002Date20221219170111 extends SimpleMigrationStep {
+class Version2300Date20221219170111 extends SimpleMigrationStep {
 
 	/**
 	 * @param IOutput $output

--- a/lib/Service/DirectUploadService.php
+++ b/lib/Service/DirectUploadService.php
@@ -34,32 +34,33 @@ class DirectUploadService {
 	/**
 	 * @var IDBConnection
 	 */
-	private $db;
+	private IDBConnection $db;
 
 	/**
 	 * @var IL10N
 	 */
-	private $l;
+	private IL10N $l;
 
 	/**
 	 * @var ISecureRandom
 	 */
-	private $secureRandom;
+	private ISecureRandom $secureRandom;
 
 	/** @var string table name */
-	private $table = 'directUpload';
+	private string $table = 'directUpload';
 
 	/** @var string time of token expiration */
-	private $expiryTime = '+1 hour';
+	private string $expiryTime = '+1 hour';
 
-	public function __construct(IDBConnection $db,
-								IL10N $l,
-								ISecureRandom $secureRandom) {
+	public function __construct(
+		IDBConnection $db,
+		IL10N $l,
+		ISecureRandom $secureRandom
+	) {
 		$this->db = $db;
 		$this->l = $l;
 		$this->secureRandom = $secureRandom;
 	}
-
 
 	/**
 	 *

--- a/lib/Service/DirectUploadService.php
+++ b/lib/Service/DirectUploadService.php
@@ -74,7 +74,7 @@ class DirectUploadService {
 		$date = new DateTime();
 		$createdAt = ($date)->getTimestamp();
 		$expriesOn = ($date->modify($this->expiryTime))->getTimestamp();
-		try{
+		try {
 			$query->insert($this->table)
 				->values(
 					[
@@ -90,12 +90,10 @@ class DirectUploadService {
 				'token' => $token,
 				'expires_on' => $expriesOn,
 			];
-		} catch (Exception $e){
+		} catch (Exception $e) {
 			return [
 				'error' => $this->l->t($e->getMessage())
 			];
 		}
-
-
 	}
 }

--- a/lib/Service/DirectUploadService.php
+++ b/lib/Service/DirectUploadService.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @copyright Copyright (c) 2022 Swikriti Tripathi <swikriti@jankaritech.com>
+ *
+ * @author Your name <swikriti@jankaritech.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\OpenProject\Service;
+
+class DirectUploadService {
+
+}

--- a/tests/acceptance/features/api/directUploadPrepare.feature
+++ b/tests/acceptance/features/api/directUploadPrepare.feature
@@ -139,3 +139,8 @@ Feature: API endpoint to prepare direct upload
       }
     }
     """
+
+
+  Scenario: Try to get token as non-existent user
+    When user "test" sends a GET request to the direct-upload endpoint with the ID "123"
+    Then the HTTP status code should be "401"

--- a/tests/acceptance/features/api/directUploadPrepare.feature
+++ b/tests/acceptance/features/api/directUploadPrepare.feature
@@ -1,4 +1,3 @@
-@skip
 Feature: API endpoint to prepare direct upload
 
   As an OpenProject user


### PR DESCRIPTION
Related work-package: [OP#45465] https://community.openproject.org/projects/nextcloud-integration/work_packages/45465/activity?query_id=3504

## Description
This PR adds a new endpoint `/direct-upload` that tests the parameter `folder_id`, for the preparation of the direct upload.
The added endpoint will return the `token` that can be used for direct upload and `expires_on` which is the expiration time of the token.

The end-point can be tested with:

```console
 curl -u USER:PASSWD http://<nextcloud_host>/index.php/apps/integration_openproject/direct-upload?folder_id=<folder_id>
```