### PR TITLE
[OP#47869]Update github actions packages 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
 
 name: CI
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unittest-linting:
     name: unit tests and linting
@@ -26,17 +30,11 @@ jobs:
             phpVersion: 7.4
     runs-on: ubuntu-latest
     steps:
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          all_but_latest: true
-          access_token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup PHP ${{ matrix.phpVersion }}
-        uses: shivammathur/setup-php@2.23.0
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.phpVersion }}
           tools: composer, phpunit
@@ -44,7 +42,7 @@ jobs:
 
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache PHP dependencies
         uses: actions/cache@v3
@@ -54,14 +52,14 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-
 
       - name: Read package.json node and npm engines version
-        uses: skjnldsv/read-package-engines-version-actions@v1.2
+        uses: skjnldsv/read-package-engines-version-actions@v2
         id: versions
         with:
           fallbackNode: '^14'
           fallbackNpm: '^7'
 
       - name: Setup NodeJS ${{ steps.versions.outputs.nodeVersion }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ steps.versions.outputs.nodeVersion }}
           cache: 'npm'
@@ -224,26 +222,20 @@ jobs:
         image: redis:7
 
     steps:
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          all_but_latest: true
-          access_token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: integration_openproject
 
       - name: Checkout activity app
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: nextcloud/activity
           path: activity
           ref: ${{ matrix.nextcloudVersion }}
 
       - name: Setup PHP ${{ format('{0}.{1}', matrix.phpVersionMajor,matrix.phpVersionMinor) }}
-        uses: shivammathur/setup-php@2.23.0
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ format('{0}.{1}', matrix.phpVersionMajor,matrix.phpVersionMinor) }}
           tools: composer
@@ -251,7 +243,7 @@ jobs:
 
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache PHP dependencies
         uses: actions/cache@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Use Node 14
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 14
 
@@ -30,7 +30,7 @@ jobs:
           tools: php-cs-fixer, phpunit
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get current tag
         id: tag
@@ -39,13 +39,13 @@ jobs:
           tag=$(git tag -l --points-at HEAD)
           echo CURRENT TAG IS '"'${tag}'"' '!!!!'
           vtag=$(echo $tag | grep "^v[0-9]\+\.[0-9]\+\.[0-9]\+" || echo "")
-          echo "##[set-output name=currenttag;]$vtag"
+          echo "currenttag=$vtag" >> $GITHUB_OUTPUT
 
       - name: Build project
         if: ${{ startsWith( steps.tag.outputs.currenttag , 'v' ) }}
         id: build_release
         run: |
-          echo "##[set-output name=app_id;]$APP_ID"
+          echo "app_id=$APP_ID" >> $GITHUB_OUTPUT
           echo "###### copy certificate"
           mkdir -p ~/.nextcloud/certificates
           echo "$APP_CRT" > ~/.nextcloud/certificates/${APP_ID}.crt
@@ -69,7 +69,7 @@ jobs:
           tag=${{ steps.tag.outputs.currenttag }}
           version=${tag/v/}
           webserveruser=runner occ_dir=~/html/nextcloud version=$version make appstore
-          echo "##[set-output name=version;]$version"
+          echo "version=$version" >> $GITHUB_OUTPUT
         env:
           APP_CRT: ${{ secrets.APP_CRT }}
           APP_KEY: ${{ secrets.APP_KEY }}
@@ -77,26 +77,20 @@ jobs:
       - name: Create Release
         if: ${{ startsWith( steps.tag.outputs.currenttag , 'v' ) }}
         id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ steps.tag.outputs.currenttag }}
-          release_name: ${{ steps.tag.outputs.currenttag }}
+          name: ${{ steps.tag.outputs.currenttag }}
           draft: false
           prerelease: false
 
       - name: Upload Release Asset
         if: ${{ startsWith( steps.tag.outputs.currenttag , 'v' ) }}
         id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: /tmp/build/${{ steps.build_release.outputs.app_id }}-${{ steps.build_release.outputs.version }}.tar.gz
-          asset_name: ${{ steps.build_release.outputs.app_id }}-${{ steps.build_release.outputs.version }}.tar.gz
-          asset_content_type: application/gzip
+          files: /tmp/build/${{ steps.build_release.outputs.app_id }}-${{ steps.build_release.outputs.version }}.tar.gz
 
       - name: Publish to appstore
         if: ${{ startsWith( steps.tag.outputs.currenttag , 'v' ) && !endsWith( steps.tag.outputs.currenttag , 'nightly' ) }}


### PR DESCRIPTION
This PR

1. updates GitHub actions packages.
2. According to https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ save-state and set-output are deprecated so update to write to the new GITHUB_STATE and GITHUB_OUTPUT environment files
3. Use the concurrency step provided by GitHub to cancel the concurrent workflow on the same PR
https://docs.github.com/en/actions/using-jobs/using-concurrency#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow
4. `actions/create-release` and `actions/upload-release-asset` repos are no longer maintained https://github.com/actions/create-release/issues/119 https://github.com/actions/upload-release-asset/issues/78 so shift to https://github.com/softprops/action-gh-release for release process as it's actively maintained

Related workpackages:

- [OP#47509] : https://community.openproject.org/projects/nextcloud-integration/work_packages/47509
- [OP#47869] : https://community.openproject.org/projects/nextcloud-integration/work_packages/47869