### PR TITLE
[OP#47630] Check if free space is a positive value

### DIFF
--- a/lib/Controller/DirectUploadController.php
+++ b/lib/Controller/DirectUploadController.php
@@ -30,6 +30,7 @@ use OC\User\NoUserException;
 use InvalidArgumentException;
 use OC\ForbiddenException;
 use OCA\OpenProject\Exception\OpenprojectFileNotUploadedException;
+use OCA\OpenProject\Exception\OpenprojectUnauthorizedUserException;
 use \OCP\AppFramework\ApiController;
 use OCP\Files\File;
 use OCP\Files\InvalidCharacterInPathException;
@@ -37,12 +38,12 @@ use OCP\Files\InvalidContentException;
 use OCP\Files\InvalidPathException;
 use OCP\Files\NotEnoughSpaceException;
 use OCP\Files\NotFoundException;
+use OCP\Lock\LockedException;
 use OCA\OpenProject\Service\DirectUploadService;
 use OCA\OpenProject\Service\DatabaseService;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\Files\IRootFolder;
-use OCP\Files\NotPermittedException;
 use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUser;
@@ -216,8 +217,10 @@ class DirectUploadController extends ApiController {
 
 			// this is also true if we try to overwrite
 			// to overwrite a file we need enough free quota for the new data
-			// otherwise `putContent()` fails
-			if ($directUploadFile['size'] > $freeSpace) {
+			// otherwise `putContent()` fails,
+			// if freeSpace is smaller than 0 then treat it as a unlimited space
+			// and don't throw an error
+			if ($directUploadFile['size'] > $freeSpace && $freeSpace >= 0) {
 				throw new NotEnoughSpaceException('insufficient quota');
 			}
 			if ($folderNode->nodeExists($fileName) && $overwrite) {
@@ -246,7 +249,7 @@ class DirectUploadController extends ApiController {
 			}
 			$fileInfo = $folderNode->newFile($fileName, fopen($tmpPath, 'r'));
 			$fileId = $fileInfo->getId();
-		} catch (NotPermittedException $e) {
+		} catch (OpenprojectUnauthorizedUserException $e) {
 			return new DataResponse([
 				'error' => $this->l->t($e->getMessage())
 			], Http::STATUS_UNAUTHORIZED);
@@ -279,6 +282,10 @@ class DirectUploadController extends ApiController {
 			return new DataResponse([
 				'error' => $this->l->t($e->getMessage())
 			], Http::STATUS_UNSUPPORTED_MEDIA_TYPE);
+		} catch (LockedException $e) {
+			return new DataResponse([
+				'error' => $this->l->t($e->getMessage())
+			], Http::STATUS_LOCKED);
 		} catch (\Exception $e) {
 			return new DataResponse([
 				'error' => $this->l->t($e->getMessage())

--- a/lib/Exception/OpenprojectUnauthorizedUserException.php
+++ b/lib/Exception/OpenprojectUnauthorizedUserException.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace OCA\OpenProject\Exception;
+
+use Exception;
+use Throwable;
+
+class OpenprojectUnauthorizedUserException extends Exception {
+
+	/**
+	 * @param string $message
+	 * @param int $code
+	 * @param Throwable|null $previous
+	 */
+	public function __construct(string $message, int $code = 0, Throwable $previous = null) {
+		parent::__construct($message, $code, $previous);
+	}
+}

--- a/lib/Service/DirectUploadService.php
+++ b/lib/Service/DirectUploadService.php
@@ -27,7 +27,7 @@ namespace OCA\OpenProject\Service;
 use DateTime;
 use OCP\Files\NotFoundException;
 use OCP\DB\Exception;
-use OCP\Files\NotPermittedException;
+use OCA\OpenProject\Exception\OpenprojectUnauthorizedUserException;
 use OCP\IL10N;
 use OCP\Security\ISecureRandom;
 use OCP\IUserManager;
@@ -101,7 +101,7 @@ class DirectUploadService {
 	 *
 	 * @return array<mixed>
 	 *
-	 * @throws NotPermittedException
+	 * @throws OpenprojectUnauthorizedUserException
 	 * @throws NotFoundException
 	 * @throws Exception
 	 */
@@ -109,7 +109,7 @@ class DirectUploadService {
 		$tokenInfo = $this->databaseService->getTokenInfoFromDB($token);
 		$userId = $this->userManager->get($tokenInfo['user_id']);
 		if ($tokenInfo['user_id'] === null || !$this->userManager->userExists($tokenInfo['user_id']) || !$userId->isEnabled()) {
-			throw new NotPermittedException('unauthorized');
+			throw new OpenprojectUnauthorizedUserException('unauthorized');
 		}
 		$currentTime = (new DateTime())->getTimestamp();
 		if ($currentTime > $tokenInfo['expires_on']) {

--- a/tests/lib/Controller/DirectUploadControllerTest.php
+++ b/tests/lib/Controller/DirectUploadControllerTest.php
@@ -214,6 +214,33 @@ class DirectUploadControllerTest extends TestCase {
 		assertSame($expectedStatusCode, $result->getStatus());
 	}
 
+	public function testNegativeFreeSpace(): void {
+		$fileMock = $this->getMockBuilder('\OC\Files\Node\File')->disableOriginalConstructor()->getMock();
+		$fileMock->method('getId')->willReturn(123);
+		$nodeMock = $this->getNodeMock('folder');
+		$tmpFileName = '/tmp/integration_openproject_unit_test';
+		\Safe\touch($tmpFileName);
+		$nodeMock[0]->method('getFreeSpace')->willReturn(-3);
+		$nodeMock[0]->method('newFile')->willReturn($fileMock);
+		$userFolderMock = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$userFolderMock->method('getById')->willReturn($nodeMock);
+		$directUploadController = $this->createDirectUploadController(
+			$userFolderMock, 101, $tmpFileName
+		);
+		$result = $directUploadController->directUpload(
+			'WampxL5Z97CndGwB7qLPfotosDT5mXk7oFyGLa64nmY35ANtkzT7zDQwYyXrbdC3'
+		);
+		$resultArray = $result->getData();
+		assertSame(
+			[
+				'file_name' => 'file.txt',
+				'file_id' => 123
+			],
+			$resultArray
+		);
+	}
+
+
 	/**
 	 * @param MockObject $folderMock
 	 * @param int $uploadedFileSize


### PR DESCRIPTION
Currently we're checking quota like this

```php
$freeSpace = $folderNode->getFreeSpace();

// this is also true if we try to overwrite
// to overwrite a file we need enough free quota for the new data
// otherwise `putContent()` fails
if ($directUploadFile['size'] > $freeSpace) {
	throw new NotEnoughSpaceException('insufficient quota');
}
```
But since there's a possibility that the function getFreeSpace might return a negative

https://github.com/nextcloud/server/blob/b1abc57c07a61b5a0557395d86c3e31486a96c23/lib/public/Files/FileInfo.php#L52

https://github.com/nextcloud/server/blob/b1abc57c07a61b5a0557395d86c3e31486a96c23/lib/public/Files/FileInfo.php#L57

https://github.com/nextcloud/server/blob/b1abc57c07a61b5a0557395d86c3e31486a96c23/lib/public/Files/FileInfo.php#L62

So treat a negative return as an unlimited space

Related work package: https://community.openproject.org/projects/nextcloud-integration/work_packages/47630/activity?query_id=3504