### PR TITLE
Add tag name in the upload artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,17 +81,9 @@ jobs:
         with:
           tag_name: ${{ steps.tag.outputs.currenttag }}
           name: ${{ steps.tag.outputs.currenttag }}
+          files: /tmp/build/${{ steps.build_release.outputs.app_id }}-${{ steps.build_release.outputs.version }}.tar.gz
           draft: false
           prerelease: false
-
-      - name: Upload Release Asset
-        if: ${{ startsWith( steps.tag.outputs.currenttag , 'v' ) }}
-        id: upload-release-asset
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: ${{ steps.tag.outputs.currenttag }}
-          name: ${{ steps.tag.outputs.currenttag }}
-          files: /tmp/build/${{ steps.build_release.outputs.app_id }}-${{ steps.build_release.outputs.version }}.tar.gz
 
       - name: Publish to appstore
         if: ${{ startsWith( steps.tag.outputs.currenttag , 'v' ) && !endsWith( steps.tag.outputs.currenttag , 'nightly' ) }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,8 @@ jobs:
         id: upload-release-asset
         uses: softprops/action-gh-release@v1
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          tag_name: ${{ steps.tag.outputs.currenttag }}
+          name: ${{ steps.tag.outputs.currenttag }}
           files: /tmp/build/${{ steps.build_release.outputs.app_id }}-${{ steps.build_release.outputs.version }}.tar.gz
 
       - name: Publish to appstore


### PR DESCRIPTION
In the recent release we got an error https://github.com/nextcloud/integration_openproject/actions/runs/4871023942/jobs/8687484590

Since we recently updated the github packages in https://github.com/nextcloud/integration_openproject/pull/395 , these changes were not tested against the release workflow. This PR hopefully fixes that