### PR TITLE
[OP#45928] hide the tab if the app is limited to specific groups

### DIFF
--- a/lib/Listener/LoadSidebarScript.php
+++ b/lib/Listener/LoadSidebarScript.php
@@ -29,6 +29,7 @@ namespace OCA\OpenProject\Listener;
 use OCA\Files\Event\LoadSidebar;
 use OCA\OpenProject\AppInfo\Application;
 use OCA\OpenProject\Service\OpenProjectAPIService;
+use OCP\App\IAppManager;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
@@ -57,13 +58,20 @@ class LoadSidebarScript implements IEventListener {
 	 */
 	private $oauthConnectionErrorMessage = '';
 
+	/**
+	 * @var IAppManager
+	 */
+	protected $appManager;
+
 	public function __construct(
 		IInitialState $initialStateService,
 		IConfig $config,
-		IUserSession $userSession
+		IUserSession $userSession,
+		IAppManager $appManager
 	) {
 		$this->initialStateService = $initialStateService;
 		$this->config = $config;
+		$this->appManager = $appManager;
 		$user = $userSession->getUser();
 		if (strpos(\OC::$server->get(IRequest::class)->getRequestUri(), 'files') !== false) {
 			$this->oauthConnectionResult = $this->config->getUserValue(
@@ -83,6 +91,9 @@ class LoadSidebarScript implements IEventListener {
 
 	public function handle(Event $event): void {
 		if (!($event instanceof LoadSidebar)) {
+			return;
+		}
+		if (!$this->appManager->isEnabledForUser(Application::APP_ID)) {
 			return;
 		}
 		$currentVersion = implode('.', Util::getVersion());


### PR DESCRIPTION
If the administrator limits the app to specific groups, don't show the OpenProject tab in the files details sidebar.

The limitation seems to work out of the box for all other places:
- user settings
- dashboard
- search
- navigation link
- APIs

fixes https://community.openproject.org/work_packages/45928 
