### PR TITLE
bump version to 2.2.1

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -19,7 +19,7 @@ On the OpenProject end, users are able to:
 
 For more information on how to set up and use the OpenProject application, please refer to [integration setup guide](https://www.openproject.org/docs/system-admin-guide/integrations/nextcloud/) for administrators and [the user guide](https://www.openproject.org/docs/user-guide/nextcloud-integration/).
 	]]></description>
-	<version>2.2.0</version>
+	<version>2.2.1</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>OpenProject</namespace>


### PR DESCRIPTION
bump version to 2.2.1 because the build of 2.2.0 failed see https://github.com/nextcloud/integration_openproject/actions/runs/4015405945
