### PR TITLE
Rename the direct upload table

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -19,7 +19,7 @@ On the OpenProject end, users are able to:
 
 For more information on how to set up and use the OpenProject application, please refer to [integration setup guide](https://www.openproject.org/docs/system-admin-guide/integrations/nextcloud/) for administrators and [the user guide](https://www.openproject.org/docs/user-guide/nextcloud-integration/).
 	]]></description>
-	<version>2.3.0</version>
+	<version>2.3.1</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>OpenProject</namespace>

--- a/lib/Migration/Version2300Date20221219170111.php
+++ b/lib/Migration/Version2300Date20221219170111.php
@@ -45,8 +45,8 @@ class Version2300Date20221219170111 extends SimpleMigrationStep {
 		/** @var ISchemaWrapper $schema */
 		$schema = $schemaClosure();
 
-		if (!$schema->hasTable('directUpload')) {
-			$table = $schema->createTable('directUpload');
+		if (!$schema->hasTable('direct_upload')) {
+			$table = $schema->createTable('direct_upload');
 			$table->addColumn('id', 'integer', [
 				'autoincrement' => true,
 				'notnull' => true,

--- a/lib/Migration/Version2310Date20230116153411.php
+++ b/lib/Migration/Version2310Date20230116153411.php
@@ -32,7 +32,7 @@ use OCP\DB\ISchemaWrapper;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
-class Version2300Date20221219170111 extends SimpleMigrationStep {
+class Version2310Date20230116153411 extends SimpleMigrationStep {
 
 	/**
 	 * @param IOutput $output

--- a/lib/Migration/Version2310Date20230116153411.php
+++ b/lib/Migration/Version2310Date20230116153411.php
@@ -45,6 +45,12 @@ class Version2310Date20230116153411 extends SimpleMigrationStep {
 		/** @var ISchemaWrapper $schema */
 		$schema = $schemaClosure();
 
+		// in case the previous migration created this table we drop them
+		if ($schema->hasTable('directUpload')) {
+			$schema->dropTable('directUpload');
+		} elseif ($schema->hasTable('directupload')) {
+			$schema->dropTable('directupload');
+		}
 		if (!$schema->hasTable('direct_upload')) {
 			$table = $schema->createTable('direct_upload');
 			$table->addColumn('id', 'integer', [
@@ -73,7 +79,7 @@ class Version2310Date20230116153411 extends SimpleMigrationStep {
 			]);
 
 			$table->setPrimaryKey(['id']);
-			$table->addIndex(['token'], 'directUpload_token_index');
+			$table->addIndex(['token'], 'direct_upload_token_index');
 		}
 		return $schema;
 	}

--- a/lib/Service/DatabaseService.php
+++ b/lib/Service/DatabaseService.php
@@ -35,7 +35,7 @@ class DatabaseService {
 
 
 	/** @var string table name */
-	private string $table = 'directUpload';
+	private string $table = 'direct_upload';
 
 
 	public function __construct(


### PR DESCRIPTION
We made a table `directUpload` for the `direct-upload` API which worked for the current nextcloud master i.e `nextcloud-26` as it's stored as `oc_directUpload` in the database. But in nextcloud 25 and probably below the table is stored as `oc_directupload` without camelcase in the database so the request for `direct-upload` threw exceptions as the code is searching for `directUpload` to perform the operations. This PR renames the table to `direct_upload` so that the aforementioned problem doesn't occur and also bumps the version of the app from `2.3.0` to `2.3.1` for this change to take place.

In case the system went through the migration step `2.3.0` and created the database `directUpolad` or `directupload` depending upon the version of the nextcloud , the pre-existing table will be deleted in this migration.