### PR TITLE
[OP#47205] Sanitize the openproject instance url for global search

### DIFF
--- a/lib/Search/OpenProjectSearchProvider.php
+++ b/lib/Search/OpenProjectSearchProvider.php
@@ -114,7 +114,7 @@ class OpenProjectSearchProvider implements IProvider {
 		$term = $query->getTerm();
 		$offset = $query->getCursor();
 		$offset = $offset ? intval($offset) : 0;
-		$openprojectUrl = $this->config->getAppValue(Application::APP_ID, 'openproject_instance_url');
+		$openprojectUrl = OpenProjectAPIService::sanitizeUrl($this->config->getAppValue(Application::APP_ID, 'openproject_instance_url'));
 		$accessToken = $this->config->getUserValue($user->getUID(), Application::APP_ID, 'token');
 
 		$searchEnabled = $this->config->getUserValue(


### PR DESCRIPTION
This Pr sanitizes the `openproject_instance_url` so that  the links don't have extra `/`
Related work package: https://community.openproject.org/projects/nextcloud-integration/work_packages/47205/activity