### PR TITLE
[OP#45952] Fix the dashboard item not aligning properly

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -22,10 +22,6 @@ body.theme--dark .icon-openproject {
 	position: relative;
 }
 
-.panel--content > div {
-	height: 100%;
-}
-
 .panel--content .empty-content {
 	margin: 0 !important;
 	height: 100%;


### PR DESCRIPTION
### Steps to reproduce 
1. Download and enable `talks` app of nextcloud while the integration app is also enabled

Whenever our app and another app that uses the Dashboard widget are enabled, the dashboard items were placed outside for other apps because of the CSS removed in this PR. As the CSS is doing changes to the dashboard widget element it'll be applied for all the apps with dashboard widgets that are enabled along with this app.

This PR fixes that problem. 

## Before
![Screenshot from 2023-02-03 14-25-13](https://user-images.githubusercontent.com/41103328/216553160-836e108b-c04f-4ca9-a968-89dbba3a1e5a.png)

## After
![Screenshot from 2023-02-03 14-25-29](https://user-images.githubusercontent.com/41103328/216553134-7ea63689-7eff-4f65-99bc-5189758c69f4.png)


## Related work package 
[OP#45952] - https://community.openproject.org/projects/nextcloud-integration/work_packages/45952/activity