### PR TITLE
mention all notification reasons

### DIFF
--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -255,6 +255,12 @@ export default {
 				case 'watched':
 					value = t('integration_openproject', 'watcher')
 					break
+				case 'commented':
+					value = t('integration_openproject', 'commented')
+					break
+				case 'mentioned':
+					value = t('integration_openproject', 'mentioned')
+					break
 				}
 				reasonsString = reasonsString + ', ' + value
 			})


### PR DESCRIPTION
All possible strings need to be mentioned so that transifex picks them up correctly and translates them.

This should finally fix https://community.openproject.org/projects/nextcloud-integration/work_packages/45399
