### PR TITLE
[OP#45596] fix fetching avatars from openproject

### DIFF
--- a/lib/Controller/OpenProjectAPIController.php
+++ b/lib/Controller/OpenProjectAPIController.php
@@ -109,7 +109,7 @@ class OpenProjectAPIController extends Controller {
 	 */
 	public function getOpenProjectAvatar(string $userId = '', string $userName = '') {
 		$result = $this->openprojectAPIService->getOpenProjectAvatar(
-			$userId, $userName
+			$userId, $userName, $this->userId
 		);
 		$response = new DataDownloadResponse(
 			$result['avatar'], 'avatar', $result['type'] ?? ''

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -224,28 +224,35 @@ class OpenProjectAPIService {
 	/**
 	 * authenticated request to get an image from openproject
 	 *
-	 * @param string $userId
-	 * @param string $userName
+	 * @param string $openprojectUserId
+	 * @param string $openprojectUserName
+	 * @param string $nextcloudUserId
 	 * @return array{avatar: string, type?: string}
 	 * @throws \OCP\Files\NotFoundException
 	 * @throws \OCP\Files\NotPermittedException
 	 * @throws \OCP\Lock\LockedException
 	 */
-	public function getOpenProjectAvatar(string $userId, string $userName): array {
-		$accessToken = $this->config->getUserValue($userId, Application::APP_ID, 'token');
+	public function getOpenProjectAvatar(
+		string $openprojectUserId,
+		string $openprojectUserName,
+		string $nextcloudUserId
+	): array {
+		$accessToken = $this->config->getUserValue($nextcloudUserId, Application::APP_ID, 'token');
 		$this->config->getAppValue(Application::APP_ID, 'openproject_client_id');
 		$this->config->getAppValue(Application::APP_ID, 'openproject_client_secret');
 		$openprojectUrl = $this->config->getAppValue(Application::APP_ID, 'openproject_instance_url');
 		try {
-			$response = $this->rawRequest($accessToken, $openprojectUrl, 'users/'.$userId.'/avatar');
+			$response = $this->rawRequest(
+				$accessToken, $openprojectUrl, 'users/'.$openprojectUserId.'/avatar'
+			);
 			$headers = $response->getHeaders();
 			return [
 				'avatar' => $response->getBody(),
 				'type' => implode(',', $headers['Content-Type']),
 			];
 		} catch (ServerException | ClientException | ConnectException | Exception $e) {
-			$this->logger->debug('Error while getting OpenProject avatar for user ' . $userId . ': ' . $e->getMessage(), ['app' => $this->appName]);
-			$avatar = $this->avatarManager->getGuestAvatar($userName);
+			$this->logger->debug('Error while getting OpenProject avatar for user ' . $openprojectUserId . ': ' . $e->getMessage(), ['app' => $this->appName]);
+			$avatar = $this->avatarManager->getGuestAvatar($openprojectUserName);
 			$avatarContent = $avatar->getFile(64)->getContent();
 			return ['avatar' => $avatarContent];
 		}

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -688,7 +688,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$consumerRequest = new ConsumerRequest();
 		$consumerRequest
 			->setMethod('GET')
-			->setPath('/api/v3/users/userWithAvatar/avatar')
+			->setPath('/api/v3/users/openProjectUserWithAvatar/avatar')
 			->setHeaders(["Authorization" => "Bearer 1234567890"]);
 
 		$providerResponse = new ProviderResponse();
@@ -703,10 +703,11 @@ class OpenProjectAPIServiceTest extends TestCase {
 			->uponReceiving('a request to get the avatar of a user that has an avatar')
 			->with($consumerRequest)
 			->willRespondWith($providerResponse);
-		$service = $this->getOpenProjectAPIService(null, '1234567890', 'https://nc.my-server.org', 'userWithAvatar');
+		$service = $this->getOpenProjectAPIService(null, '1234567890', 'https://nc.my-server.org', 'NCuser');
 		$result = $service->getOpenProjectAvatar(
-			'userWithAvatar',
-			'Me'
+			'openProjectUserWithAvatar',
+			'Me',
+			'NCuser'
 		);
 		$this->assertArrayHasKey('avatar', $result);
 		$this->assertArrayHasKey('type', $result);
@@ -721,7 +722,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$consumerRequest = new ConsumerRequest();
 		$consumerRequest
 			->setMethod('GET')
-			->setPath('/api/v3/users/testUser/avatar')
+			->setPath('/api/v3/users/openProjectUser/avatar')
 			->setHeaders(["Authorization" => "Bearer 1234567890"]);
 
 		$providerResponse = new ProviderResponse();
@@ -734,8 +735,9 @@ class OpenProjectAPIServiceTest extends TestCase {
 			->willRespondWith($providerResponse);
 
 		$result = $this->service->getOpenProjectAvatar(
-			'testUser',
-			'Me'
+			'openProjectUser',
+			'Me',
+			'testUser'
 		);
 		$this->assertArrayHasKey('avatar', $result);
 		//make sure its an image, if something else is returned it will throw an exception


### PR DESCRIPTION
This PR fixes the fetching of avatars from openproject.
The problem was that we had the wrong userId in `getOpenProjectAvatar`, the id given was the openproject id, but we tried to use it to read the token from the NC database.
Now we passing also in the NC userId to read the token and the openproject userId is used to generate the openproject URL to get the avatars from there as before.
