### PR TITLE
[OP#46349] return HTTP 413 if max_post_size is exceeded

### DIFF
--- a/lib/Controller/DirectUploadController.php
+++ b/lib/Controller/DirectUploadController.php
@@ -173,7 +173,9 @@ class DirectUploadController extends ApiController {
 			$fileId = null;
 			$directUploadFile = $this->request->getUploadedFile('file');
 			if (empty($directUploadFile)) {
-				throw new InvalidCharacterInPathException('invalid file name');
+				throw new OpenprojectFileNotUploadedException(
+					'File was not uploaded. post_max_size exceeded?'
+				);
 			}
 			$fileName = trim($directUploadFile['name']);
 			$this->scanForInvalidCharacters($fileName, "\\/");


### PR DESCRIPTION
In the case when the max_post_size of PHP is exceeded the `$directUploadFile` variable is empty, because no data is actually forwarded to the code, so return HTTP 413 for that.
The same happens when a completely empty file-name is send, sadly we cannot distinguish both cases :-(

For the code actually even to get there and to be able to throw this exception and catch it later `display_errors` need to be set to `Off` in the php.ini
