### PR TITLE
[OP#45464] Feature/direct upload api overwrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ There's an end-point `direct-upload` available which can be used for direct-uplo
       ```
    
    2. **Direct upload with overwrite parameter**:
-   The overwrite parameter can be either set to `true` or `false`.
+      The overwrite parameter can be either set to `true` or `false`.
       1. **overwrite set to false**: 
          If the parameter is set to `false` and a file with the name already exists, a new file will be uploaded with existing name having a number suffix.
 	      ```console
@@ -170,6 +170,7 @@ There's an end-point `direct-upload` available which can be used for direct-uplo
 	      ```
       2. **overwrite set to true**:
          If the parameter is set to `true` and a file with the name already exists, the existing file will be overwritten.
+
 		   ```console
 		   curl -X POST 'http://<nextcloud_host>/index.php/apps/integration_openproject/direct-upload/<token>' \
 		   --form 'file=@"<path-of-file>"' --form 'overwrite="true"' -H'Content-Type: multipart/form-data'

--- a/README.md
+++ b/README.md
@@ -169,12 +169,12 @@ There's an end-point `direct-upload` available which can be used for direct-uplo
 	          "file_id": <file_id>
 	      }  
 	      ```
-      2. **overwrite set to true**:
-         If the parameter is set to `true` and a file with the name already exists, the existing file will be overwritten.
 
-		   ```console
-		   curl -X POST 'http://<nextcloud_host>/index.php/apps/integration_openproject/direct-upload/<token>' \
-		   --form 'file=@"<path-of-file>"' --form 'overwrite="true"' -H'Content-Type: multipart/form-data'
+      2. **overwrite set to true**: 
+         If the parameter is set to `true` and a file with the name already exists, the existing file will be overwritten.
+	      ```console
+         curl -X POST 'http://<nextcloud_host>/index.php/apps/integration_openproject/direct-upload/<token>' \
+         --form 'file=@"<path-of-file>"' --form 'overwrite="true"' -H'Content-Type: multipart/form-data' 
 		   ```
 
 	      The response from the above curl request will be

--- a/README.md
+++ b/README.md
@@ -138,48 +138,48 @@ There's an end-point `direct-upload` available which can be used for direct-uplo
 2. **Direct upload**:
    Send multipart form data POST request to `direct-upload` end-point to upload the file with `token` acquired from preparation endpoint. The API takes and optional parameter `overwrite`.
    1. **Direct upload without overwrite parameter**:
-   If the `overwrite` parameter is not set at all only the file with non-existing name is uploaded and a conflict error is thrown in case the file already exists.
-         ```console
-          curl-X POST 'http://<nextcloud_host>/index.php/apps/integration_openproject/direct-upload/<token>' \
-          --form 'file=@"<path-of-file>"' -H'Content-Type: multipart/form-data'
-        ```
-      
-        The response from the above curl request will be
-        ```json
-        {
+      In case the `overwrite` parameter is not set at all a file will be only uploaded if no file exists with that name, otherwise a conflict error is thrown.
+      ```console
+      curl -X POST 'http://<nextcloud_host>/index.php/apps/integration_openproject/direct-upload/<token>' \
+      --form 'file=@"<path-of-file>"' -H'Content-Type: multipart/form-data'
+      ```
+
+      The response from the above curl request will be
+      ```json
+      {
           "file_name": "<file_name>",
           "file_id": <file_id>
-        }  
-       ```
+      }  
+      ```
    
    2. **Direct upload with overwrite parameter**:
    The overwrite parameter can be either set to `true` or `false`.
       1. **overwrite set to false**: 
-      If the parameter is set to `false` and a file with the name already exists, a new file will be uploaded with existing name having a number suffix.
-	     ```console
-          curl-X POST 'http://<nextcloud_host>/index.php/apps/integration_openproject/direct-upload/<token>' \
-          --form 'file=@"<path-of-file>"' --form 'overwrite="false"' -H'Content-Type: multipart/form-data' 
-		 ```
+         If the parameter is set to `false` and a file with the name already exists, a new file will be uploaded with existing name having a number suffix.
+	      ```console
+         curl -X POST 'http://<nextcloud_host>/index.php/apps/integration_openproject/direct-upload/<token>' \
+         --form 'file=@"<path-of-file>"' --form 'overwrite="false"' -H'Content-Type: multipart/form-data' 
+		   ```
 
 	      The response from the above curl request will be
 	      ```json
 	      {
-	      "file_name": "<file_name>(some-number)",
-	      "file_id": <file_id>
+	          "file_name": "<file_name>(some-number)",
+	          "file_id": <file_id>
 	      }  
 	      ```
       2. **overwrite set to true**:
-      If the parameter is set to `true` and a file with the name already exists, the existing file will be overwritten.
-		 ```console
-		 curl-X POST 'http://<nextcloud_host>/index.php/apps/integration_openproject/direct-upload/<token>' \
-		 --form 'file=@"<path-of-file>"' --form 'overwrite="true"' -H'Content-Type: multipart/form-data'
-		 ```
+         If the parameter is set to `true` and a file with the name already exists, the existing file will be overwritten.
+		   ```console
+		   curl -X POST 'http://<nextcloud_host>/index.php/apps/integration_openproject/direct-upload/<token>' \
+		   --form 'file=@"<path-of-file>"' --form 'overwrite="true"' -H'Content-Type: multipart/form-data'
+		   ```
 
 	      The response from the above curl request will be
 	      ```json
 	      {
-	      "file_name": "<file_name>",
-	      "file_id": <file_id>
+	          "file_name": "<file_name>",
+	          "file_id": <file_id>
 	      }  
 	      ```
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ bash integration_setup.sh
 ***Note: these credentials are only used by the script to do the setup. They are not stored/remembered.***
 
 ## Direct upload
-There's an end-point `direct-upload` available which can be used for direct-upload. There's two steps to direct upload first we need to get the `token` which is then used for direct upload.
+There's an end-point `direct-upload` available which can be used for direct-upload. There's two steps to direct upload. First we need to get the `token`. Then use the token in the direct upload request.
 
 1. **Preparation for direct upload**:
    Send the `POST` request to `direct-upload-token` end-point with data `folder_id` of the destination folder.
@@ -137,9 +137,9 @@ There's an end-point `direct-upload` available which can be used for direct-uplo
    > Note: The token is one-time only.
 
 2. **Direct upload**:
-   Send multipart form data POST request to `direct-upload` end-point to upload the file with `token` acquired from preparation endpoint. The API takes and optional parameter `overwrite`.
+   Send a multipart form data POST request to the `direct-upload` end-point to upload the file with `token` acquired from the preparation endpoint. The API takes an optional parameter `overwrite`.
    1. **Direct upload without overwrite parameter**:
-      In case the `overwrite` parameter is not set at all a file will be only uploaded if no file exists with that name, otherwise a conflict error is thrown.
+      If the `overwrite` parameter is not set, a file will only be uploaded if no file exists with that name, otherwise a conflict error is thrown.
       ```console
       curl -X POST 'http://<nextcloud_host>/index.php/apps/integration_openproject/direct-upload/<token>' \
       --form 'file=@"<path-of-file>"' -H'Content-Type: multipart/form-data'
@@ -156,7 +156,7 @@ There's an end-point `direct-upload` available which can be used for direct-uplo
    2. **Direct upload with overwrite parameter**:
       The overwrite parameter can be either set to `true` or `false`.
       1. **overwrite set to false**: 
-         If the parameter is set to `false` and a file with the name already exists, a new file will be uploaded with existing name having a number suffix.
+         If the parameter is set to `false` and a file with the name already exists, a new file will be uploaded with the existing name and a number suffix.
           ```console
          curl -X POST 'http://<nextcloud_host>/index.php/apps/integration_openproject/direct-upload/<token>' \
          --form 'file=@"<path-of-file>"' --form 'overwrite="false"' -H'Content-Type: multipart/form-data' 
@@ -165,7 +165,7 @@ There's an end-point `direct-upload` available which can be used for direct-uplo
           The response from the above curl request will be
           ```json
           {
-              "file_name": "<file_name>(some-number)",
+              "file_name": "<file_name>(some-number).ext",
               "file_id": <file_id>
           }
           ```
@@ -184,6 +184,14 @@ There's an end-point `direct-upload` available which can be used for direct-uplo
               "file_id": <file_id>
           }
           ```
+          Suppose we have a file with name `file.txt` in the server, and we send a request to direct-upload api with file `file.txt` and overwrite set to `true` then the response will be:
+		  ```json
+		  {
+			  "file_name": "file (2).txt",
+			  "file_id": 123
+		  }
+		  ```
+		 > Note: The file id in this case is the id of the original file. Only the content is overwritten.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -157,33 +157,33 @@ There's an end-point `direct-upload` available which can be used for direct-uplo
       The overwrite parameter can be either set to `true` or `false`.
       1. **overwrite set to false**: 
          If the parameter is set to `false` and a file with the name already exists, a new file will be uploaded with existing name having a number suffix.
-	      ```console
+          ```console
          curl -X POST 'http://<nextcloud_host>/index.php/apps/integration_openproject/direct-upload/<token>' \
          --form 'file=@"<path-of-file>"' --form 'overwrite="false"' -H'Content-Type: multipart/form-data' 
-		   ```
+           ```
 
-	      The response from the above curl request will be
-	      ```json
-	      {
-	          "file_name": "<file_name>(some-number)",
-	          "file_id": <file_id>
-	      }  
-	      ```
+          The response from the above curl request will be
+          ```json
+          {
+              "file_name": "<file_name>(some-number)",
+              "file_id": <file_id>
+          }
+          ```
 
       2. **overwrite set to true**: 
          If the parameter is set to `true` and a file with the name already exists, the existing file will be overwritten.
-	      ```console
+          ```console
          curl -X POST 'http://<nextcloud_host>/index.php/apps/integration_openproject/direct-upload/<token>' \
          --form 'file=@"<path-of-file>"' --form 'overwrite="true"' -H'Content-Type: multipart/form-data' 
-		   ```
+           ```
 
-	      The response from the above curl request will be
-	      ```json
-	      {
-	          "file_name": "<file_name>",
-	          "file_id": <file_id>
-	      }  
-	      ```
+          The response from the above curl request will be
+          ```json
+          {
+              "file_name": "<file_name>",
+              "file_id": <file_id>
+          }
+          ```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ bash integration_setup.sh
 ## Direct upload
 There's an end-point `direct-upload` available which can be used for direct-upload. There's two steps to direct upload first we need to get the `token` which is then used for direct upload.
 
-1. **Preparation for direct upload**
+1. **Preparation for direct upload**:
    Send the `POST` request to `direct-upload-token` end-point with data `folder_id` of the destination folder.
    ```console
    curl -u USER:PASSWD http://<nextcloud_host>/index.php/apps/integration_openproject/direct-upload-token -d '{"folder_id":<folder_id>}' -H'Content-Type: application/json'
@@ -135,19 +135,53 @@ There's an end-point `direct-upload` available which can be used for direct-uplo
    }
    ```
 
-2. **Direct upload**
-   Send multipart form data POST request to `direct-upload` end-point to upload the file with `token` acquired from preparation endpoint
-   ```console
-   curl -XPOST 'http://<nextcloud_host>/index.php/apps/integration_openproject/direct-upload/<token>' \
-   --form 'file=@"<path-of-file>"' -H'Content-Type: multipart/form-data'
-   ```
-   The response from the above curl request will be
-   ```json
-   {
-       "file_name": "<file_name>",
-       "file_id": <file_id>
-   }  
-   ```
+2. **Direct upload**:
+   Send multipart form data POST request to `direct-upload` end-point to upload the file with `token` acquired from preparation endpoint. The API takes and optional parameter `overwrite`.
+   1. **Direct upload without overwrite parameter**:
+   If the `overwrite` parameter is not set at all only the file with non-existing name is uploaded and a conflict error is thrown in case the file already exists.
+         ```console
+          curl-X POST 'http://<nextcloud_host>/index.php/apps/integration_openproject/direct-upload/<token>' \
+          --form 'file=@"<path-of-file>"' -H'Content-Type: multipart/form-data'
+        ```
+      
+        The response from the above curl request will be
+        ```json
+        {
+          "file_name": "<file_name>",
+          "file_id": <file_id>
+        }  
+       ```
+   
+   2. **Direct upload with overwrite parameter**:
+   The overwrite parameter can be either set to `true` or `false`.
+      1. **overwrite set to false**: 
+      If the parameter is set to `false` and a file with the name already exists, a new file will be uploaded with existing name having a number suffix.
+	     ```console
+          curl-X POST 'http://<nextcloud_host>/index.php/apps/integration_openproject/direct-upload/<token>' \
+          --form 'file=@"<path-of-file>"' --form 'overwrite="false"' -H'Content-Type: multipart/form-data' 
+		 ```
+
+	      The response from the above curl request will be
+	      ```json
+	      {
+	      "file_name": "<file_name>(some-number)",
+	      "file_id": <file_id>
+	      }  
+	      ```
+      2. **overwrite set to true**:
+      If the parameter is set to `true` and a file with the name already exists, the existing file will be overwritten.
+		 ```console
+		 curl-X POST 'http://<nextcloud_host>/index.php/apps/integration_openproject/direct-upload/<token>' \
+		 --form 'file=@"<path-of-file>"' --form 'overwrite="true"' -H'Content-Type: multipart/form-data'
+		 ```
+
+	      The response from the above curl request will be
+	      ```json
+	      {
+	      "file_name": "<file_name>",
+	      "file_id": <file_id>
+	      }  
+	      ```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ There's an end-point `direct-upload` available which can be used for direct-uplo
        "expires_on": <some_timestamp>
    }
    ```
+   > Note: The token is one-time only.
 
 2. **Direct upload**:
    Send multipart form data POST request to `direct-upload` end-point to upload the file with `token` acquired from preparation endpoint. The API takes and optional parameter `overwrite`.

--- a/lib/Controller/DirectUploadController.php
+++ b/lib/Controller/DirectUploadController.php
@@ -191,7 +191,6 @@ class DirectUploadController extends ApiController {
 					// overwrite the file
 					$file->putContent(fopen($tmpPath, 'r'));
 					$fileId = $file->getId();
-					$this->databaseService->deleteToken($token);
 					return new DataResponse([
 						'file_name' => $fileName,
 						'file_id' => $fileId
@@ -205,10 +204,8 @@ class DirectUploadController extends ApiController {
 				elseif ($folderNode->nodeExists($fileName)) {
 					throw new Conflict('conflict, file name already exists');
 				}
-
 				$fileInfo = $folderNode->newFile($fileName, fopen($tmpPath, 'r')); // @phpstan-ignore-line
 				$fileId = $fileInfo->getId();
-				$this->databaseService->deleteToken($token);
 			}
 		} catch (NotPermittedException $e) {
 			return new DataResponse([

--- a/lib/Controller/DirectUploadController.php
+++ b/lib/Controller/DirectUploadController.php
@@ -148,7 +148,7 @@ class DirectUploadController extends ApiController {
 			$fileId = null;
 			$directUploadFile = $this->request->getUploadedFile('file');
 			$overwrite = $this->request->getParam('overwrite');
-			if(isset($overwrite)){
+			if (isset($overwrite)) {
 				$overwrite = $overwrite === 'true';
 			} else {
 				$overwrite = null;
@@ -170,8 +170,14 @@ class DirectUploadController extends ApiController {
 			if (
 				$folderNode->isCreatable()
 			) {
-				if($folderNode->nodeExists($fileName) && $overwrite){
-					$file = $folderNode->get($fileName);
+				// @phpstan-ignore-next-line
+				if ($folderNode->nodeExists($fileName) && $overwrite) {
+					$file = $folderNode->get($fileName); // @phpstan-ignore-line
+					if (!$file->isUpdateable()) {
+						return new DataResponse([
+							'error' => "not enough permissions"
+						], Http::STATUS_FORBIDDEN);
+					}
 					// overwrite the file
 					$file->putContent(fopen($tmpPath, 'r'));
 					$fileId = $file->getId();
@@ -180,13 +186,13 @@ class DirectUploadController extends ApiController {
 						'file_name' => $fileName,
 						'file_id' => $fileId
 					], Http::STATUS_OK);
-
-				} else if($folderNode->nodeExists($fileName) && $overwrite === false){
+				} // @phpstan-ignore-next-line
+				elseif ($folderNode->nodeExists($fileName) && $overwrite === false) {
 					// get unique name for duplicate file with number suffix
-					$fileName = $folderNode->getNonExistingName($fileName);
+					$fileName = $folderNode->getNonExistingName($fileName); // @phpstan-ignore-line
 				}
 				// @phpstan-ignore-next-line
-				else if($folderNode->nodeExists($fileName)){
+				elseif ($folderNode->nodeExists($fileName)) {
 					return new DataResponse([
 						'error' => 'conflict, file name already exists',
 					], Http::STATUS_CONFLICT);

--- a/lib/Controller/DirectUploadController.php
+++ b/lib/Controller/DirectUploadController.php
@@ -179,9 +179,9 @@ class DirectUploadController extends ApiController {
 					return new DataResponse([
 						'file_name' => $fileName,
 						'file_id' => $fileId
-					], Http::STATUS_CREATED);
+					], Http::STATUS_OK);
 
-				} else if($folderNode->nodeExists($fileName) && !$overwrite){
+				} else if($folderNode->nodeExists($fileName) && $overwrite === false){
 					// get unique name for duplicate file with number suffix
 					$fileName = $folderNode->getNonExistingName($fileName);
 				}

--- a/lib/Controller/DirectUploadController.php
+++ b/lib/Controller/DirectUploadController.php
@@ -28,7 +28,6 @@ use OC\User\NoUserException;
 use InvalidArgumentException;
 use OC\ForbiddenException;
 use \OCP\AppFramework\ApiController;
-use OCA\OpenProject\Service\DatabaseService;
 use OCP\Files\InvalidCharacterInPathException;
 use OCP\Files\InvalidPathException;
 use OCP\Files\NotFoundException;
@@ -57,11 +56,6 @@ class DirectUploadController extends ApiController {
 	private DirectUploadService $directUploadService;
 
 	/**
-	 * @var DatabaseService
-	 */
-	private DatabaseService $databaseService;
-
-	/**
 	 * @var IUser|null
 	 */
 	private ?IUser $user;
@@ -84,7 +78,6 @@ class DirectUploadController extends ApiController {
 		IUserSession $userSession,
 		IUserManager $userManager,
 		DirectUploadService $directUploadService,
-		DatabaseService $databaseService,
 		?string $userId
 	) {
 		parent::__construct($appName, $request, 'POST');
@@ -93,7 +86,6 @@ class DirectUploadController extends ApiController {
 		$this->user = $userSession->getUser();
 		$this->rootFolder = $rootFolder;
 		$this->userManager = $userManager;
-		$this->databaseService = $databaseService;
 	}
 
 	/**

--- a/lib/Controller/DirectUploadController.php
+++ b/lib/Controller/DirectUploadController.php
@@ -153,7 +153,7 @@ class DirectUploadController extends ApiController {
 			$overwrite = $this->request->getParam('overwrite');
 			if (isset($overwrite)) {
 				if (in_array($overwrite, $acceptedOverwriteValues)) {
-					$overwrite = $overwrite === 'true';
+					$overwrite = $overwrite === 'true' || $overwrite === 'True' ;
 				} else {
 					throw new InvalidArgumentException('invalid overwrite value');
 				}

--- a/lib/Service/DatabaseService.php
+++ b/lib/Service/DatabaseService.php
@@ -94,6 +94,7 @@ class DatabaseService {
 		}
 		$req->closeCursor();
 		$query->resetQueryParts();
+		$this->deleteToken($token);
 		return [
 			'user_id' => $userId,
 			'expires_on' => $expiresOn,

--- a/tests/acceptance/features/api/directUpload.feature
+++ b/tests/acceptance/features/api/directUpload.feature
@@ -356,8 +356,8 @@ Feature: API endpoint for direct upload
       }
     }
     """
-    And the content of file at "/file.txt" for user "Alice" should be "original data"
-    And the content of file at "/file (2)(2).txt" for user "Alice" should be "new data"
+    And the content of file at "/file (2).txt" for user "Alice" should be "original data"
+    And the content of file at "/file (3).txt" for user "Alice" should be "new data"
 
 
   Scenario: set overwrite to true and send file with an existing filename
@@ -384,7 +384,7 @@ Feature: API endpoint for direct upload
     """
     And the content of file at "/file.txt" for user "Alice" should be "new data"
 
-  
+
   Scenario: set overwrite to true and send file with an existing filename, but no permissions to overwrite
     Given user "Brian" has been created
     And user "Brian" has uploaded file with content "original data" to "/file.txt"

--- a/tests/acceptance/features/api/directUpload.feature
+++ b/tests/acceptance/features/api/directUpload.feature
@@ -488,7 +488,7 @@ Feature: API endpoint for direct upload
       | false     |
 
 
-  Scenario: set overwrite to true and send a file with existing folder name
+  Scenario: set overwrite to true and send a file with an existing folder name
     Given user "Alice" has created folder "file.txt"
     And user "Alice" got a direct-upload token for "/"
     When an anonymous user sends a multipart form data POST request to the "direct-upload/%last-created-direct-upload-token%" endpoint with:
@@ -516,7 +516,7 @@ Feature: API endpoint for direct upload
     """
 
 
-  Scenario: set overwrite to false and send a file with existing folder name
+  Scenario: set overwrite to false and send a file with an existing folder name
     Given user "Alice" has created folder "file.txt"
     And user "Alice" got a direct-upload token for "/"
     When an anonymous user sends a multipart form data POST request to the "direct-upload/%last-created-direct-upload-token%" endpoint with:
@@ -541,7 +541,7 @@ Feature: API endpoint for direct upload
     And the content of file at "/file (2).txt" for user "Alice" should be "new data"
 
 
-  Scenario: don't set override and send a file with existing folder name
+  Scenario: don't set overwrite and send a file with an existing folder name
     Given user "Alice" has created folder "file.txt"
     And user "Alice" got a direct-upload token for "/"
     When an anonymous user sends a multipart form data POST request to the "direct-upload/%last-created-direct-upload-token%" endpoint with:

--- a/tests/acceptance/features/api/directUpload.feature
+++ b/tests/acceptance/features/api/directUpload.feature
@@ -421,18 +421,18 @@ Feature: API endpoint for direct upload
     And the data of the response should match
     """"
     {
-    "type":"object",
-    "not":{
-       "required": [
+    "type": "object",
+    "not": {
+      "required": [
           "file_name",
           "file_id"
         ]
-     },
-     "required": [
-      "error"
-    ],
-    "properties": {
-        "error": {"type": "string", "pattern": "^invalid overwrite value$"}
+      },
+    "required": [
+        "error"
+      ],
+      "properties": {
+          "error": {"type": "string", "pattern": "^invalid overwrite value$"}
       }
     }
     """
@@ -444,6 +444,7 @@ Feature: API endpoint for direct upload
       | null      |
       |           |
       | rubbish   |
+
 
   Scenario: CORS preflight request
     Given user "Alice" got a direct-upload token for "/"

--- a/tests/acceptance/features/api/directUpload.feature
+++ b/tests/acceptance/features/api/directUpload.feature
@@ -410,7 +410,6 @@ Feature: API endpoint for direct upload
     And the content of file at "/file.txt" for user "Alice" should be "original data"
 
 
-  @skip
   Scenario Outline: set overwrite to an invalid value
     Given user "Alice" has uploaded file with content "original data" to "/file.txt"
     And user "Alice" got a direct-upload token for "/"
@@ -422,18 +421,18 @@ Feature: API endpoint for direct upload
     And the data of the response should match
     """"
     {
-    "type": "object",
-    "not": {
-      "required": [
+    "type":"object",
+    "not":{
+       "required": [
           "file_name",
           "file_id"
-        ],
-      }
-    "required": [
-        "error"
-      ],
-      "properties": {
-          "error": {"type": "string", "pattern": "^invalid overwrite value$"}
+        ]
+     },
+     "required": [
+      "error"
+    ],
+    "properties": {
+        "error": {"type": "string", "pattern": "^invalid overwrite value$"}
       }
     }
     """

--- a/tests/acceptance/features/api/directUpload.feature
+++ b/tests/acceptance/features/api/directUpload.feature
@@ -277,7 +277,7 @@ Feature: API endpoint for direct upload
     }
     """
 
-  @skip
+
   Scenario: set overwrite to false and send file with an existing filename
     Given user "Alice" has uploaded file with content "original data" to "/file.txt"
     And user "Alice" got a direct-upload token for "/"
@@ -285,7 +285,7 @@ Feature: API endpoint for direct upload
       | file_name | file.txt |
       | data      | new data |
       | overwrite | false    |
-    Then the HTTP status code should be "200"
+    Then the HTTP status code should be "201"
     And the data of the response should match
     """"
     {
@@ -303,7 +303,7 @@ Feature: API endpoint for direct upload
     And the content of file at "/file.txt" for user "Alice" should be "original data"
     And the content of file at "/file (2).txt" for user "Alice" should be "new data"
 
-  @skip
+
   Scenario: set overwrite to false and send file with an existing filename, also files with that name and suffixed numbers also exist
     Given user "Alice" has uploaded file with content "data 1" to "/file.txt"
     And user "Alice" has uploaded file with content "data 2" to "/file (2).txt"
@@ -313,7 +313,7 @@ Feature: API endpoint for direct upload
       | file_name | file.txt |
       | data      | new data |
       | overwrite | false    |
-    Then the HTTP status code should be "200"
+    Then the HTTP status code should be "201"
     And the data of the response should match
     """"
     {
@@ -333,7 +333,7 @@ Feature: API endpoint for direct upload
     And the content of file at "/file (3).txt" for user "Alice" should be "data 3"
     And the content of file at "/file (4).txt" for user "Alice" should be "new data"
 
-  @skip
+
   Scenario: set overwrite to false and send file with an existing filename (filename has already a number in brackets)
     Given user "Alice" has uploaded file with content "original data" to "/file (2).txt"
     And user "Alice" got a direct-upload token for "/"
@@ -341,7 +341,7 @@ Feature: API endpoint for direct upload
       | file_name | file (2).txt |
       | data      | new data     |
       | overwrite | false        |
-    Then the HTTP status code should be "200"
+    Then the HTTP status code should be "201"
     And the data of the response should match
     """"
     {
@@ -351,7 +351,7 @@ Feature: API endpoint for direct upload
         "file_id"
       ],
       "properties": {
-          "file_name": {"type": "string", "pattern": "^file \\(2\\)\\(2\\)\\.txt$"},
+          "file_name": {"type": "string", "pattern": "^file \\(3\\)\\.txt$"},
           "file_id": {"type" : "integer"}
       }
     }
@@ -359,7 +359,7 @@ Feature: API endpoint for direct upload
     And the content of file at "/file.txt" for user "Alice" should be "original data"
     And the content of file at "/file (2)(2).txt" for user "Alice" should be "new data"
 
-  @skip
+
   Scenario: set overwrite to true and send file with an existing filename
     Given user "Alice" has uploaded file with content "original data" to "/file.txt"
     And user "Alice" got a direct-upload token for "/"
@@ -384,7 +384,7 @@ Feature: API endpoint for direct upload
     """
     And the content of file at "/file.txt" for user "Alice" should be "new data"
 
-  @skip
+  
   Scenario: set overwrite to true and send file with an existing filename, but no permissions to overwrite
     Given user "Brian" has been created
     And user "Brian" has uploaded file with content "original data" to "/file.txt"

--- a/tests/lib/Controller/DirectUploadControllerTest.php
+++ b/tests/lib/Controller/DirectUploadControllerTest.php
@@ -26,7 +26,6 @@ namespace OCA\OpenProject\Controller;
 use OCP\IRequest;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use OCA\OpenProject\Service\DatabaseService;
 use function PHPUnit\Framework\assertSame;
 
 class DirectUploadControllerTest extends TestCase {
@@ -149,7 +148,6 @@ class DirectUploadControllerTest extends TestCase {
 			$userSessionMock,
 			$userManagerMock,
 			$directUploadServiceMock,
-			$this->createMock(DatabaseService::class),
 			'testUser',
 		);
 	}


### PR DESCRIPTION
related work package [OP#45464] : https://community.openproject.org/projects/nextcloud-integration/work_packages/45464

## Description
**Direct upload with overwrite parameter**:
   The overwrite parameter can be either set to `true` or `false`.
      1. **overwrite set to false**: 
      If the parameter is set to `false` and a file with the name already exists, a new file will be uploaded with existing name having a number suffix.
```console
curl-X POST 'http://<nextcloud_host>/index.php/apps/integration_openproject/direct-upload/<token>' \
--form 'file=@"<path-of-file>"' --form 'overwrite="false"' -H'Content-Type: multipart/form-data' 
```
The response from the above curl request will be
```json
 {
  "file_name": "<file_name>(some-number)",
   "file_id": <file_id>
 }  
```
     
 2. **overwrite set to true**:
      If the parameter is set to `true` and a file with the name already exists, the existing file will be overwritten.
 ```console
 curl-X POST 'http://<nextcloud_host>/index.php/apps/integration_openproject/direct-upload/<token>' \
 --form 'file=@"<path-of-file>"' --form 'overwrite="true"' -H'Content-Type: multipart/form-data'
 ```

The response from the above curl request will be
```json
{
   "file_name": "<file_name>",
  "file_id": <file_id>
} 
```