### PR TITLE
[OP#47849]Fix unit test failing on CI

### DIFF
--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -227,9 +227,28 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$clientConfigMock = $this->getMockBuilder(IConfig::class)->getMock();
 
 		$clientConfigMock
-			->method('getSystemValueBool')
-			->with('allow_local_remote_servers', false)
-			->willReturn(true);
+		->method('getSystemValueBool')
+		->withConsecutive(
+		['allow_local_remote_servers', false],
+		['installed', false],
+		['allow_local_remote_servers', false],
+		['allow_local_remote_servers', false],
+		['installed', false],
+		['allow_local_remote_servers', false],
+		['allow_local_remote_servers', false],
+		['installed', false],
+		['allow_local_remote_servers', false])
+		->willReturnOnConsecutiveCalls(
+			true,
+			true,
+			true,
+			true,
+			true,
+			true,
+			true,
+			true,
+			true
+		);
 
 		if (version_compare(OC_Util::getVersionString(), '26') >= 0) {
 			//changed from nextcloud 26

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -227,30 +227,45 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$clientConfigMock = $this->getMockBuilder(IConfig::class)->getMock();
 
 
-		if (version_compare(OC_Util::getVersionString(), '26') >= 0) {
+		if (version_compare(OC_Util::getVersionString(), '27') >= 0) {
 			$clientConfigMock
-		->method('getSystemValueBool')
-		->withConsecutive(
-		['allow_local_remote_servers', false],
-		['installed', false],
-		['allow_local_remote_servers', false],
-		['allow_local_remote_servers', false],
-		['installed', false],
-		['allow_local_remote_servers', false],
-		['allow_local_remote_servers', false],
-		['installed', false],
-		['allow_local_remote_servers', false])
-		->willReturnOnConsecutiveCalls(
-			true,
-			true,
-			true,
-			true,
-			true,
-			true,
-			true,
-			true,
-			true
-		);
+			->method('getSystemValueBool')
+			->withConsecutive(
+				['allow_local_remote_servers', false],
+				['installed', false],
+				['allow_local_remote_servers', false],
+				['allow_local_remote_servers', false],
+				['installed', false],
+				['allow_local_remote_servers', false],
+				['allow_local_remote_servers', false],
+				['installed', false],
+				['allow_local_remote_servers', false]
+			)
+				->willReturnOnConsecutiveCalls(
+					true,
+					true,
+					true,
+					true,
+					true,
+					true,
+					true,
+					true,
+					true
+				);
+			//changed from nextcloud 26
+			// @phpstan-ignore-next-line
+			$ocClient = new Client(
+				$clientConfigMock,                                             // @phpstan-ignore-line
+				$certificateManager,                                           // @phpstan-ignore-line
+				$client,                                                       // @phpstan-ignore-line
+				$this->createMock(IRemoteHostValidator::class)                 // @phpstan-ignore-line
+			);
+		} elseif (version_compare(OC_Util::getVersionString(), '26') >= 0) {
+			$clientConfigMock
+			->method('getSystemValueBool')
+			->with('allow_local_remote_servers', false)
+			->willReturn(true);
+
 			//changed from nextcloud 26
 			// @phpstan-ignore-next-line
 			$ocClient = new Client(

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -226,7 +226,9 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$client = new GuzzleClient();
 		$clientConfigMock = $this->getMockBuilder(IConfig::class)->getMock();
 
-		$clientConfigMock
+
+		if (version_compare(OC_Util::getVersionString(), '26') >= 0) {
+			$clientConfigMock
 		->method('getSystemValueBool')
 		->withConsecutive(
 		['allow_local_remote_servers', false],
@@ -249,8 +251,6 @@ class OpenProjectAPIServiceTest extends TestCase {
 			true,
 			true
 		);
-
-		if (version_compare(OC_Util::getVersionString(), '26') >= 0) {
 			//changed from nextcloud 26
 			// @phpstan-ignore-next-line
 			$ocClient = new Client(
@@ -260,6 +260,10 @@ class OpenProjectAPIServiceTest extends TestCase {
 				$this->createMock(IRemoteHostValidator::class)                 // @phpstan-ignore-line
 			);
 		} elseif (version_compare(OC_Util::getVersionString(), '24') >= 0) {
+			$clientConfigMock
+			->method('getSystemValueBool')
+			->with('allow_local_remote_servers', false)
+			->willReturn(true);
 			//changed from nextcloud 24
 			// @phpstan-ignore-next-line
 			$ocClient = new Client(
@@ -269,6 +273,10 @@ class OpenProjectAPIServiceTest extends TestCase {
 				$this->createMock(\OC\Http\Client\LocalAddressChecker::class)  // @phpstan-ignore-line
 			);
 		} else {
+			$clientConfigMock
+			->method('getSystemValueBool')
+			->with('allow_local_remote_servers', false)
+			->willReturn(true);
 			// @phpstan-ignore-next-line
 			$ocClient = new Client(
 				$clientConfigMock,                                             // @phpstan-ignore-line


### PR DESCRIPTION
Related workpackage: [OP#47849] https://community.openproject.org/projects/nextcloud-integration/work_packages/47849/github?query_id=3714

There was some refactoring done in the nextcloud server[master branch] by PR https://github.com/nextcloud/server/pull/37596 that changed some of the function calls so we needed to mock them in the order that they are called to make tests pass. Since these changes were added only to the master (nc-27), other versions need to work with the previous setup. So this PR
1. Mocks the functions needed for the master
2. separates the mocks according to versions