### PR TITLE
[OP#45941] Add more api tests for direct upload feature

### DIFF
--- a/tests/lib/Controller/DirectUploadControllerTest.php
+++ b/tests/lib/Controller/DirectUploadControllerTest.php
@@ -211,6 +211,9 @@ class DirectUploadControllerTest extends TestCase {
 
 	/**
 	 * @param MockObject $folderMock
+	 * @param int $uploadedFileSize
+	 * @param string $uploadedFileTmpName
+	 * @param int $uploadedFileError
 	 * @return DirectUploadController
 	 */
 	private function createDirectUploadController(
@@ -262,6 +265,7 @@ class DirectUploadControllerTest extends TestCase {
 			$userSessionMock,
 			$userManagerMock,
 			$directUploadServiceMock,
+			$this->getMockBuilder('OCA\OpenProject\Service\DatabaseService')->disableOriginalConstructor()->getMock(),
 			'testUser',
 		);
 	}


### PR DESCRIPTION
related work package OP#45941 : https://community.openproject.org/projects/nextcloud-integration/work_packages/45941/activity
 
This PR
1. Adds API test
2. moves the `getTokenInfo` function call at the beginning as the token is deleted when this function is called. Previously, the token was usable if the request failed before it reached this function and we don't want that since the token is one-time only.  