### PR TITLE
[OP#45849] report error when file was not uploaded

### DIFF
--- a/lib/Controller/DirectUploadController.php
+++ b/lib/Controller/DirectUploadController.php
@@ -147,13 +147,14 @@ class DirectUploadController extends ApiController {
 		try {
 			$fileId = null;
 			$directUploadFile = $this->request->getUploadedFile('file');
+			$fileName = trim($directUploadFile['name']);
+			$this->scanForInvalidCharacters($fileName, "\\/");
 			if (empty($directUploadFile['tmp_name']) || $directUploadFile['error'] === 1) {
 				throw new OpenprojectFileNotUploadedException(
 					'File was not uploaded. upload_max_filesize exceeded?'
 				);
 			}
 			$tmpPath = $directUploadFile['tmp_name'];
-			$fileName = trim($directUploadFile['name']);
 			if (Filesystem::isFileBlacklisted($fileName)) {
 				throw new ForbiddenException('invalid file name');
 			}
@@ -173,7 +174,6 @@ class DirectUploadController extends ApiController {
 			if (strlen($token) !== 64 || !preg_match('/^[a-zA-Z0-9]*/', $token)) {
 				throw new NotFoundException('invalid token');
 			}
-			$this->scanForInvalidCharacters($fileName, "\\/");
 			$tokenInfo = $this->directUploadService->getTokenInfo($token);
 			$user = $this->userManager->get($tokenInfo['user_id']);
 			$userFolder = $this->rootFolder->getUserFolder($user->getUID());

--- a/lib/Exception/OpenprojectFileNotUploadedException.php
+++ b/lib/Exception/OpenprojectFileNotUploadedException.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace OCA\OpenProject\Exception;
+
+use Exception;
+use Throwable;
+
+class OpenprojectFileNotUploadedException extends Exception {
+
+	/**
+	 * @param string $message
+	 * @param int $code
+	 * @param Throwable|null $previous
+	 */
+	public function __construct(string $message, int $code = 0, Throwable $previous = null) {
+		parent::__construct($message, $code, $previous);
+	}
+}

--- a/tests/lib/Controller/DirectUploadControllerTest.php
+++ b/tests/lib/Controller/DirectUploadControllerTest.php
@@ -142,7 +142,7 @@ class DirectUploadControllerTest extends TestCase {
 		$userFolderMock = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
 		$userFolderMock->method('getById')->willReturn($nodeMock);
 		$directUploadController = $this->createDirectUploadController(
-			$userFolderMock, 100, ''
+			$userFolderMock, 100, $tmpName, $error
 		);
 		$result = $directUploadController->directUpload(
 			'WampxL5Z97CndGwB7qLPfotosDT5mXk7oFyGLa64nmY35ANtkzT7zDQwYyXrbdC3'

--- a/tests/lib/Controller/DirectUploadControllerTest.php
+++ b/tests/lib/Controller/DirectUploadControllerTest.php
@@ -152,7 +152,7 @@ class DirectUploadControllerTest extends TestCase {
 			'File was not uploaded. upload_max_filesize exceeded?',
 			$resultArray['error']
 		);
-		self::assertIsInt($resultArray['upload_limit']);
+		self::assertIsNumeric($resultArray['upload_limit']);
 		assertSame(413, $result->getStatus());
 	}
 


### PR DESCRIPTION
~~on top of #325~~
This case happens when the uploaded file is bigger than upload_max_filesize.
In that case return a 413 HTTP code and show what the max upload size is.
