### PR TITLE
[op#48127]Add new params as required by the constructor of FolderManager class

### DIFF
--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -22,6 +22,7 @@ use OCA\OpenProject\AppInfo\Application;
 use OCA\OpenProject\Exception\OpenprojectErrorException;
 use OCA\OpenProject\Exception\OpenprojectResponseException;
 use OCP\App\IAppManager;
+use OCP\Files\IMimeTypeLoader;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
@@ -377,7 +378,8 @@ class OpenProjectAPIServiceTest extends TestCase {
 			$this->createMock(IGroupManager::class),
 			$this->createMock(IAppManager::class),
 			$this->createMock(IDBConnection::class),
-			$this->createMock(ISubAdmin::class)
+			$this->createMock(ISubAdmin::class),
+			$this->createMock(IMimeTypeLoader::class)
 		);
 	}
 
@@ -436,6 +438,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 					$appManagerMock,
 					$this->createMock(IDBConnection::class),
 					$subAdminManagerMock,
+					$this->createMock(IMimeTypeLoader::class)
 				])
 			->onlyMethods($onlyMethods)
 			->getMock();
@@ -1315,6 +1318,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 			$this->createMock(IAppManager::class),
 			$this->createMock(IDBConnection::class),
 			$this->createMock(ISubAdmin::class),
+			$this->createMock(IMimeTypeLoader::class)
 		);
 
 		$response = $service->request('', '', []);


### PR DESCRIPTION
The API tests were failing in CI and locally with 
```
"Too few arguments to function OCA\\GroupFolders\\Folder\\FolderManager::__construct(), 1 passed in /home/swikriti/www/nextcloud/master/apps/integration_openproject/lib/Service/OpenProjectAPIService.php on line 963 and exactly 4 expected in file '/home/swikriti/www/nextcloud/master/apps/groupfolders/lib/Folder/FolderManager.php' line 50",
```
There was a new beta release of the group folders app https://github.com/nextcloud/groupfolders/releases/tag/v15.0.0-beta1 
Seems like there were certain updates in FolderManager class in the latest version that added new values in the constructor. As these changes were made in the latest version of the app, they should only be supported by the latest master. This PR adds the new required parameters.

Related work package: https://community.openproject.org/projects/nextcloud-integration/work_packages/48127