### PR TITLE
[OP#45897] check for exception that is thrown by files_antivirus

### DIFF
--- a/lib/Controller/DirectUploadController.php
+++ b/lib/Controller/DirectUploadController.php
@@ -33,6 +33,7 @@ use OCA\OpenProject\Exception\OpenprojectFileNotUploadedException;
 use \OCP\AppFramework\ApiController;
 use OCP\Files\File;
 use OCP\Files\InvalidCharacterInPathException;
+use OCP\Files\InvalidContentException;
 use OCP\Files\InvalidPathException;
 use OCP\Files\NotEnoughSpaceException;
 use OCP\Files\NotFoundException;
@@ -256,6 +257,10 @@ class DirectUploadController extends ApiController {
 				'error' => $e->getMessage(),
 				'upload_limit' => \OC_Helper::uploadLimit()
 			], Http::STATUS_REQUEST_ENTITY_TOO_LARGE);
+		} catch (InvalidContentException $e) { // files_antivirus throws this exception
+			return new DataResponse([
+				'error' => $e->getMessage()
+			], Http::STATUS_UNSUPPORTED_MEDIA_TYPE);
 		} catch (Exception $e) {
 			return new DataResponse([
 				'error' => $e->getMessage()


### PR DESCRIPTION
The InvalidContentException is thrown by the files_antivirus app. So catch it and return the same error code that the DAV endpoint would return if a virus is detected.
