### PR TITLE
[OP##45596] set defaults for oauth connection message&result

### DIFF
--- a/lib/Dashboard/OpenProjectWidget.php
+++ b/lib/Dashboard/OpenProjectWidget.php
@@ -126,7 +126,7 @@ class OpenProjectWidget implements IWidget {
 		$this->initialStateService->provideInitialState('admin-config-status', OpenProjectAPIService::isAdminConfigOk($this->config));
 
 		$oauthConnectionResult = $this->config->getUserValue(
-			$this->user->getUID(), Application::APP_ID, 'oauth_connection_result'
+			$this->user->getUID(), Application::APP_ID, 'oauth_connection_result', ''
 		);
 		$this->config->deleteUserValue(
 			$this->user->getUID(), Application::APP_ID, 'oauth_connection_result'
@@ -135,7 +135,7 @@ class OpenProjectWidget implements IWidget {
 			'oauth-connection-result', $oauthConnectionResult
 		);
 		$oauthConnectionErrorMessage = $this->config->getUserValue(
-			$this->user->getUID(), Application::APP_ID, 'oauth_connection_error_message'
+			$this->user->getUID(), Application::APP_ID, 'oauth_connection_error_message', ''
 		);
 		$this->config->deleteUserValue(
 			$this->user->getUID(), Application::APP_ID, 'oauth_connection_error_message'

--- a/lib/Listener/LoadSidebarScript.php
+++ b/lib/Listener/LoadSidebarScript.php
@@ -51,11 +51,11 @@ class LoadSidebarScript implements IEventListener {
 	/**
 	 * @var string "error"|"success"|""
 	 */
-	private $oauthConnectionResult;
+	private $oauthConnectionResult = '';
 	/**
 	 * @var string
 	 */
-	private $oauthConnectionErrorMessage;
+	private $oauthConnectionErrorMessage = '';
 
 	public function __construct(
 		IInitialState $initialStateService,
@@ -67,13 +67,13 @@ class LoadSidebarScript implements IEventListener {
 		$user = $userSession->getUser();
 		if (strpos(\OC::$server->get(IRequest::class)->getRequestUri(), 'files') !== false) {
 			$this->oauthConnectionResult = $this->config->getUserValue(
-				$user->getUID(), Application::APP_ID, 'oauth_connection_result'
+				$user->getUID(), Application::APP_ID, 'oauth_connection_result', ''
 			);
 			$this->config->deleteUserValue(
 				$user->getUID(), Application::APP_ID, 'oauth_connection_result'
 			);
 			$this->oauthConnectionErrorMessage = $this->config->getUserValue(
-				$user->getUID(), Application::APP_ID, 'oauth_connection_error_message'
+				$user->getUID(), Application::APP_ID, 'oauth_connection_error_message', ''
 			);
 			$this->config->deleteUserValue(
 				$user->getUID(), Application::APP_ID, 'oauth_connection_error_message'

--- a/lib/Settings/Personal.php
+++ b/lib/Settings/Personal.php
@@ -77,7 +77,7 @@ class Personal implements ISettings {
 			'oauth-connection-result', $oauthConnectionResult
 		);
 		$oauthConnectionErrorMessage = $this->config->getUserValue(
-			$this->userId, Application::APP_ID, 'oauth_connection_error_message'
+			$this->userId, Application::APP_ID, 'oauth_connection_error_message', ''
 		);
 		$this->config->deleteUserValue(
 			$this->userId, Application::APP_ID, 'oauth_connection_error_message'


### PR DESCRIPTION
Set the defaults to an empty string to avoid ugly log outputs.
Fixes https://community.openproject.org/work_packages/45596
