### PR TITLE
support NC 27

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     name: unit tests and linting
     strategy:
       matrix:
-        nextcloudVersion: [ stable22, stable23, stable24, stable25, master ]
+        nextcloudVersion: [ stable22, stable23, stable24, stable25, stable26, master ]
         phpVersion: [ 7.4, 8.0, 8.1 ]
         exclude:
           - nextcloudVersion: stable22
@@ -20,6 +20,8 @@ jobs:
             phpVersion: 8.1
           - nextcloudVersion: stable24
             phpVersion: 8.1
+          - nextcloudVersion: stable26
+            phpVersion: 7.4
           - nextcloudVersion: master
             phpVersion: 7.4
     runs-on: ubuntu-latest
@@ -154,7 +156,7 @@ jobs:
     name: API tests
     strategy:
       matrix:
-        nextcloudVersion: [ stable22, stable23, stable24, stable25, master ]
+        nextcloudVersion: [ stable22, stable23, stable24, stable25, stable26, master ]
         phpVersionMajor: [ 7, 8 ]
         phpVersionMinor: [ 4, 1 ]
         database: [pgsql, mysql]
@@ -168,6 +170,14 @@ jobs:
           - nextcloudVersion: stable24
             phpVersionMajor: 8
             phpVersionMinor: 1
+          - nextcloudVersion: stable26
+            phpVersionMajor: 7
+          - phpVersionMajor: 7
+            phpVersionMinor: 0
+          - phpVersionMajor: 7
+            phpVersionMinor: 1
+          - phpVersionMajor: 8
+            phpVersionMinor: 4
           - nextcloudVersion: master
             phpVersionMajor: 7
           - phpVersionMajor: 7

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -35,7 +35,7 @@ For more information on how to set up and use the OpenProject application, pleas
 	<screenshot>https://github.com/nextcloud/integration_openproject/raw/master/img/screenshot1.png</screenshot>
 	<screenshot>https://github.com/nextcloud/integration_openproject/raw/master/img/screenshot2.png</screenshot>
 	<dependencies>
-		<nextcloud min-version="22" max-version="26"/>
+		<nextcloud min-version="22" max-version="27"/>
 	</dependencies>
 	<background-jobs>
 		<job>OCA\OpenProject\BackgroundJob\RemoveExpiredDirectUploadTokens</job>


### PR DESCRIPTION
Nextcloud master branch got renamed to version 27 https://github.com/nextcloud/server/commit/87f103dc6c4cf86e0e128ed9379f77f373034342
So we need to test against stable26 branch and enable support for NC 27