### PR TITLE
[OP#46668] Make the translation string inline

### DIFF
--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -505,8 +505,7 @@ export default {
 					)
 					this.openProjectNotReachableErrorMessageDetails = t(
 						'integration_openproject',
-						'To be able to use an OpenProject server with a local address, '
-						+ 'enable the `allow_local_remote_servers` setting. {htmlLink}.',
+						'To be able to use an OpenProject server with a local address, enable the `allow_local_remote_servers` setting. {htmlLink}.',
 						{ htmlLink },
 						null,
 						{ escape: false, sanitize: false }


### PR DESCRIPTION
fixes: https://github.com/nextcloud/integration_openproject/issues/362

Related workpackage [OP#46668]: https://community.openproject.org/projects/nextcloud-integration/work_packages/46668

The first half of this string is available but the second half is not available in the Transifex 
https://github.com/nextcloud/integration_openproject/blob/216d6ca4d9d513392b0dd2e5c2d1f155fbff3b7a/l10n/de.json#L46

Here it's mentioned https://docs.nextcloud.com/server/stable/developer_manual/basics/front-end/l10n.html#improving-your-translations

> You shall never split sentences and never concatenate two translations (e.g. “Enable” and “dark mode” can not be combined to “Enable dark mode”, because languages might have to use different cases)! Translators lose the context and they have no chance to possibly re-arrange words/parts as needed.

 