### PR TITLE
check empty filename

### DIFF
--- a/lib/Controller/DirectUploadController.php
+++ b/lib/Controller/DirectUploadController.php
@@ -147,6 +147,9 @@ class DirectUploadController extends ApiController {
 		try {
 			$fileId = null;
 			$directUploadFile = $this->request->getUploadedFile('file');
+			if (empty($directUploadFile)) {
+				throw new InvalidCharacterInPathException('invalid file name');
+			}
 			$fileName = trim($directUploadFile['name']);
 			$this->scanForInvalidCharacters($fileName, "\\/");
 			if (empty($directUploadFile['tmp_name']) || $directUploadFile['error'] === 1) {


### PR DESCRIPTION
Check early if `$directUploadFile` is an array or not. Effectively this is also checked in `scanForInvalidCharacters` but after trying to access the array and that produces a log output like: `"message": "Trying to access array offset on value of type null at /home/artur/www/nextcloud-server/custom_apps/integration_openproject/lib/Controller/DirectUploadController.php#150",`

How to test:
1. set log-level to at least "error"
2. run API test `directUpload.feature:66`
3. check the log file (the mentioned message appears before the fix but not after)