### PR TITLE
[OP#45551] use `shivammathur/setup-php@2.23.0` instead of `shivammathur/setup-php@v2`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup PHP ${{ matrix.phpVersion }}
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@2.23.0
         with:
           php-version: ${{ matrix.phpVersion }}
           tools: composer, phpunit


### PR DESCRIPTION
We were having a `Segmentation fault  (core dumped)` error in CI upon using the `2.23.0` tag of `setup-php` instead of `v2` the problem doesn't occur. `2.23.0` is the latest version now. 

Related work package : [OP#45551] https://community.openproject.org/projects/nextcloud-integration/work_packages/45551