### PR TITLE
[OP#48106] Add a reference provider and a reference widget for work packages

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -15,5 +15,6 @@ $config
 	->notPath('src')
 	->notPath('vendor')
 	->notPath('server')
+	->notPath('lib/Reference/WorkPackageReferenceProvider.php')
 	->in(__DIR__);
 return $config;

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -16,6 +16,8 @@ use OCA\OpenProject\Listener\BeforeUserDeletedListener;
 use OCA\OpenProject\Listener\BeforeGroupDeletedListener;
 use OCA\OpenProject\Listener\LoadSidebarScript;
 use OCA\OpenProject\Listener\UserChangedListener;
+use OCA\OpenProject\Reference\WorkPackageReferenceProvider;
+use OCA\OpenProject\Listener\OpenProjectReferenceListener;
 use OCP\Files\Events\Node\BeforeNodeDeletedEvent;
 use OCP\Files\Events\Node\BeforeNodeRenamedEvent;
 use OCP\IConfig;
@@ -24,6 +26,7 @@ use OCP\INavigationManager;
 use OCP\IURLGenerator;
 use OCP\IUserSession;
 use OCP\Util;
+use OCP\Collaboration\Reference\RenderReferenceEvent;
 
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
@@ -76,6 +79,15 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(
 			BeforeNodeRenamedEvent::class, BeforeNodeInsideOpenProjectGroupfilderChangedListener::class
 		);
+
+		if (version_compare($this->config->getSystemValueString('version', '0.0.0'), '26.0.0', '>=')) {
+			// @phpstan-ignore-next-line - make phpstan not complain in nextcloud version other than 26
+			$context->registerReferenceProvider(WorkPackageReferenceProvider::class);
+			// RenderReferenceEvent is dispatched when we know the smart picker or link previews will be used
+			// so we need to load our scripts at this moment
+			// @phpstan-ignore-next-line - make phpstan not complain in nextcloud version other than 26
+			$context->registerEventListener(RenderReferenceEvent::class, OpenProjectReferenceListener::class);
+		}
 	}
 
 	public function boot(IBootContext $context): void {

--- a/lib/Listener/OpenProjectReferenceListener.php
+++ b/lib/Listener/OpenProjectReferenceListener.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * @copyright Copyright (c) 2023 Julien Veyssier <julien-nc@posteo.net>
+ *
+ * @author Julien Veyssier <julien-nc@posteo.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\OpenProject\Listener;
+
+use OCA\OpenProject\AppInfo\Application;
+use OCP\Collaboration\Reference\RenderReferenceEvent;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\Util;
+
+class OpenProjectReferenceListener implements IEventListener {
+	public function handle(Event $event): void {
+		// @phpstan-ignore-next-line - make phpstan not complain in nextcloud version other than 26
+		if (!$event instanceof RenderReferenceEvent) {
+			return;
+		}
+
+		Util::addScript(Application::APP_ID, Application::APP_ID . '-reference');
+	}
+}

--- a/lib/Reference/WorkPackageReferenceProvider.php
+++ b/lib/Reference/WorkPackageReferenceProvider.php
@@ -1,0 +1,188 @@
+<?php
+
+/**
+ * @copyright Copyright (c) 2023 Julien Veyssier <julien-nc@posteo.net>
+ *
+ * @author Julien Veyssier <julien-nc@posteo.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\OpenProject\Reference;
+
+use OCA\OpenProject\Service\OpenProjectAPIService;
+use OCP\Collaboration\Reference\ADiscoverableReferenceProvider;
+use OCP\Collaboration\Reference\ISearchableReferenceProvider;
+use OCP\Collaboration\Reference\Reference;
+use OC\Collaboration\Reference\ReferenceManager;
+use OCA\OpenProject\AppInfo\Application;
+use OCP\Collaboration\Reference\IReference;
+use OCP\IConfig;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+
+class WorkPackageReferenceProvider extends ADiscoverableReferenceProvider implements ISearchableReferenceProvider {
+	private const RICH_OBJECT_TYPE = Application::APP_ID . '_work_package';
+
+	// as we know we are on NC >= 26, we can use Php 8 syntax for class attributes
+	public function __construct(private IConfig $config,
+								private IL10N $l10n,
+								private IURLGenerator $urlGenerator,
+								private ReferenceManager $referenceManager,
+								private OpenProjectAPIService $openProjectAPIService,
+								private ?string $userId) {
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getId(): string {
+		return 'openproject-work-package-ref';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getTitle(): string {
+		return $this->l10n->t('OpenProject work packages');
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getOrder(): int {
+		return 10;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getIconUrl(): string {
+		return $this->urlGenerator->getAbsoluteURL(
+			$this->urlGenerator->imagePath(Application::APP_ID, 'app-dark.svg')
+		);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getSupportedSearchProviderIds(): array {
+		if ($this->userId !== null) {
+			$ids = [];
+			// take the fallback value from the defaults
+			$searchEnabled = $this->config->getUserValue(
+				$this->userId,
+				Application::APP_ID,
+				'search_enabled',
+				$this->config->getAppValue(Application::APP_ID, 'default_enable_unified_search', '0')
+			);
+			if ($searchEnabled) {
+				$ids[] = 'openproject-search';
+			}
+			return $ids;
+		}
+		return ['openproject-search'];
+	}
+
+	/**
+	 * Parse a link to find a work package ID
+	 *
+	 * @param string $referenceText
+	 *
+	 * @return int|null
+	 */
+	private function getWorkPackageIdFromUrl(string $referenceText): ?int {
+		// example links
+		// https://community.openproject.org/projects/nextcloud-integration/work_packages/40070
+		$openProjectUrl = $this->config->getAppValue(Application::APP_ID, 'openproject_instance_url');
+		preg_match('/^' . preg_quote($openProjectUrl, '/') . '\/projects\/[^\/\?]+\/work_packages\/([0-9]+)/', $referenceText, $matches);
+		if (count($matches) > 1) {
+			return (int) $matches[1];
+		}
+
+		return null;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function matchReference(string $referenceText): bool {
+		if ($this->userId !== null) {
+			$linkPreviewEnabled = $this->config->getUserValue($this->userId, Application::APP_ID, 'link_preview_enabled', '1') === '1';
+			if (!$linkPreviewEnabled) {
+				return false;
+			}
+		}
+		$adminLinkPreviewEnabled = $this->config->getAppValue(Application::APP_ID, 'link_preview_enabled', '1') === '1';
+		if (!$adminLinkPreviewEnabled) {
+			return false;
+		}
+
+		return $this->getWorkPackageIdFromUrl($referenceText) !== null;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function resolveReference(string $referenceText): ?IReference {
+		if ($this->matchReference($referenceText)) {
+			$wpId = $this->getWorkPackageIdFromUrl($referenceText);
+			if ($wpId !== null) {
+				$wpInfo = $this->openProjectAPIService->getWorkPackageInfo($this->userId, $wpId);
+
+				$reference = new Reference($referenceText);
+				// this is used if your custom reference widget cannot be loaded (in mobile/desktop clients for example)
+				$reference->setTitle($wpInfo['title']);
+				$reference->setDescription($wpInfo['description']);
+				$reference->setImageUrl($wpInfo['imageUrl']);
+				// this is the data you will get in your custom reference widget
+				$reference->setRichObject(
+					self::RICH_OBJECT_TYPE,
+					$wpInfo
+				);
+				return $reference;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * We use the userId here because when connecting/disconnecting from the OpenProject account,
+	 * we want to invalidate all the user cache and this is only possible with the cache prefix
+	 * @inheritDoc
+	 */
+	public function getCachePrefix(string $referenceId): string {
+		return $this->userId ?? '';
+	}
+
+	/**
+	 * We don't use the userId here but rather a reference unique id
+	 * @inheritDoc
+	 */
+	public function getCacheKey(string $referenceId): ?string {
+		$wpId = $this->getWorkPackageIdFromUrl($referenceId);
+		return $wpId ?? $referenceId;
+	}
+
+	/**
+	 * @param string $userId
+	 * @return void
+	 */
+	public function invalidateUserCache(string $userId): void {
+		$this->referenceManager->invalidateCache($userId);
+	}
+}

--- a/lib/Search/OpenProjectSearchProvider.php
+++ b/lib/Search/OpenProjectSearchProvider.php
@@ -29,7 +29,6 @@ use OCA\OpenProject\AppInfo\Application;
 use OCP\App\IAppManager;
 use OCP\IL10N;
 use OCP\IConfig;
-use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\Search\IProvider;
 use OCP\Search\ISearchQuery;
@@ -43,8 +42,6 @@ class OpenProjectSearchProvider implements IProvider {
 	/** @var IL10N */
 	private $l10n;
 
-	/** @var IURLGenerator */
-	private $urlGenerator;
 	/**
 	 * @var IConfig
 	 */
@@ -60,18 +57,15 @@ class OpenProjectSearchProvider implements IProvider {
 	 * @param IAppManager $appManager
 	 * @param IL10N $l10n
 	 * @param IConfig $config
-	 * @param IURLGenerator $urlGenerator
 	 * @param OpenProjectAPIService $service
 	 */
 	public function __construct(IAppManager $appManager,
 								IL10N $l10n,
 								IConfig $config,
-								IURLGenerator $urlGenerator,
 								OpenProjectAPIService $service) {
 		$this->appManager = $appManager;
 		$this->l10n = $l10n;
 		$this->config = $config;
-		$this->urlGenerator = $urlGenerator;
 		$this->service = $service;
 	}
 
@@ -135,10 +129,10 @@ class OpenProjectSearchProvider implements IProvider {
 		// @phpstan-ignore-next-line array_map supports also lambda functions
 		$formattedResults = array_map(function (array $entry) use ($openprojectUrl): OpenProjectSearchResultEntry {
 			return new OpenProjectSearchResultEntry(
-				$this->getOpenProjectUserAvatarUrl($entry),
-				$this->getMainText($entry),
-				$this->getSubline($entry),
-				$this->getLinkToOpenProject($entry, $openprojectUrl),
+				$this->service->getOpenProjectUserAvatarUrl($entry),
+				$this->service->getMainText($entry),
+				$this->service->getSubline($entry),
+				$this->service->getLinkToOpenProject($entry, $openprojectUrl),
 				'',
 				true
 			);
@@ -149,70 +143,5 @@ class OpenProjectSearchProvider implements IProvider {
 			$formattedResults,
 			$offset + $limit
 		);
-	}
-
-	/**
-	 * @param array<mixed> $entry
-	 * @return string
-	 */
-	protected function getMainText(array $entry): string {
-		$workPackageType = isset($entry['_links'], $entry['_links']['type'], $entry['_links']['type']['title'])
-			? strtoupper($entry['_links']['type']['title'])
-			: '';
-		$subject = $entry['subject'] ?? '';
-		return $workPackageType . ": " . $subject;
-	}
-
-	/**
-	 * @param array<mixed> $entry
-	 * @return string
-	 */
-	protected function getOpenProjectUserAvatarUrl(array $entry): string {
-		$userIdURL = isset($entry['_links'], $entry['_links']['assignee'], $entry['_links']['assignee']['href'])
-			? $entry['_links']['assignee']['href']
-			: '';
-		$userName = isset($entry['_links'], $entry['_links']['assignee'], $entry['_links']['assignee']['title'])
-			? $entry['_links']['assignee']['title']
-			: '';
-		$userId = preg_replace('/.*\//', "", $userIdURL);
-		return $this->urlGenerator->getAbsoluteURL(
-			'index.php/apps/integration_openproject/avatar?' .
-			"userId" .
-			'=' .
-			$userId .
-			'&' .
-			"userName" .
-			'=' .
-			$userName
-		);
-	}
-
-	/**
-	 * @param array<mixed> $entry
-	 * @return string
-	 */
-	protected function getSubline(array $entry): string {
-		$workPackageID = $entry['id'] ?? '';
-		$status = isset($entry['_links'], $entry['_links']['status'], $entry['_links']['status']['title'])
-			? '[' . $entry['_links']['status']['title'] . '] '
-			: '';
-		$projectTitle = isset($entry['_links'], $entry['_links']['project'], $entry['_links']['project']['title'])
-			? $entry['_links']['project']['title']
-			: '';
-		return "#" . $workPackageID . " " . $status . $projectTitle;
-	}
-
-	/**
-	 * @param array<mixed> $entry
-	 * @param string $url
-	 * @return string
-	 */
-	protected function getLinkToOpenProject(array $entry, string $url): string {
-		$projectId = isset($entry['_links'], $entry['_links']['project'], $entry['_links']['project']['href'])
-			? preg_replace('/.*\//', '', $entry['_links']['project']['href'])
-			: '';
-		return ($projectId !== '')
-			? $url . '/projects/' . $projectId . '/work_packages/' . $entry['id'] . '/activity'
-			: '';
 	}
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,3 +7,5 @@ parameters:
         - bootstrap.php
     checkGenericClassInNonGenericObjectType: false
     reportUnmatchedIgnoredErrors: false
+    excludePaths:
+    	-  './lib/Reference/WorkPackageReferenceProvider.php'

--- a/src/reference.js
+++ b/src/reference.js
@@ -1,0 +1,43 @@
+/**
+ * @copyright Copyright (c) 2023 Julien Veyssier <julien-nc@posteo.net>
+ *
+ * @author Julien Veyssier <julien-nc@posteo.net>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// this requires @nextcloud/vue >= 7.9.0
+import { registerWidget } from '@nextcloud/vue/dist/Components/NcRichText.js'
+
+// this is required for lazy loading
+__webpack_nonce__ = btoa(OC.requestToken) // eslint-disable-line
+__webpack_public_path__ = OC.linkTo('integration_openproject', 'js/') // eslint-disable-line
+
+// this is where we associate our widget component with the richobjects that we return in the reference provider
+registerWidget('integration_openproject_work_package', async (el, { richObjectType, richObject, accessible }) => {
+	// here we lazy load the components so it does not slow down the initial page load
+	const { default: Vue } = await import(/* webpackChunkName: "reference-wp-lazy" */'vue')
+	const { default: WorkPackageReferenceWidget } = await import(/* webpackChunkName: "reference-wp-lazy" */'./views/WorkPackageReferenceWidget.vue')
+	Vue.mixin({ methods: { t, n } })
+	const Widget = Vue.extend(WorkPackageReferenceWidget)
+	new Widget({
+		propsData: {
+			richObjectType,
+			richObject,
+			accessible,
+		},
+	}).$mount(el)
+})

--- a/src/views/WorkPackageReferenceWidget.vue
+++ b/src/views/WorkPackageReferenceWidget.vue
@@ -1,0 +1,126 @@
+<!--
+  - @copyright Copyright (c) 2023 Julien Veyssier <julien-nc@posteo.net>
+  -
+  - @author 2023 Julien Veyssier <julien-nc@posteo.net>
+  -
+  - @license GNU AGPL version 3 or any later version
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<template>
+	<div class="work-package-reference">
+		<div v-if="isError">
+			<h3 class="error-title">
+				<CloseIcon :size="20" class="icon" />
+				<span>{{ t('integration_openproject', 'OpenProject API error') }}</span>
+			</h3>
+			<a :href="settingsUrl" class="settings-link external" target="_blank">
+				<OpenInNewIcon :size="20" class="icon" />
+				{{ t('integration_openproject', 'OpenProject settings') }}
+			</a>
+		</div>
+		<div v-else class="work-package-wrapper">
+			{{ richObject.title }}
+		</div>
+	</div>
+</template>
+
+<script>
+import CloseIcon from 'vue-material-design-icons/Close.vue'
+import OpenInNewIcon from 'vue-material-design-icons/OpenInNew.vue'
+import { generateUrl } from '@nextcloud/router'
+
+export default {
+	name: 'WorkPackageReferenceWidget',
+
+	components: {
+		OpenInNewIcon,
+		CloseIcon,
+	},
+
+	props: {
+		richObjectType: {
+			type: String,
+			default: '',
+		},
+		richObject: {
+			type: Object,
+			default: null,
+		},
+		accessible: {
+			type: Boolean,
+			default: true,
+		},
+	},
+
+	data() {
+		return {
+			settingsUrl: generateUrl('/settings/user/openproject'),
+		}
+	},
+
+	computed: {
+		isError() {
+			return !!this.richObject.error
+		},
+	},
+
+	methods: {
+	},
+}
+</script>
+
+<style scoped lang="scss">
+.work-package-reference {
+	width: 100%;
+	white-space: normal;
+	padding: 12px;
+
+	a {
+		padding: 0 !important;
+		color: var(--color-main-text) !important;
+		text-decoration: unset !important;
+	}
+
+	.error-title {
+		display: flex;
+		align-items: center;
+		font-weight: bold;
+		margin-top: 0;
+		.icon {
+			margin-right: 8px;
+		}
+	}
+
+	.work-package-wrapper {
+		width: 100%;
+		display: flex;
+		align-items: start;
+
+	}
+
+	.settings-link {
+		display: flex;
+		align-items: center;
+		.icon {
+			margin-right: 4px;
+		}
+	}
+
+	.spacer {
+		flex-grow: 1;
+	}
+}
+</style>

--- a/webpack.js
+++ b/webpack.js
@@ -19,6 +19,7 @@ webpackConfig.entry = {
 	dashboard: { import: path.join(__dirname, 'src', 'dashboard.js'), filename: appId + '-dashboard.js' },
 	'openproject-tab': { import: path.join(__dirname, 'src', 'projectTab.js'), filename: appId + '-projectTab.js' },
 	fileActions: { import: path.join(__dirname, 'src', 'fileActions.js'), filename: appId + '-fileActions.js' },
+	reference: { import: path.join(__dirname, 'src', 'reference.js'), filename: appId + '-reference.js' },
 }
 
 webpackConfig.plugins.push(


### PR DESCRIPTION
This is just the structure, the provider and the widget do nothing at the moment.
This requires https://github.com/nextcloud/integration_openproject/pull/380 as the widget registration function appeared recently in `@nextcloud/vue` and the latest `@nextcloud/webpack-vue-config` is required.

The registration of the reference provider and of the widget only happen on NC >= 26.

The reference system is documented there: https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/reference.html

The reference provider has 2 goals:
* Add a smart picker provider so users can get work package links
* Resolve and render work package link previews

### The smart picker

There are 2 ways to implement a smart picker provider. This PR implements the first one.

1. Just use a unified search provider and let the picker show a generic rendering for the provider (like for other apps like integration_github, integration_gitlab, collectives, deck, tables...). In this case there is nothing to implement on the frontend side. Users can perform a basic search and the picker result is the "resourceUrl" of the selected search result entry.
2. It is possible to register a custom picker component to have a custom interface. For example, this is done in integration_openstreetmap (it shows a map to get a location link), in integration_giphy (it shows a GIF picker with a grid view and infinite scrolling) etc...

We can start by implementing the first one and see if it makes sense to have a custom picker later. It would allow us to add search options for example.

### The link previews (reference widgets)

If a reference provider recognizes a link that it can handle, it resolves it and provides information for the frontend.
If only the generic title, description and image are set, the default rendering will be used.
The rendering can be customized if a rich object is set and a widget component is registered for this rich object type.
This is done in this PR.

Related workpackage: https://community.openproject.org/projects/nextcloud-integration/work_packages/48106/activity