### PR TITLE
[OP#45849] check quota before writing file

### DIFF
--- a/lib/Controller/DirectUploadController.php
+++ b/lib/Controller/DirectUploadController.php
@@ -24,12 +24,15 @@
 
 namespace OCA\OpenProject\Controller;
 
+use OC\Files\Node\Folder;
 use OC\User\NoUserException;
 use InvalidArgumentException;
 use OC\ForbiddenException;
 use \OCP\AppFramework\ApiController;
+use OCP\Files\File;
 use OCP\Files\InvalidCharacterInPathException;
 use OCP\Files\InvalidPathException;
+use OCP\Files\NotEnoughSpaceException;
 use OCP\Files\NotFoundException;
 use OCA\OpenProject\Service\DirectUploadService;
 use OCP\AppFramework\Http;
@@ -142,6 +145,7 @@ class DirectUploadController extends ApiController {
 		try {
 			$fileId = null;
 			$directUploadFile = $this->request->getUploadedFile('file');
+			$tmpPath = $directUploadFile['tmp_name'];
 			$overwrite = $this->request->getParam('overwrite');
 			if (isset($overwrite)) {
 				$acceptedOverwriteValues = ['true','false'];
@@ -155,7 +159,7 @@ class DirectUploadController extends ApiController {
 				$overwrite = null;
 			}
 			$fileName = trim($directUploadFile['name']);
-			$tmpPath = $directUploadFile['tmp_name'];
+
 			if (strlen($token) !== 64 || !preg_match('/^[a-zA-Z0-9]*/', $token)) {
 				throw new NotFoundException('invalid token');
 			}
@@ -167,12 +171,27 @@ class DirectUploadController extends ApiController {
 			if (empty($nodes)) {
 				throw new NotFoundException('folder not found or not enough permissions');
 			}
+			/**
+			 * @var Folder $folderNode
+			 */
 			$folderNode = array_shift($nodes);
+			$freeSpace = $folderNode->getFreeSpace();
+			$fileSize = \Safe\filesize($tmpPath);
+
+			// this is also true if we try to overwrite
+			// to overwrite a file we need enough free quota for the new data
+			// otherwise `putContent()` fails
+			if ($fileSize > $freeSpace) {
+				throw new NotEnoughSpaceException('insufficient quota');
+			}
 			if (
 				$folderNode->isCreatable()
 			) {
 				// @phpstan-ignore-next-line
 				if ($folderNode->nodeExists($fileName) && $overwrite) {
+					/**
+					 * @var File $file
+					 */
 					$file = $folderNode->get($fileName); // @phpstan-ignore-line
 					if ($file->getType() === FileInfo::TYPE_FOLDER) {
 						throw new Conflict('overwrite is not allowed on non-files');
@@ -219,6 +238,10 @@ class DirectUploadController extends ApiController {
 			return new DataResponse([
 				'error' => $e->getMessage(),
 			], Http::STATUS_CONFLICT);
+		} catch (NotEnoughSpaceException $e) {
+			return new DataResponse([
+				'error' => $e->getMessage(),
+			], Http::STATUS_INSUFFICIENT_STORAGE);
 		} catch (Exception $e) {
 			return new DataResponse([
 				'error' => $e->getMessage()

--- a/lib/Controller/DirectUploadController.php
+++ b/lib/Controller/DirectUploadController.php
@@ -176,12 +176,11 @@ class DirectUploadController extends ApiController {
 			 */
 			$folderNode = array_shift($nodes);
 			$freeSpace = $folderNode->getFreeSpace();
-			$fileSize = \Safe\filesize($tmpPath);
 
 			// this is also true if we try to overwrite
 			// to overwrite a file we need enough free quota for the new data
 			// otherwise `putContent()` fails
-			if ($fileSize > $freeSpace) {
+			if ($directUploadFile['size'] > $freeSpace) {
 				throw new NotEnoughSpaceException('insufficient quota');
 			}
 			if (

--- a/lib/Controller/DirectUploadController.php
+++ b/lib/Controller/DirectUploadController.php
@@ -146,6 +146,7 @@ class DirectUploadController extends ApiController {
 			$fileId = null;
 			$directUploadFile = $this->request->getUploadedFile('file');
 			$tmpPath = $directUploadFile['tmp_name'];
+			$fileName = trim($directUploadFile['name']);
 			$overwrite = $this->request->getParam('overwrite');
 			if (isset($overwrite)) {
 				$acceptedOverwriteValues = ['true','false'];
@@ -158,7 +159,6 @@ class DirectUploadController extends ApiController {
 			} else {
 				$overwrite = null;
 			}
-			$fileName = trim($directUploadFile['name']);
 
 			if (strlen($token) !== 64 || !preg_match('/^[a-zA-Z0-9]*/', $token)) {
 				throw new NotFoundException('invalid token');

--- a/tests/acceptance/features/bootstrap/DirectUploadContext.php
+++ b/tests/acceptance/features/bootstrap/DirectUploadContext.php
@@ -117,6 +117,24 @@ class DirectUploadContext implements Context {
 		$this->featureContext->theHTTPStatusCodeShouldBe(201);
 	}
 
+	/**
+	 * @Given /^the quota of user "([^"]*)" has been set to "([^"]*)"$/
+	 */
+	public function theQuotaOfUserHasBeenSetTo(string $user, string $quota):void {
+		$body = [
+			'key' => 'quota',
+			'value' => $quota,
+		];
+		$response = $this->featureContext->sendOCSRequest(
+			"/cloud/users/$user",
+			"PUT",
+			$this->featureContext->getAdminUsername(),
+			$body
+		);
+		$this->featureContext->theHttpStatusCodeShouldBe(
+			200, "could not set quota", $response
+		);
+	}
 
 	/**
 	 * @When /^an anonymous user sends an OPTIONS request to the "([^"]*)" endpoint with these headers:$/

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -92,6 +92,7 @@ class FeatureContext implements Context {
 			'/cloud/users', 'POST', $this->getAdminUsername(), $userAttributes
 		);
 		$this->theHttpStatusCodeShouldBe(200);
+		$this->userHasDeletedFile($user, "welcome.txt");
 	}
 
 	/**
@@ -296,11 +297,17 @@ class FeatureContext implements Context {
 	 *
 	 * @param int|int[]|string|string[] $expectedStatusCode
 	 * @param string|null $message
+	 * @param ResponseInterface $response
 	 *
 	 * @return void
 	 */
-	public function theHTTPStatusCodeShouldBe($expectedStatusCode, ?string $message = ""): void {
-		$actualStatusCode = $this->response->getStatusCode();
+	public function theHTTPStatusCodeShouldBe(
+		$expectedStatusCode, ?string $message = "", $response = null
+	): void {
+		if ($response === null) {
+			$response = $this->response;
+		}
+		$actualStatusCode = $response->getStatusCode();
 		if (\is_array($expectedStatusCode)) {
 			if ($message === "") {
 				$message = "HTTP status code $actualStatusCode is not one of the expected values " .


### PR DESCRIPTION
Check for free quota on that particular folder before writing a file.
There is still the chance of a race-condition. e.g. while we are writing data an other client also writes and together we run out of quota, no idea how we could avoid that.

part of https://community.openproject.org/projects/nextcloud-integration/work_packages/45849