### PR TITLE
[OP#48128] Don't use user Alice in tests and delete user in after scenario

### DIFF
--- a/tests/acceptance/features/api/directUpload.feature
+++ b/tests/acceptance/features/api/directUpload.feature
@@ -9,11 +9,11 @@ Feature: API endpoint for direct upload
   So that the long requests for uploading don't block any resources on the OpenProject back-end.
 
   Background:
-    Given user "Alice" has been created
+    Given user "Carol" has been created
 
 
   Scenario Outline: Send a file to the direct-upload endpoint
-    Given user "Alice" got a direct-upload token for "/"
+    Given user "Carol" got a direct-upload token for "/"
     When an anonymous user sends a multipart form data POST request to the "direct-upload/%last-created-direct-upload-token%" endpoint with:
       | file_name | "<valid-file-name>" |
       | data      | some data           |
@@ -32,7 +32,7 @@ Feature: API endpoint for direct upload
       }
     }
     """
-    And the content of file at "<file-name>" for user "Alice" should be "some data"
+    And the content of file at "<file-name>" for user "Carol" should be "some data"
     Examples:
       | valid-file-name     | file-name       | pattern                     |
       | textfile0.txt       | textfile0.txt   | textfile0\\.txt             |
@@ -44,7 +44,7 @@ Feature: API endpoint for direct upload
 
 
   Scenario: Send an invalid filename to the direct-upload endpoint
-    Given user "Alice" got a direct-upload token for "/"
+    Given user "Carol" got a direct-upload token for "/"
     When an anonymous user sends a multipart form data POST request to the "direct-upload/%last-created-direct-upload-token%" endpoint with:
       | file_name | "         " |
       | data      | some data   |
@@ -64,7 +64,7 @@ Feature: API endpoint for direct upload
 
   Scenario: Send an empty filename to the direct-upload endpoint or exceed max_post_size
     # we cannot distinguish both cases
-    Given user "Alice" got a direct-upload token for "/"
+    Given user "Carol" got a direct-upload token for "/"
     When an anonymous user sends a multipart form data POST request to the "direct-upload/%last-created-direct-upload-token%" endpoint with:
       | file_name | ""          |
       | data      | some data   |
@@ -105,8 +105,8 @@ Feature: API endpoint for direct upload
 
 
   Scenario: Send a file with a filename that already exists (no overwrite parameter)
-    Given user "Alice" has uploaded file with content "original data" to "/file.txt"
-    And user "Alice" got a direct-upload token for "/"
+    Given user "Carol" has uploaded file with content "original data" to "/file.txt"
+    And user "Carol" got a direct-upload token for "/"
     When an anonymous user sends a multipart form data POST request to the "direct-upload/%last-created-direct-upload-token%" endpoint with:
       | file_name | file.txt     |
       | data      | changed data |
@@ -123,13 +123,13 @@ Feature: API endpoint for direct upload
       }
     }
     """
-    And the content of file at "/file.txt" for user "Alice" should be "original data"
+    And the content of file at "/file.txt" for user "Carol" should be "original data"
 
 
   Scenario: Folder is deleted before upload happens
-    Given user "Alice" has created folder "/forOP"
-    And user "Alice" got a direct-upload token for "/forOP"
-    And user "Alice" has deleted folder "/forOP"
+    Given user "Carol" has created folder "/forOP"
+    And user "Carol" got a direct-upload token for "/forOP"
+    And user "Carol" has deleted folder "/forOP"
     When an anonymous user sends a multipart form data POST request to the "direct-upload/%last-created-direct-upload-token%" endpoint with:
       | file_name | file.txt  |
       | data      | some data |
@@ -149,10 +149,10 @@ Feature: API endpoint for direct upload
 
 
   Scenario: Folder is deleted and recreated (new fileid) before upload happens
-    Given user "Alice" has created folder "/forOP"
-    And user "Alice" got a direct-upload token for "/forOP"
-    And user "Alice" has deleted folder "/forOP"
-    And user "Alice" has created folder "/forOP"
+    Given user "Carol" has created folder "/forOP"
+    And user "Carol" got a direct-upload token for "/forOP"
+    And user "Carol" has deleted folder "/forOP"
+    And user "Carol" has created folder "/forOP"
     When an anonymous user sends a multipart form data POST request to the "direct-upload/%last-created-direct-upload-token%" endpoint with:
       | file_name | file.txt  |
       | data      | some data |
@@ -172,10 +172,10 @@ Feature: API endpoint for direct upload
 
 
   Scenario Outline: Folder is renamed before upload happens
-    Given user "Alice" has created folder "/forOP"
-    And user "Alice" has created folder "/secondfolder"
-    And user "Alice" got a direct-upload token for "/forOP"
-    And user "Alice" has renamed folder "/forOP" to "<rename-destination>"
+    Given user "Carol" has created folder "/forOP"
+    And user "Carol" has created folder "/secondfolder"
+    And user "Carol" got a direct-upload token for "/forOP"
+    And user "Carol" has renamed folder "/forOP" to "<rename-destination>"
     When an anonymous user sends a multipart form data POST request to the "direct-upload/%last-created-direct-upload-token%" endpoint with:
       | file_name | file.txt  |
       | data      | some data |
@@ -194,7 +194,7 @@ Feature: API endpoint for direct upload
       }
     }
     """
-    And the content of file at "<rename-destination>/file.txt" for user "Alice" should be "some data"
+    And the content of file at "<rename-destination>/file.txt" for user "Carol" should be "some data"
     Examples:
       | rename-destination  |
       | /renamed            |
@@ -206,12 +206,12 @@ Feature: API endpoint for direct upload
     And user "Chandra" has been created
     And user "Dipak" has been created
     And user "Brian" has created folder "/toShare"
-    And user "Brian" has shared folder "/toShare" with user "Alice" with "all" permissions
+    And user "Brian" has shared folder "/toShare" with user "Carol" with "all" permissions
     And user "Brian" has shared folder "/toShare" with user "Chandra" with "all" permissions
     And user "Brian" has shared folder "/toShare" with user "Dipak" with "all" permissions
-    And user "Chandra" has shared folder "/toShare" with user "Alice" with "all" permissions
-    And user "Dipak" has shared folder "/toShare" with user "Alice" with "all" permissions
-    And user "Alice" got a direct-upload token for "/toShare"
+    And user "Chandra" has shared folder "/toShare" with user "Carol" with "all" permissions
+    And user "Dipak" has shared folder "/toShare" with user "Carol" with "all" permissions
+    And user "Carol" got a direct-upload token for "/toShare"
     When an anonymous user sends a multipart form data POST request to the "direct-upload/%last-created-direct-upload-token%" endpoint with:
       | file_name | file.txt  |
       | data      | some data |
@@ -232,7 +232,7 @@ Feature: API endpoint for direct upload
     """
 
   Scenario: Use the same token after one successful upload
-    Given user "Alice" got a direct-upload token for "/"
+    Given user "Carol" got a direct-upload token for "/"
     And an anonymous user has sent a multipart form data POST request to the "direct-upload/%last-created-direct-upload-token%" endpoint with:
       | file_name | testfile.txt |
       | data      | some data    |
@@ -254,7 +254,7 @@ Feature: API endpoint for direct upload
     """
 
   Scenario: Use the same token after one unsuccessful upload
-    Given user "Alice" got a direct-upload token for "/"
+    Given user "Carol" got a direct-upload token for "/"
     When an anonymous user sends a multipart form data POST request to the "direct-upload/%last-created-direct-upload-token%" endpoint with:
       | file_name | ""        |
       | data      | some data |
@@ -277,8 +277,8 @@ Feature: API endpoint for direct upload
     """
 
   Scenario: use a token created by a user that was disabled after creating the token
-    Given user "Alice" got a direct-upload token for "/"
-    And user "Alice" has been disabled
+    Given user "Carol" got a direct-upload token for "/"
+    And user "Carol" has been disabled
     When an anonymous user sends a multipart form data POST request to the "direct-upload/%last-created-direct-upload-token%" endpoint with:
       | file_name | file.txt  |
       | data      | some data |
@@ -298,8 +298,8 @@ Feature: API endpoint for direct upload
 
 
   Scenario: use a token created by a user that was deleted after creating the token
-    Given user "Alice" got a direct-upload token for "/"
-    And user "Alice" has been deleted
+    Given user "Carol" got a direct-upload token for "/"
+    And user "Carol" has been deleted
     When an anonymous user sends a multipart form data POST request to the "direct-upload/%last-created-direct-upload-token%" endpoint with:
       | file_name | file.txt  |
       | data      | some data |
@@ -319,9 +319,9 @@ Feature: API endpoint for direct upload
 
 
   Scenario: use a token created by a user that was deleted and recreated after creating the token
-    Given user "Alice" got a direct-upload token for "/"
-    And user "Alice" has been deleted
-    And user "Alice" has been created
+    Given user "Carol" got a direct-upload token for "/"
+    And user "Carol" has been deleted
+    And user "Carol" has been created
     When an anonymous user sends a multipart form data POST request to the "direct-upload/%last-created-direct-upload-token%" endpoint with:
       | file_name | file.txt  |
       | data      | some data |
@@ -343,8 +343,8 @@ Feature: API endpoint for direct upload
   Scenario: send file to a share without create permissions
     Given user "Brian" has been created
     And user "Brian" has created folder "/toShare"
-    And user "Brian" has shared folder "/toShare" with user "Alice" with "all" permissions
-    And user "Alice" got a direct-upload token for "/toShare"
+    And user "Brian" has shared folder "/toShare" with user "Carol" with "all" permissions
+    And user "Carol" got a direct-upload token for "/toShare"
     And user "Brian" has changed the share permissions of last created share to "read+update+delete+share"
     When an anonymous user sends a multipart form data POST request to the "direct-upload/%last-created-direct-upload-token%" endpoint with:
       | file_name | file.txt |
@@ -367,8 +367,8 @@ Feature: API endpoint for direct upload
     Given user "Brian" has been created
     And user "Brian" has created folder "/toShare"
     And user "Brian" has uploaded file with content "original data" to "/toShare/file.txt"
-    And user "Brian" has shared folder "/toShare" with user "Alice" with "all" permissions
-    And user "Alice" got a direct-upload token for "/toShare"
+    And user "Brian" has shared folder "/toShare" with user "Carol" with "all" permissions
+    And user "Carol" got a direct-upload token for "/toShare"
     And user "Brian" has changed the share permissions of last created share to "read+update+delete+share"
     When an anonymous user sends a multipart form data POST request to the "direct-upload/%last-created-direct-upload-token%" endpoint with:
       | file_name | file.txt |
@@ -389,13 +389,13 @@ Feature: API endpoint for direct upload
       }
     }
     """
-    And the content of file at "/toShare/file.txt" for user "Alice" should be "new data"
+    And the content of file at "/toShare/file.txt" for user "Carol" should be "new data"
     And the content of file at "/toShare/file.txt" for user "Brian" should be "new data"
 
 
   Scenario: set overwrite to false and send file with an existing filename
-    Given user "Alice" has uploaded file with content "original data" to "/file.txt"
-    And user "Alice" got a direct-upload token for "/"
+    Given user "Carol" has uploaded file with content "original data" to "/file.txt"
+    And user "Carol" got a direct-upload token for "/"
     When an anonymous user sends a multipart form data POST request to the "direct-upload/%last-created-direct-upload-token%" endpoint with:
       | file_name | file.txt |
       | data      | new data |
@@ -415,15 +415,15 @@ Feature: API endpoint for direct upload
       }
     }
     """
-    And the content of file at "/file.txt" for user "Alice" should be "original data"
-    And the content of file at "/file (2).txt" for user "Alice" should be "new data"
+    And the content of file at "/file.txt" for user "Carol" should be "original data"
+    And the content of file at "/file (2).txt" for user "Carol" should be "new data"
 
 
   Scenario: set overwrite to false and send file with an existing filename, also files with that name and suffixed numbers also exist
-    Given user "Alice" has uploaded file with content "data 1" to "/file.txt"
-    And user "Alice" has uploaded file with content "data 2" to "/file (2).txt"
-    And user "Alice" has uploaded file with content "data 3" to "/file (3).txt"
-    And user "Alice" got a direct-upload token for "/"
+    Given user "Carol" has uploaded file with content "data 1" to "/file.txt"
+    And user "Carol" has uploaded file with content "data 2" to "/file (2).txt"
+    And user "Carol" has uploaded file with content "data 3" to "/file (3).txt"
+    And user "Carol" got a direct-upload token for "/"
     When an anonymous user sends a multipart form data POST request to the "direct-upload/%last-created-direct-upload-token%" endpoint with:
       | file_name | file.txt |
       | data      | new data |
@@ -443,15 +443,15 @@ Feature: API endpoint for direct upload
       }
     }
     """
-    And the content of file at "/file.txt" for user "Alice" should be "data 1"
-    And the content of file at "/file (2).txt" for user "Alice" should be "data 2"
-    And the content of file at "/file (3).txt" for user "Alice" should be "data 3"
-    And the content of file at "/file (4).txt" for user "Alice" should be "new data"
+    And the content of file at "/file.txt" for user "Carol" should be "data 1"
+    And the content of file at "/file (2).txt" for user "Carol" should be "data 2"
+    And the content of file at "/file (3).txt" for user "Carol" should be "data 3"
+    And the content of file at "/file (4).txt" for user "Carol" should be "new data"
 
 
   Scenario: set overwrite to false and send file with an existing filename (filename has already a number in brackets)
-    Given user "Alice" has uploaded file with content "original data" to "/file (2).txt"
-    And user "Alice" got a direct-upload token for "/"
+    Given user "Carol" has uploaded file with content "original data" to "/file (2).txt"
+    And user "Carol" got a direct-upload token for "/"
     When an anonymous user sends a multipart form data POST request to the "direct-upload/%last-created-direct-upload-token%" endpoint with:
       | file_name | file (2).txt |
       | data      | new data     |
@@ -471,13 +471,13 @@ Feature: API endpoint for direct upload
       }
     }
     """
-    And the content of file at "/file (2).txt" for user "Alice" should be "original data"
-    And the content of file at "/file (3).txt" for user "Alice" should be "new data"
+    And the content of file at "/file (2).txt" for user "Carol" should be "original data"
+    And the content of file at "/file (3).txt" for user "Carol" should be "new data"
 
 
   Scenario: set overwrite to true and send file with an existing filename
-    Given user "Alice" has uploaded file with content "original data" to "/file.txt"
-    And user "Alice" got a direct-upload token for "/"
+    Given user "Carol" has uploaded file with content "original data" to "/file.txt"
+    And user "Carol" got a direct-upload token for "/"
     When an anonymous user sends a multipart form data POST request to the "direct-upload/%last-created-direct-upload-token%" endpoint with:
       | file_name | file.txt |
       | data      | new data |
@@ -497,14 +497,14 @@ Feature: API endpoint for direct upload
       }
     }
     """
-    And the content of file at "/file.txt" for user "Alice" should be "new data"
+    And the content of file at "/file.txt" for user "Carol" should be "new data"
 
 
   Scenario: set overwrite to true and send file with an existing filename, but no permissions to overwrite
     Given user "Brian" has been created
     And user "Brian" has uploaded file with content "original data" to "/file.txt"
-    And user "Brian" has shared file "/file.txt" with user "Alice" with "read" permissions
-    And user "Alice" got a direct-upload token for "/"
+    And user "Brian" has shared file "/file.txt" with user "Carol" with "read" permissions
+    And user "Carol" got a direct-upload token for "/"
     When an anonymous user sends a multipart form data POST request to the "direct-upload/%last-created-direct-upload-token%" endpoint with:
       | file_name | file.txt |
       | data      | new data |
@@ -522,12 +522,12 @@ Feature: API endpoint for direct upload
       }
     }
     """
-    And the content of file at "/file.txt" for user "Alice" should be "original data"
+    And the content of file at "/file.txt" for user "Carol" should be "original data"
 
 
   Scenario Outline: set overwrite to an invalid value
-    Given user "Alice" has uploaded file with content "original data" to "/file.txt"
-    And user "Alice" got a direct-upload token for "/"
+    Given user "Carol" has uploaded file with content "original data" to "/file.txt"
+    And user "Carol" got a direct-upload token for "/"
     When an anonymous user sends a multipart form data POST request to the "direct-upload/%last-created-direct-upload-token%" endpoint with:
       | file_name | file.txt    |
       | data      | new data    |
@@ -551,7 +551,7 @@ Feature: API endpoint for direct upload
       }
     }
     """
-    And the content of file at "/file.txt" for user "Alice" should be "original data"
+    And the content of file at "/file.txt" for user "Carol" should be "original data"
     Examples:
       | overwrite |
       | 1         |
@@ -562,7 +562,7 @@ Feature: API endpoint for direct upload
 
 
   Scenario: CORS preflight request
-    Given user "Alice" got a direct-upload token for "/"
+    Given user "Carol" got a direct-upload token for "/"
     When an anonymous user sends an OPTIONS request to the "direct-upload/%last-created-direct-upload-token%" endpoint with these headers:
       | header                         | value                    |
       | Access-Control-Request-Method  | POST                     |
@@ -576,7 +576,7 @@ Feature: API endpoint for direct upload
 
 
   Scenario Outline: set overwrite and send a new file
-    Given user "Alice" got a direct-upload token for "/"
+    Given user "Carol" got a direct-upload token for "/"
     When an anonymous user sends a multipart form data POST request to the "direct-upload/%last-created-direct-upload-token%" endpoint with:
       | file_name | file.txt    |
       | data      | new data    |
@@ -596,7 +596,7 @@ Feature: API endpoint for direct upload
       }
     }
     """
-    And the content of file at "/file.txt" for user "Alice" should be "new data"
+    And the content of file at "/file.txt" for user "Carol" should be "new data"
     Examples:
       | overwrite |
       | true      |
@@ -604,8 +604,8 @@ Feature: API endpoint for direct upload
 
 
   Scenario: set overwrite to true and send a file with an existing folder name
-    Given user "Alice" has created folder "file.txt"
-    And user "Alice" got a direct-upload token for "/"
+    Given user "Carol" has created folder "file.txt"
+    And user "Carol" got a direct-upload token for "/"
     When an anonymous user sends a multipart form data POST request to the "direct-upload/%last-created-direct-upload-token%" endpoint with:
       | file_name | file.txt |
       | data      | new data |
@@ -632,8 +632,8 @@ Feature: API endpoint for direct upload
 
 
   Scenario: set overwrite to false and send a file with an existing folder name
-    Given user "Alice" has created folder "file.txt"
-    And user "Alice" got a direct-upload token for "/"
+    Given user "Carol" has created folder "file.txt"
+    And user "Carol" got a direct-upload token for "/"
     When an anonymous user sends a multipart form data POST request to the "direct-upload/%last-created-direct-upload-token%" endpoint with:
       | file_name | file.txt |
       | data      | new data |
@@ -653,12 +653,12 @@ Feature: API endpoint for direct upload
       }
     }
     """
-    And the content of file at "/file (2).txt" for user "Alice" should be "new data"
+    And the content of file at "/file (2).txt" for user "Carol" should be "new data"
 
 
   Scenario: don't set overwrite and send a file with an existing folder name
-    Given user "Alice" has created folder "file.txt"
-    And user "Alice" got a direct-upload token for "/"
+    Given user "Carol" has created folder "file.txt"
+    And user "Carol" got a direct-upload token for "/"
     When an anonymous user sends a multipart form data POST request to the "direct-upload/%last-created-direct-upload-token%" endpoint with:
       | file_name | file.txt |
       | data      | new data |
@@ -678,8 +678,8 @@ Feature: API endpoint for direct upload
 
 
   Scenario: Upload a file that just fits into the users quota
-    Given the quota of user "Alice" has been set to "10 B"
-    And user "Alice" got a direct-upload token for "/"
+    Given the quota of user "Carol" has been set to "10 B"
+    And user "Carol" got a direct-upload token for "/"
     When an anonymous user sends a multipart form data POST request to the "direct-upload/%last-created-direct-upload-token%" endpoint with:
       | file_name | textfile0.txt |
       | data      | 1234567890    |
@@ -698,12 +698,12 @@ Feature: API endpoint for direct upload
       }
     }
     """
-    And the content of file at "textfile0.txt" for user "Alice" should be "1234567890"
+    And the content of file at "textfile0.txt" for user "Carol" should be "1234567890"
 
 
   Scenario: Upload a file exceeding the users quota
-    Given the quota of user "Alice" has been set to "9 B"
-    And user "Alice" got a direct-upload token for "/"
+    Given the quota of user "Carol" has been set to "9 B"
+    And user "Carol" got a direct-upload token for "/"
     When an anonymous user sends a multipart form data POST request to the "direct-upload/%last-created-direct-upload-token%" endpoint with:
       | file_name | file.txt   |
       | data      | 1234567890 |
@@ -723,9 +723,9 @@ Feature: API endpoint for direct upload
 
 
   Scenario: Upload a file into a folder, exceeding the users quota
-    Given the quota of user "Alice" has been set to "9 B"
-    And user "Alice" has created folder "/forOP"
-    And user "Alice" got a direct-upload token for "/forOP"
+    Given the quota of user "Carol" has been set to "9 B"
+    And user "Carol" has created folder "/forOP"
+    And user "Carol" got a direct-upload token for "/forOP"
     When an anonymous user sends a multipart form data POST request to the "direct-upload/%last-created-direct-upload-token%" endpoint with:
       | file_name | file.txt   |
       | data      | 1234567890 |
@@ -746,11 +746,11 @@ Feature: API endpoint for direct upload
 
   Scenario: Upload a file into a shared folder exceeding the quota of the user sharing the folder
     Given user "Brian" has been created
-    And the quota of user "Alice" has been set to "10 B"
+    And the quota of user "Carol" has been set to "10 B"
     And the quota of user "Brian" has been set to "9 B"
     And user "Brian" has created folder "/toShare"
-    And user "Brian" has shared folder "/toShare" with user "Alice" with "all" permissions
-    And user "Alice" got a direct-upload token for "/toShare"
+    And user "Brian" has shared folder "/toShare" with user "Carol" with "all" permissions
+    And user "Carol" got a direct-upload token for "/toShare"
     When an anonymous user sends a multipart form data POST request to the "direct-upload/%last-created-direct-upload-token%" endpoint with:
       | file_name | file.txt   |
       | data      | 1234567890 |
@@ -771,11 +771,11 @@ Feature: API endpoint for direct upload
 
   Scenario: Upload a file into a shared folder exceeding the quota of sharee but not that of sharer
     Given user "Brian" has been created
-    And the quota of user "Alice" has been set to "10 B"
+    And the quota of user "Carol" has been set to "10 B"
     And the quota of user "Brian" has been set to "20 B"
     And user "Brian" has created folder "/toShare"
-    And user "Brian" has shared folder "/toShare" with user "Alice" with "all" permissions
-    And user "Alice" got a direct-upload token for "/toShare"
+    And user "Brian" has shared folder "/toShare" with user "Carol" with "all" permissions
+    And user "Carol" got a direct-upload token for "/toShare"
     When an anonymous user sends a multipart form data POST request to the "direct-upload/%last-created-direct-upload-token%" endpoint with:
       | file_name | file.txt        |
       | data      | 123456789012345 |
@@ -794,14 +794,14 @@ Feature: API endpoint for direct upload
       }
     }
     """
-    And the content of file at "/toShare/file.txt" for user "Alice" should be "123456789012345"
+    And the content of file at "/toShare/file.txt" for user "Carol" should be "123456789012345"
     And the content of file at "/toShare/file.txt" for user "Brian" should be "123456789012345"
 
 
   Scenario: overwrite an existing file with content that fits the quota. Needed quota is sizeof(old data)+sizeof(new data)
-    Given the quota of user "Alice" has been set to "20 B"
-    And user "Alice" has uploaded file with content "1234567890" to "/file.txt"
-    And user "Alice" got a direct-upload token for "/"
+    Given the quota of user "Carol" has been set to "20 B"
+    And user "Carol" has uploaded file with content "1234567890" to "/file.txt"
+    And user "Carol" got a direct-upload token for "/"
     When an anonymous user sends a multipart form data POST request to the "direct-upload/%last-created-direct-upload-token%" endpoint with:
       | file_name | file.txt   |
       | data      | 0987654321 |
@@ -821,13 +821,13 @@ Feature: API endpoint for direct upload
       }
     }
     """
-    And the content of file at "/file.txt" for user "Alice" should be "0987654321"
+    And the content of file at "/file.txt" for user "Carol" should be "0987654321"
 
 
   Scenario: try to overwrite an existing file with content that exceeds the quota. Needed quota is sizeof(old data)+sizeof(new data)
-    Given the quota of user "Alice" has been set to "19 B"
-    And user "Alice" has uploaded file with content "1234567890" to "/file.txt"
-    And user "Alice" got a direct-upload token for "/"
+    Given the quota of user "Carol" has been set to "19 B"
+    And user "Carol" has uploaded file with content "1234567890" to "/file.txt"
+    And user "Carol" got a direct-upload token for "/"
     When an anonymous user sends a multipart form data POST request to the "direct-upload/%last-created-direct-upload-token%" endpoint with:
       | file_name | file.txt   |
       | data      | 0987654321 |
@@ -845,11 +845,11 @@ Feature: API endpoint for direct upload
       }
     }
     """
-    And the content of file at "/file.txt" for user "Alice" should be "1234567890"
+    And the content of file at "/file.txt" for user "Carol" should be "1234567890"
 
 
   Scenario: Try to upload a file with a blacklisted file name
-    Given user "Alice" got a direct-upload token for "/"
+    Given user "Carol" got a direct-upload token for "/"
     When an anonymous user sends a multipart form data POST request to the "direct-upload/%last-created-direct-upload-token%" endpoint with:
       | file_name | .htaccess              |
       | data      | <IfModule mod_alias.c> |
@@ -869,7 +869,7 @@ Feature: API endpoint for direct upload
 
 
   Scenario: upload a hidden file
-    Given user "Alice" got a direct-upload token for "/"
+    Given user "Carol" got a direct-upload token for "/"
     When an anonymous user sends a multipart form data POST request to the "direct-upload/%last-created-direct-upload-token%" endpoint with:
       | file_name | .hidden     |
       | data      | hidden file |
@@ -888,6 +888,6 @@ Feature: API endpoint for direct upload
       }
     }
     """
-    And the content of file at "/.hidden" for user "Alice" should be "hidden file"
+    And the content of file at "/.hidden" for user "Carol" should be "hidden file"
 
 

--- a/tests/acceptance/features/api/directUploadPrepare.feature
+++ b/tests/acceptance/features/api/directUploadPrepare.feature
@@ -9,11 +9,11 @@ Feature: API endpoint to prepare direct upload
   So that the long requests for uploading don't block any resources on the OpenProject back-end.
 
   Background:
-    Given user "Alice" has been created
+    Given user "Carol" has been created
 
   Scenario Outline: Get a direct-upload token for a folder
-    Given user "Alice" has created folder <folder>
-    When user "Alice" sends a POST request to the direct-upload-token endpoint with the ID of <folder>
+    Given user "Carol" has created folder <folder>
+    When user "Carol" sends a POST request to the direct-upload-token endpoint with the ID of <folder>
     Then the HTTP status code should be "200"
     And the data of the response should match
     """"
@@ -39,7 +39,7 @@ Feature: API endpoint to prepare direct upload
 
 
   Scenario: Try to get a direct-upload token for the root folder
-    When user "Alice" sends a POST request to the direct-upload-token endpoint with the ID of "/"
+    When user "Carol" sends a POST request to the direct-upload-token endpoint with the ID of "/"
     Then the HTTP status code should be "200"
     And the data of the response should match
     """"
@@ -60,8 +60,8 @@ Feature: API endpoint to prepare direct upload
   Scenario Outline: Get a direct-upload token for a folder received as share
     Given user "Brian" has been created
     And user "Brian" has created folder "/toShare"
-    And user "Brian" has shared folder "/toShare" with user "Alice" with "<permissions>" permissions
-    When user "Alice" sends a POST request to the direct-upload-token endpoint with the ID of "/toShare"
+    And user "Brian" has shared folder "/toShare" with user "Carol" with "<permissions>" permissions
+    When user "Carol" sends a POST request to the direct-upload-token endpoint with the ID of "/toShare"
     Then the HTTP status code should be "200"
     And the data of the response should match
     """"
@@ -87,8 +87,8 @@ Feature: API endpoint to prepare direct upload
 
 
   Scenario: Try to get a direct-upload token for a file
-    Given user "Alice" has uploaded file with content "some data" to "/file.txt"
-    When user "Alice" sends a POST request to the direct-upload-token endpoint with the ID of "/file.txt"
+    Given user "Carol" has uploaded file with content "some data" to "/file.txt"
+    When user "Carol" sends a POST request to the direct-upload-token endpoint with the ID of "/file.txt"
     Then the HTTP status code should be "404"
     And the data of the response should match
     """"
@@ -105,7 +105,7 @@ Feature: API endpoint to prepare direct upload
 
 
   Scenario: Try to get a direct-upload token for a non existing folder-id
-    When user "Alice" sends a POST request to the direct-upload-token endpoint with the ID "999999999"
+    When user "Carol" sends a POST request to the direct-upload-token endpoint with the ID "999999999"
     Then the HTTP status code should be "404"
     And the data of the response should match
     """"
@@ -124,8 +124,8 @@ Feature: API endpoint to prepare direct upload
   Scenario: Try to get a direct-upload token for a folder without create permissions
     Given user "Brian" has been created
     And user "Brian" has created folder "/toShare"
-    And user "Brian" has shared folder "/toShare" with user "Alice" with "read+update+delete+share" permissions
-    When user "Alice" sends a POST request to the direct-upload-token endpoint with the ID of "/toShare"
+    And user "Brian" has shared folder "/toShare" with user "Carol" with "read+update+delete+share" permissions
+    When user "Carol" sends a POST request to the direct-upload-token endpoint with the ID of "/toShare"
     Then the HTTP status code should be "404"
     And the data of the response should match
     """"
@@ -148,10 +148,10 @@ Feature: API endpoint to prepare direct upload
 
   Scenario: Tokens should be random
     Given user "Brian" has been created
-    And user "Alice" has created folder "/folder for OpenProject"
+    And user "Carol" has created folder "/folder for OpenProject"
     And user "Brian" has created folder "/folder for OpenProject"
-    When user "Alice" gets a direct-upload token for "/folder for OpenProject"
+    When user "Carol" gets a direct-upload token for "/folder for OpenProject"
     And user "Brian" gets a direct-upload token for "/folder for OpenProject"
-    And user "Alice" gets a direct-upload token for "/"
+    And user "Carol" gets a direct-upload token for "/"
     And user "Brian" gets a direct-upload token for "/"
     Then all direct-upload tokens should be different

--- a/tests/acceptance/features/api/getFileinfoByFileIDAPI.feature
+++ b/tests/acceptance/features/api/getFileinfoByFileIDAPI.feature
@@ -229,7 +229,7 @@ Feature: retrieve file information of a single file, using the file ID
   Scenario: get information of a non-existing file
     Given user "Carol" has been created
     When user "Brian" gets the information of the file with the id "9999999999999"
-    Then the HTTP status code should be "404"
+    Then the HTTP status code should be "401"
     And the ocs data of the response should match
       """"
       {

--- a/tests/acceptance/features/api/getFileinfoByFileIDAPI.feature
+++ b/tests/acceptance/features/api/getFileinfoByFileIDAPI.feature
@@ -1,9 +1,9 @@
 Feature: retrieve file information of a single file, using the file ID
 
   Scenario: get information of an existing file
-    Given user "Alice" has been created
-    And user "Alice" has uploaded file with content "some data" to "file.txt"
-    When user "Alice" gets the information of last created file
+    Given user "Carol" has been created
+    And user "Carol" has uploaded file with content "some data" to "file.txt"
+    When user "Carol" gets the information of last created file
     Then the HTTP status code should be "200"
     And the ocs data of the response should match
       """"
@@ -35,8 +35,8 @@ Feature: retrieve file information of a single file, using the file ID
       "ctime" : {"type" : "integer", "enum": [0]},
       "name": {"type": "string", "pattern": "^file.txt$"},
       "mimetype": {"type": "string", "pattern": "^text\/plain$"},
-      "owner_id": {"type": "string", "pattern": "^Alice$"},
-      "owner_name": {"type": "string", "pattern": "^Alice$"},
+      "owner_id": {"type": "string", "pattern": "^Carol$"},
+      "owner_name": {"type": "string", "pattern": "^Carol$"},
       "modifier_id": {"type": "null"},
       "modifier_name": {"type": "null"},
       "trashed": {"type": "boolean", "enum": [false]},
@@ -47,10 +47,10 @@ Feature: retrieve file information of a single file, using the file ID
       """
 
   Scenario: get information of an existing file in a subfolder
-    Given user "Alice" has been created
-    And user "Alice" has created folder "/subfolder"
-    And user "Alice" has uploaded file with content "some data" to "/subfolder/file.txt"
-    When user "Alice" gets the information of last created file
+    Given user "Carol" has been created
+    And user "Carol" has created folder "/subfolder"
+    And user "Carol" has uploaded file with content "some data" to "/subfolder/file.txt"
+    When user "Carol" gets the information of last created file
     Then the HTTP status code should be "200"
     And the ocs data of the response should match
       """"
@@ -82,8 +82,8 @@ Feature: retrieve file information of a single file, using the file ID
       "ctime" : {"type" : "integer", "enum": [0]},
       "name": {"type": "string", "pattern": "^file.txt$"},
       "mimetype": {"type": "string", "pattern": "^text\/plain$"},
-      "owner_id": {"type": "string", "pattern": "^Alice$"},
-      "owner_name": {"type": "string", "pattern": "^Alice$"},
+      "owner_id": {"type": "string", "pattern": "^Carol$"},
+      "owner_name": {"type": "string", "pattern": "^Carol$"},
       "modifier_id": {"type": "null"},
       "modifier_name": {"type": "null"},
       "trashed": {"type": "boolean", "enum": [false]},
@@ -94,10 +94,10 @@ Feature: retrieve file information of a single file, using the file ID
       """
 
   Scenario: get information of a trashed file
-    Given user "Alice" has been created
-    And user "Alice" has uploaded file with content "some data" to "file.txt"
-    And user "Alice" has deleted file "file.txt"
-    When user "Alice" gets the information of last created file
+    Given user "Carol" has been created
+    And user "Carol" has uploaded file with content "some data" to "file.txt"
+    And user "Carol" has deleted file "file.txt"
+    When user "Carol" gets the information of last created file
     Then the HTTP status code should be "200"
     And the ocs data of the response should match
       """"
@@ -129,8 +129,8 @@ Feature: retrieve file information of a single file, using the file ID
       "ctime" : {"type" : "integer", "enum": [0]},
       "name": {"type": "string", "pattern": "^file.txt.d\\d{10}$"},
       "mimetype": {"type": "string", "pattern": "^text\/plain$"},
-      "owner_id": {"type": "string", "pattern": "^Alice$"},
-      "owner_name": {"type": "string", "pattern": "^Alice$"},
+      "owner_id": {"type": "string", "pattern": "^Carol$"},
+      "owner_name": {"type": "string", "pattern": "^Carol$"},
       "modifier_id": {"type": "null"},
       "modifier_name": {"type": "null"},
       "trashed": {"type": "boolean", "enum": [true]},
@@ -141,11 +141,11 @@ Feature: retrieve file information of a single file, using the file ID
       """
 
   Scenario: get information of a file that is inside of a trashed folder
-    Given user "Alice" has been created
-    And user "Alice" has created folder "/subfolder"
-    And user "Alice" has uploaded file with content "some data" to "/subfolder/file.txt"
-    And user "Alice" has deleted folder "subfolder"
-    When user "Alice" gets the information of last created file
+    Given user "Carol" has been created
+    And user "Carol" has created folder "/subfolder"
+    And user "Carol" has uploaded file with content "some data" to "/subfolder/file.txt"
+    And user "Carol" has deleted folder "subfolder"
+    When user "Carol" gets the information of last created file
     Then the HTTP status code should be "200"
     And the ocs data of the response should match
       """"
@@ -177,8 +177,8 @@ Feature: retrieve file information of a single file, using the file ID
       "ctime" : {"type" : "integer", "enum": [0]},
       "name": {"type": "string", "pattern": "^file.txt$"},
       "mimetype": {"type": "string", "pattern": "^text\/plain$"},
-      "owner_id": {"type": "string", "pattern": "^Alice$"},
-      "owner_name": {"type": "string", "pattern": "^Alice$"},
+      "owner_id": {"type": "string", "pattern": "^Carol$"},
+      "owner_name": {"type": "string", "pattern": "^Carol$"},
       "modifier_id": {"type": "null"},
       "modifier_name": {"type": "null"},
       "trashed": {"type": "boolean", "enum": [true]},
@@ -189,9 +189,9 @@ Feature: retrieve file information of a single file, using the file ID
       """
 
   Scenario: get information of a file owned by an different user
-    Given user "Alice" has been created
+    Given user "Carol" has been created
     And user "Brian" has been created
-    And user "Alice" has uploaded file with content "some data" to "file.txt"
+    And user "Carol" has uploaded file with content "some data" to "file.txt"
     When user "Brian" gets the information of last created file
     Then the HTTP status code should be "403"
     And the ocs data of the response should match
@@ -227,7 +227,7 @@ Feature: retrieve file information of a single file, using the file ID
       """
 
   Scenario: get information of a non-existing file
-    Given user "Alice" has been created
+    Given user "Carol" has been created
     When user "Brian" gets the information of the file with the id "9999999999999"
     Then the HTTP status code should be "404"
     And the ocs data of the response should match
@@ -263,10 +263,10 @@ Feature: retrieve file information of a single file, using the file ID
       """
 
   Scenario: get information of a file received as a share
-    Given user "Alice" has been created
+    Given user "Carol" has been created
     And user "Brian" has been created
-    And user "Alice" has uploaded file with content "some data" to "/file.txt"
-    And user "Alice" has shared file "/file.txt" with user "Brian"
+    And user "Carol" has uploaded file with content "some data" to "/file.txt"
+    And user "Carol" has shared file "/file.txt" with user "Brian"
     When user "Brian" gets the information of last created file
     Then the HTTP status code should be "200"
     And the ocs data of the response should match
@@ -289,8 +289,8 @@ Feature: retrieve file information of a single file, using the file ID
       "status": {"type": "string", "pattern": "^OK$"},
       "statuscode" : {"type" : "number",  "enum": [200] },
       "name": {"type": "string", "pattern": "^file.txt$"},
-      "owner_id": {"type": "string", "pattern": "^Alice$"},
-      "owner_name": {"type": "string", "pattern": "^Alice$"},
+      "owner_id": {"type": "string", "pattern": "^Carol$"},
+      "owner_name": {"type": "string", "pattern": "^Carol$"},
       "modifier_id": {"type": "null"},
       "modifier_name": {"type": "null"},
       "trashed": {"type": "boolean", "enum": [false]},
@@ -301,11 +301,11 @@ Feature: retrieve file information of a single file, using the file ID
       """
 
   Scenario: get information of a file that is in a folder received as a share
-    Given user "Alice" has been created
+    Given user "Carol" has been created
     And user "Brian" has been created
-    And user "Alice" has created folder "/to-share"
-    And user "Alice" has uploaded file with content "some data" to "/to-share/file.txt"
-    And user "Alice" has shared folder "/to-share" with user "Brian"
+    And user "Carol" has created folder "/to-share"
+    And user "Carol" has uploaded file with content "some data" to "/to-share/file.txt"
+    And user "Carol" has shared folder "/to-share" with user "Brian"
     When user "Brian" gets the information of last created file
     Then the HTTP status code should be "200"
     And the ocs data of the response should match
@@ -328,8 +328,8 @@ Feature: retrieve file information of a single file, using the file ID
       "status": {"type": "string", "pattern": "^OK$"},
       "statuscode" : {"type" : "number",  "enum": [200] },
       "name": {"type": "string", "pattern": "^file.txt$"},
-      "owner_id": {"type": "string", "pattern": "^Alice$"},
-      "owner_name": {"type": "string", "pattern": "^Alice$"},
+      "owner_id": {"type": "string", "pattern": "^Carol$"},
+      "owner_name": {"type": "string", "pattern": "^Carol$"},
       "modifier_id": {"type": "null"},
       "modifier_name": {"type": "null"},
       "trashed": {"type": "boolean", "enum": [false]},
@@ -340,12 +340,12 @@ Feature: retrieve file information of a single file, using the file ID
       """
 
   Scenario: get information of a file that is received through a folder and a file share
-    Given user "Alice" has been created
+    Given user "Carol" has been created
     And user "Brian" has been created
-    And user "Alice" has created folder "/to-share"
-    And user "Alice" has uploaded file with content "some data" to "/to-share/file.txt"
-    And user "Alice" has shared folder "/to-share" with user "Brian"
-    And user "Alice" has shared file "/to-share/file.txt" with user "Brian"
+    And user "Carol" has created folder "/to-share"
+    And user "Carol" has uploaded file with content "some data" to "/to-share/file.txt"
+    And user "Carol" has shared folder "/to-share" with user "Brian"
+    And user "Carol" has shared file "/to-share/file.txt" with user "Brian"
     When user "Brian" gets the information of last created file
     Then the HTTP status code should be "200"
     And the ocs data of the response should match
@@ -368,8 +368,8 @@ Feature: retrieve file information of a single file, using the file ID
       "status": {"type": "string", "pattern": "^OK$"},
       "statuscode" : {"type" : "number",  "enum": [200] },
       "name": {"type": "string", "pattern": "^file.txt$"},
-      "owner_id": {"type": "string", "pattern": "^Alice$"},
-      "owner_name": {"type": "string", "pattern": "^Alice$"},
+      "owner_id": {"type": "string", "pattern": "^Carol$"},
+      "owner_name": {"type": "string", "pattern": "^Carol$"},
       "modifier_id": {"type": "null"},
       "modifier_name": {"type": "null"},
       "trashed": {"type": "boolean", "enum": [false]},
@@ -380,10 +380,10 @@ Feature: retrieve file information of a single file, using the file ID
       """
 
   Scenario: get information of a file received as a share and renamed
-    Given user "Alice" has been created
+    Given user "Carol" has been created
     And user "Brian" has been created
-    And user "Alice" has uploaded file with content "some data" to "/file.txt"
-    And user "Alice" has shared file "/file.txt" with user "Brian"
+    And user "Carol" has uploaded file with content "some data" to "/file.txt"
+    And user "Carol" has shared file "/file.txt" with user "Brian"
     And user "Brian" has renamed file "/file.txt" to "/renamed.txt"
     When user "Brian" gets the information of last created file
     Then the HTTP status code should be "200"
@@ -407,8 +407,8 @@ Feature: retrieve file information of a single file, using the file ID
       "status": {"type": "string", "pattern": "^OK$"},
       "statuscode" : {"type" : "number",  "enum": [200] },
       "name": {"type": "string", "pattern": "^file.txt$"},
-      "owner_id": {"type": "string", "pattern": "^Alice$"},
-      "owner_name": {"type": "string", "pattern": "^Alice$"},
+      "owner_id": {"type": "string", "pattern": "^Carol$"},
+      "owner_name": {"type": "string", "pattern": "^Carol$"},
       "modifier_id": {"type": "null"},
       "modifier_name": {"type": "null"},
       "trashed": {"type": "boolean", "enum": [false]},
@@ -419,11 +419,11 @@ Feature: retrieve file information of a single file, using the file ID
       """
 
   Scenario: get information of a file received in a folder share and renamed
-    Given user "Alice" has been created
+    Given user "Carol" has been created
     And user "Brian" has been created
-    And user "Alice" has created folder "/to-share"
-    And user "Alice" has uploaded file with content "some data" to "/to-share/file.txt"
-    And user "Alice" has shared folder "/to-share" with user "Brian"
+    And user "Carol" has created folder "/to-share"
+    And user "Carol" has uploaded file with content "some data" to "/to-share/file.txt"
+    And user "Carol" has shared folder "/to-share" with user "Brian"
     And user "Brian" has renamed file "/to-share/file.txt" to "/to-share/renamed.txt"
     When user "Brian" gets the information of last created file
     Then the HTTP status code should be "200"
@@ -447,8 +447,8 @@ Feature: retrieve file information of a single file, using the file ID
       "status": {"type": "string", "pattern": "^OK$"},
       "statuscode" : {"type" : "number",  "enum": [200] },
       "name": {"type": "string", "pattern": "^renamed.txt$"},
-      "owner_id": {"type": "string", "pattern": "^Alice$"},
-      "owner_name": {"type": "string", "pattern": "^Alice$"},
+      "owner_id": {"type": "string", "pattern": "^Carol$"},
+      "owner_name": {"type": "string", "pattern": "^Carol$"},
       "modifier_id": {"type": "null"},
       "modifier_name": {"type": "null"},
       "trashed": {"type": "boolean", "enum": [false]},
@@ -459,11 +459,11 @@ Feature: retrieve file information of a single file, using the file ID
       """
 
   Scenario: get information of a file received in a folder share and moved out of that share
-    Given user "Alice" has been created
+    Given user "Carol" has been created
     And user "Brian" has been created
-    And user "Alice" has created folder "/to-share"
-    And user "Alice" has uploaded file with content "some data" to "/to-share/file.txt"
-    And user "Alice" has shared folder "/to-share" with user "Brian"
+    And user "Carol" has created folder "/to-share"
+    And user "Carol" has uploaded file with content "some data" to "/to-share/file.txt"
+    And user "Carol" has shared folder "/to-share" with user "Brian"
     And user "Brian" has renamed file "/to-share/file.txt" to "/moved-out.txt"
     When user "Brian" gets the information of last created file
     Then the HTTP status code should be "200"
@@ -495,7 +495,7 @@ Feature: retrieve file information of a single file, using the file ID
       }
       }
       """
-    When user "Alice" gets the information of last created file
+    When user "Carol" gets the information of last created file
     Then the HTTP status code should be "403"
     And the ocs data of the response should match
       """"
@@ -530,10 +530,10 @@ Feature: retrieve file information of a single file, using the file ID
       """
 
   Scenario: get modifier when same user uploads and overwrites a file
-    Given user "Alice" has been created with display-name "Alice Hansen"
-    And user "Alice" has uploaded file with content "some data" to "file.txt"
-    And user "Alice" has uploaded file with content "changed data" to "file.txt"
-    When user "Alice" gets the information of last created file
+    Given user "Carol" has been created with display-name "Carol Hansen"
+    And user "Carol" has uploaded file with content "some data" to "file.txt"
+    And user "Carol" has uploaded file with content "changed data" to "file.txt"
+    When user "Carol" gets the information of last created file
     Then the HTTP status code should be "200"
     And the ocs data of the response should match
       """"
@@ -560,10 +560,10 @@ Feature: retrieve file information of a single file, using the file ID
       "mtime" : {"type" : "integer"},
       "ctime" : {"type" : "integer", "enum": [0]},
       "name": {"type": "string", "pattern": "^file.txt$"},
-      "owner_id": {"type": "string", "pattern": "^Alice$"},
-      "owner_name": {"type": "string", "pattern": "^Alice Hansen"},
-      "modifier_id": {"type": "string", "pattern": "^Alice$"},
-      "modifier_name": {"type": "string", "pattern": "^Alice Hansen"},
+      "owner_id": {"type": "string", "pattern": "^Carol$"},
+      "owner_name": {"type": "string", "pattern": "^Carol Hansen"},
+      "modifier_id": {"type": "string", "pattern": "^Carol$"},
+      "modifier_name": {"type": "string", "pattern": "^Carol Hansen"},
       "dav_permissions": {"type": "string", "pattern":"^RGDNVW$"},
       "path": {"type": "string", "pattern":"^files\/file.txt$"}
       }
@@ -572,11 +572,11 @@ Feature: retrieve file information of a single file, using the file ID
 
 
   Scenario Outline: get modifier in a chain of shares
-    Given user "Alice" has been created
+    Given user "Carol" has been created
     And user "Brian" has been created with display-name "Brian Peters"
     And user "Chandra" has been created with display-name "Chandra Thapa"
-    And user "Alice" has uploaded file with content "some data" to "file.txt"
-    And user "Alice" has shared file "file.txt" with user "Brian"
+    And user "Carol" has uploaded file with content "some data" to "file.txt"
+    And user "Carol" has shared file "file.txt" with user "Brian"
     And user "Brian" has shared file "file.txt" with user "Chandra"
     And user "<modifier>" has uploaded file with content "changed data" to "file.txt"
     When user "<retriever>" gets the information of last created file
@@ -606,8 +606,8 @@ Feature: retrieve file information of a single file, using the file ID
       "mtime" : {"type" : "integer"},
       "ctime" : {"type" : "integer", "enum": [0]},
       "name": {"type": "string", "pattern": "^file.txt$"},
-      "owner_id": {"type": "string", "pattern": "^Alice$"},
-      "owner_name": {"type": "string", "pattern": "^Alice"},
+      "owner_id": {"type": "string", "pattern": "^Carol$"},
+      "owner_name": {"type": "string", "pattern": "^Carol"},
       "modifier_id": {"type": "string", "pattern": "^<modifier>"},
       "modifier_name": {"type": "string", "pattern": "^<modifier-display-name>"},
       "dav_permissions": {"type": "string", "pattern":"^<dav_permissions>$"},
@@ -617,30 +617,30 @@ Feature: retrieve file information of a single file, using the file ID
       """
     Examples:
       | modifier | modifier-display-name | retriever | comment                                              | dav_permissions |
-      | Alice    | Alice                 | Alice     | display-name should be username if not specially set | RGDNVW          |
-      | Brian    | Brian Peters          | Alice     |                                                      | RGDNVW          |
-      | Chandra  | Chandra Thapa         | Alice     |                                                      | RGDNVW          |
-      | Alice    | Alice                 | Brian     |                                                      | SRGNVW          |
+      | Carol    | Carol                 | Carol     | display-name should be username if not specially set | RGDNVW          |
+      | Brian    | Brian Peters          | Carol     |                                                      | RGDNVW          |
+      | Chandra  | Chandra Thapa         | Carol     |                                                      | RGDNVW          |
+      | Carol    | Carol                 | Brian     |                                                      | SRGNVW          |
       | Brian    | Brian Peters          | Brian     |                                                      | SRGNVW          |
       | Chandra  | Chandra Thapa         | Brian     |                                                      | SRGNVW          |
-      | Alice    | Alice                 | Chandra   |                                                      | SRGNVW          |
+      | Carol    | Carol                 | Chandra   |                                                      | SRGNVW          |
       | Brian    | Brian Peters          | Chandra   |                                                      | SRGNVW          |
       | Chandra  | Chandra Thapa         | Chandra   |                                                      | SRGNVW          |
 
 
   Scenario: get modifier in a chain of shares when there are multiple modifiers
-    Given user "Alice" has been created
+    Given user "Carol" has been created
     And user "Brian" has been created
     And user "Chandra" has been created
     And user "Dipak" has been created
-    And user "Alice" has uploaded file with content "some data" to "file.txt"
-    And user "Alice" has shared file "file.txt" with user "Brian"
+    And user "Carol" has uploaded file with content "some data" to "file.txt"
+    And user "Carol" has shared file "file.txt" with user "Brian"
     And user "Brian" has shared file "file.txt" with user "Chandra"
-    And user "Alice" has shared file "file.txt" with user "Dipak"
+    And user "Carol" has shared file "file.txt" with user "Dipak"
     And user "Brian" has uploaded file with content "from B 0" to "file.txt"
     And user "Chandra" has uploaded file with content "from C 00" to "file.txt"
     And user "Dipak" has uploaded file with content "from D 000" to "file.txt"
-    When user "Alice" gets the information of last created file
+    When user "Carol" gets the information of last created file
     Then the HTTP status code should be "200"
     And the ocs data of the response should match
       """"
@@ -667,8 +667,8 @@ Feature: retrieve file information of a single file, using the file ID
       "mtime" : {"type" : "integer"},
       "ctime" : {"type" : "integer", "enum": [0]},
       "name": {"type": "string", "pattern": "^file.txt$"},
-      "owner_id": {"type": "string", "pattern": "^Alice$"},
-      "owner_name": {"type": "string", "pattern": "^Alice$"},
+      "owner_id": {"type": "string", "pattern": "^Carol$"},
+      "owner_name": {"type": "string", "pattern": "^Carol$"},
       "modifier_id": {"type": "string", "pattern": "^Dipak"},
       "modifier_name": {"type": "string", "pattern": "^Dipak"},
       "dav_permissions": {"type": "string", "pattern":"^RGDNVW$"},
@@ -679,18 +679,18 @@ Feature: retrieve file information of a single file, using the file ID
 
 
   Scenario: get modifier in a chain of shares when there are multiple modifiers (sharing and modification mixed)
-    Given user "Alice" has been created
+    Given user "Carol" has been created
     And user "Brian" has been created
     And user "Chandra" has been created
     And user "Dipak" has been created
-    And user "Alice" has uploaded file with content "some data" to "file.txt"
-    And user "Alice" has shared file "file.txt" with user "Brian"
+    And user "Carol" has uploaded file with content "some data" to "file.txt"
+    And user "Carol" has shared file "file.txt" with user "Brian"
     And user "Brian" has uploaded file with content "from B 0" to "file.txt"
     And user "Brian" has shared file "file.txt" with user "Chandra"
     And user "Chandra" has uploaded file with content "from C 00" to "file.txt"
-    And user "Alice" has shared file "file.txt" with user "Dipak"
+    And user "Carol" has shared file "file.txt" with user "Dipak"
     And user "Dipak" has uploaded file with content "from D 000" to "file.txt"
-    When user "Alice" gets the information of last created file
+    When user "Carol" gets the information of last created file
     Then the HTTP status code should be "200"
     And the ocs data of the response should match
       """"
@@ -717,8 +717,8 @@ Feature: retrieve file information of a single file, using the file ID
       "mtime" : {"type" : "integer"},
       "ctime" : {"type" : "integer", "enum": [0]},
       "name": {"type": "string", "pattern": "^file.txt$"},
-      "owner_id": {"type": "string", "pattern": "^Alice$"},
-      "owner_name": {"type": "string", "pattern": "^Alice$"},
+      "owner_id": {"type": "string", "pattern": "^Carol$"},
+      "owner_name": {"type": "string", "pattern": "^Carol$"},
       "modifier_id": {"type": "string", "pattern": "^Dipak"},
       "modifier_name": {"type": "string", "pattern": "^Dipak"},
       "dav_permissions": {"type": "string", "pattern":"^RGDNVW$"},
@@ -729,19 +729,19 @@ Feature: retrieve file information of a single file, using the file ID
 
 
   Scenario: get modifier after various renaming
-    Given user "Alice" has been created
+    Given user "Carol" has been created
     And user "Brian" has been created
     And user "Chandra" has been created
     And user "Dipak" has been created
-    And user "Alice" has uploaded file with content "some data" to "file.txt"
-    And user "Alice" has shared file "file.txt" with user "Brian"
+    And user "Carol" has uploaded file with content "some data" to "file.txt"
+    And user "Carol" has shared file "file.txt" with user "Brian"
     And user "Brian" has shared file "file.txt" with user "Chandra"
-    And user "Alice" has shared file "file.txt" with user "Dipak"
+    And user "Carol" has shared file "file.txt" with user "Dipak"
     And user "Dipak" has uploaded file with content "changed data" to "file.txt"
-    And user "Alice" has renamed file "file.txt" to "Alices-file.txt"
+    And user "Carol" has renamed file "file.txt" to "Carols-file.txt"
     And user "Brian" has renamed file "file.txt" to "Brians-file.txt"
     And user "Chandra" has renamed file "file.txt" to "Chandras-file.txt"
-    When user "Alice" gets the information of last created file
+    When user "Carol" gets the information of last created file
     Then the HTTP status code should be "200"
     And the ocs data of the response should match
       """"
@@ -761,33 +761,33 @@ Feature: retrieve file information of a single file, using the file ID
       "status": {"type": "string", "pattern": "^OK$"},
       "statuscode" : {"type" : "number", "enum": [200]},
       "size" : {"type" : "integer", "enum": [12]},
-      "name": {"type": "string", "pattern": "^Alices-file.txt$"},
+      "name": {"type": "string", "pattern": "^Carols-file.txt$"},
       "modifier_id": {"type": "string", "pattern": "^Dipak"},
       "modifier_name": {"type": "string", "pattern": "^Dipak"},
       "dav_permissions": {"type": "string", "pattern":"^RGDNVW$"},
-      "path": {"type": "string", "pattern":"^files\/Alices-file.txt$"}
+      "path": {"type": "string", "pattern":"^files\/Carols-file.txt$"}
       }
       }
       """
 
 
   Scenario: get modifier after various moving
-    Given user "Alice" has been created
+    Given user "Carol" has been created
     And user "Brian" has been created
     And user "Chandra" has been created
     And user "Dipak" has been created
-    And user "Alice" has uploaded file with content "some data" to "file.txt"
-    And user "Alice" has created folder "/Alice-folder"
+    And user "Carol" has uploaded file with content "some data" to "file.txt"
+    And user "Carol" has created folder "/Carol-folder"
     And user "Brian" has created folder "/Brian-folder"
     And user "Chandra" has created folder "/Chandra-folder"
-    And user "Alice" has shared file "file.txt" with user "Brian"
+    And user "Carol" has shared file "file.txt" with user "Brian"
     And user "Brian" has shared file "file.txt" with user "Chandra"
-    And user "Alice" has shared file "file.txt" with user "Dipak"
+    And user "Carol" has shared file "file.txt" with user "Dipak"
     And user "Dipak" has uploaded file with content "changed data" to "file.txt"
-    And user "Alice" has moved file "file.txt" to "/Alice-folder/file.txt"
+    And user "Carol" has moved file "file.txt" to "/Carol-folder/file.txt"
     And user "Brian" has moved file "file.txt" to "/Brian-folder/file.txt"
     And user "Chandra" has moved file "file.txt" to "/Chandra-folder/file.txt"
-    When user "Alice" gets the information of last created file
+    When user "Carol" gets the information of last created file
     Then the HTTP status code should be "200"
     And the ocs data of the response should match
       """"
@@ -811,20 +811,20 @@ Feature: retrieve file information of a single file, using the file ID
       "modifier_id": {"type": "string", "pattern": "^Dipak"},
       "modifier_name": {"type": "string", "pattern": "^Dipak"},
       "dav_permissions": {"type": "string", "pattern":"^RGDNVW$"},
-      "path": {"type": "string", "pattern":"^files\/Alice-folder\/file.txt$"}
+      "path": {"type": "string", "pattern":"^files\/Carol-folder\/file.txt$"}
       }
       }
       """
 
 
   Scenario: get modifier after the modifier was deleted
-    Given user "Alice" has been created
+    Given user "Carol" has been created
     And user "Brian" has been created
-    And user "Alice" has uploaded file with content "some data" to "file.txt"
-    And user "Alice" has shared file "file.txt" with user "Brian"
+    And user "Carol" has uploaded file with content "some data" to "file.txt"
+    And user "Carol" has shared file "file.txt" with user "Brian"
     And user "Brian" has uploaded file with content "changed data" to "file.txt"
     And user "Brian" has been deleted
-    When user "Alice" gets the information of last created file
+    When user "Carol" gets the information of last created file
     Then the HTTP status code should be "200"
     And the ocs data of the response should match
       """"
@@ -855,14 +855,14 @@ Feature: retrieve file information of a single file, using the file ID
 
 
   Scenario: get modifier of a folder
-    Given user "Alice" has been created with display-name "Alice Hansen"
+    Given user "Carol" has been created with display-name "Carol Hansen"
     And user "Brian" has been created
-    And user "Alice" has created folder "/folder"
-    And user "Alice" has uploaded file with content "some data" to "/folder/file.txt"
-    And user "Alice" has shared folder "/folder" with user "Brian"
+    And user "Carol" has created folder "/folder"
+    And user "Carol" has uploaded file with content "some data" to "/folder/file.txt"
+    And user "Carol" has shared folder "/folder" with user "Brian"
     And user "Brian" has uploaded file with content "changed data" to "/folder/file.txt"
     And user "Brian" has uploaded file with content "data" to "/folder/new-file.txt"
-    When user "Alice" gets the information of the folder "/folder"
+    When user "Carol" gets the information of the folder "/folder"
     Then the HTTP status code should be "200"
     And the ocs data of the response should match
       """"
@@ -894,8 +894,8 @@ Feature: retrieve file information of a single file, using the file ID
       "ctime" : {"type" : "integer", "enum": [0]},
       "name": {"type": "string", "pattern": "^folder$"},
       "mimetype": {"type": "string", "pattern": "^application\/x-op-directory$"},
-      "owner_id": {"type": "string", "pattern": "^Alice$"},
-      "owner_name": {"type": "string", "pattern": "^Alice Hansen$"},
+      "owner_id": {"type": "string", "pattern": "^Carol$"},
+      "owner_name": {"type": "string", "pattern": "^Carol Hansen$"},
       "modifier_id": {"type": "null"},
       "modifier_name": {"type": "null"},
       "trashed": {"type": "boolean", "enum": [false]},
@@ -907,12 +907,12 @@ Feature: retrieve file information of a single file, using the file ID
 
 
   Scenario: get modifier of a file changed through a public link
-    Given user "Alice" has been created with display-name "Alice Hansen"
-    And user "Alice" has created folder "/folder"
-    And user "Alice" has uploaded file with content "some data" to "/folder/file.txt"
-    And user "Alice" has shared folder "/folder" with the public
+    Given user "Carol" has been created with display-name "Carol Hansen"
+    And user "Carol" has created folder "/folder"
+    And user "Carol" has uploaded file with content "some data" to "/folder/file.txt"
+    And user "Carol" has shared folder "/folder" with the public
     And the public has uploaded file "file.txt" with content "changed content" to last created public link
-    When user "Alice" gets the information of the file "/folder/file.txt"
+    When user "Carol" gets the information of the file "/folder/file.txt"
     Then the HTTP status code should be "200"
     And the ocs data of the response should match
       """"
@@ -944,8 +944,8 @@ Feature: retrieve file information of a single file, using the file ID
       "ctime" : {"type" : "integer", "enum": [0]},
       "name": {"type": "string", "pattern": "^file.txt$"},
       "mimetype": {"type": "string", "pattern": "^text\/plain$"},
-      "owner_id": {"type": "string", "pattern": "^Alice$"},
-      "owner_name": {"type": "string", "pattern": "^Alice Hansen$"},
+      "owner_id": {"type": "string", "pattern": "^Carol$"},
+      "owner_name": {"type": "string", "pattern": "^Carol Hansen$"},
       "modifier_id": {"type": "null"},
       "modifier_name": {"type": "null"},
       "trashed": {"type": "boolean", "enum": [false]},
@@ -957,13 +957,13 @@ Feature: retrieve file information of a single file, using the file ID
 
 
   Scenario: get modifier of a file changed through a public link after a real change
-    Given user "Alice" has been created with display-name "Alice Hansen"
-    And user "Alice" has created folder "/folder"
-    And user "Alice" has uploaded file with content "some data" to "/folder/file.txt"
-    And user "Alice" has uploaded file with content "change" to "/folder/file.txt"
-    And user "Alice" has shared folder "/folder" with the public
+    Given user "Carol" has been created with display-name "Carol Hansen"
+    And user "Carol" has created folder "/folder"
+    And user "Carol" has uploaded file with content "some data" to "/folder/file.txt"
+    And user "Carol" has uploaded file with content "change" to "/folder/file.txt"
+    And user "Carol" has shared folder "/folder" with the public
     And the public has uploaded file "file.txt" with content "changed content" to last created public link
-    When user "Alice" gets the information of the file "/folder/file.txt"
+    When user "Carol" gets the information of the file "/folder/file.txt"
     Then the HTTP status code should be "200"
     And the ocs data of the response should match
       """"
@@ -986,8 +986,8 @@ Feature: retrieve file information of a single file, using the file ID
       "statuscode" : {"type" : "number", "enum": [200]},
       "size" : {"type" : "integer", "enum": [15] },
       "name": {"type": "string", "pattern": "^file.txt$"},
-      "owner_id": {"type": "string", "pattern": "^Alice$"},
-      "owner_name": {"type": "string", "pattern": "^Alice Hansen$"},
+      "owner_id": {"type": "string", "pattern": "^Carol$"},
+      "owner_name": {"type": "string", "pattern": "^Carol Hansen$"},
       "modifier_id": {"type": "null"},
       "modifier_name": {"type": "null"},
       "dav_permissions": {"type": "string", "pattern":"^RGDNVW$"},
@@ -998,35 +998,35 @@ Feature: retrieve file information of a single file, using the file ID
 
 
   Scenario: get modifier of a file with a lot of unrelated change
-    Given user "Alice" has been created with display-name "Alice Hansen"
+    Given user "Carol" has been created with display-name "Carol Hansen"
     And user "Brian" has been created
     And user "Chandra" has been created
-    And user "Alice" has uploaded file with content "some data" to "file.txt"
-    And user "Alice" has shared file "/file.txt" with user "Brian"
+    And user "Carol" has uploaded file with content "some data" to "file.txt"
+    And user "Carol" has shared file "/file.txt" with user "Brian"
     And user "Brian" has uploaded file with content "change" to "file.txt"
-    And user "Alice" has shared file "/file.txt" with user "Chandra"
+    And user "Carol" has shared file "/file.txt" with user "Chandra"
     And user "Brian" has shared file "/file.txt" with user "Chandra"
-    And user "Alice" has renamed file "/file.txt" to "/file1.txt"
-    And user "Alice" has renamed file "/file1.txt" to "/file2.txt"
-    And user "Alice" has renamed file "/file2.txt" to "/file3.txt"
-    And user "Alice" has renamed file "/file3.txt" to "/file4.txt"
-    And user "Alice" has renamed file "/file4.txt" to "/file5.txt"
-    And user "Alice" has renamed file "/file5.txt" to "/file6.txt"
-    And user "Alice" has renamed file "/file6.txt" to "/file7.txt"
-    And user "Alice" has renamed file "/file7.txt" to "/file8.txt"
-    And user "Alice" has renamed file "/file8.txt" to "/file9.txt"
-    And user "Alice" has renamed file "/file9.txt" to "/file10.txt"
-    And user "Alice" has renamed file "/file10.txt" to "/file11.txt"
-    And user "Alice" has renamed file "/file11.txt" to "/file12.txt"
-    And user "Alice" has renamed file "/file12.txt" to "/file13.txt"
-    And user "Alice" has renamed file "/file13.txt" to "/file14.txt"
-    And user "Alice" has renamed file "/file14.txt" to "/file15.txt"
-    And user "Alice" has renamed file "/file15.txt" to "/file16.txt"
-    And user "Alice" has renamed file "/file16.txt" to "/file17.txt"
-    And user "Alice" has renamed file "/file17.txt" to "/file18.txt"
-    And user "Alice" has renamed file "/file18.txt" to "/file19.txt"
-    And user "Alice" has renamed file "/file19.txt" to "/file20.txt"
-    When user "Alice" gets the information of last created file
+    And user "Carol" has renamed file "/file.txt" to "/file1.txt"
+    And user "Carol" has renamed file "/file1.txt" to "/file2.txt"
+    And user "Carol" has renamed file "/file2.txt" to "/file3.txt"
+    And user "Carol" has renamed file "/file3.txt" to "/file4.txt"
+    And user "Carol" has renamed file "/file4.txt" to "/file5.txt"
+    And user "Carol" has renamed file "/file5.txt" to "/file6.txt"
+    And user "Carol" has renamed file "/file6.txt" to "/file7.txt"
+    And user "Carol" has renamed file "/file7.txt" to "/file8.txt"
+    And user "Carol" has renamed file "/file8.txt" to "/file9.txt"
+    And user "Carol" has renamed file "/file9.txt" to "/file10.txt"
+    And user "Carol" has renamed file "/file10.txt" to "/file11.txt"
+    And user "Carol" has renamed file "/file11.txt" to "/file12.txt"
+    And user "Carol" has renamed file "/file12.txt" to "/file13.txt"
+    And user "Carol" has renamed file "/file13.txt" to "/file14.txt"
+    And user "Carol" has renamed file "/file14.txt" to "/file15.txt"
+    And user "Carol" has renamed file "/file15.txt" to "/file16.txt"
+    And user "Carol" has renamed file "/file16.txt" to "/file17.txt"
+    And user "Carol" has renamed file "/file17.txt" to "/file18.txt"
+    And user "Carol" has renamed file "/file18.txt" to "/file19.txt"
+    And user "Carol" has renamed file "/file19.txt" to "/file20.txt"
+    When user "Carol" gets the information of last created file
     Then the HTTP status code should be "200"
     And the ocs data of the response should match
       """"
@@ -1049,8 +1049,8 @@ Feature: retrieve file information of a single file, using the file ID
       "statuscode" : {"type" : "number", "enum": [200]},
       "size" : {"type" : "integer", "enum": [6] },
       "name": {"type": "string", "pattern": "^file20.txt$"},
-      "owner_id": {"type": "string", "pattern": "^Alice$"},
-      "owner_name": {"type": "string", "pattern": "^Alice Hansen$"},
+      "owner_id": {"type": "string", "pattern": "^Carol$"},
+      "owner_name": {"type": "string", "pattern": "^Carol Hansen$"},
       "modifier_id": {"type": "string", "pattern": "^Brian"},
       "modifier_name": {"type": "string", "pattern": "^Brian$"},
       "dav_permissions": {"type": "string", "pattern":"^RGDNVW$"},
@@ -1060,10 +1060,10 @@ Feature: retrieve file information of a single file, using the file ID
       """
 
   Scenario Outline: get file info of a file shared with different permissions
-    Given user "Alice" has been created with display-name "Alice Hansen"
+    Given user "Carol" has been created with display-name "Carol Hansen"
     And user "Brian" has been created
-    And user "Alice" has uploaded file with content "some data" to "file.txt"
-    And user "Alice" has shared file "/file.txt" with user "Brian" with "<share-permission>" permissions
+    And user "Carol" has uploaded file with content "some data" to "file.txt"
+    And user "Carol" has shared file "/file.txt" with user "Brian" with "<share-permission>" permissions
     When user "Brian" gets the information of the file "/file.txt"
     Then the HTTP status code should be "200"
     And the ocs data of the response should match
@@ -1087,8 +1087,8 @@ Feature: retrieve file information of a single file, using the file ID
       "statuscode" : {"type" : "number", "enum": [200]},
       "size" : {"type" : "integer", "enum": [9] },
       "name": {"type": "string", "pattern": "^file.txt$"},
-      "owner_id": {"type": "string", "pattern": "^Alice$"},
-      "owner_name": {"type": "string", "pattern": "^Alice Hansen$"},
+      "owner_id": {"type": "string", "pattern": "^Carol$"},
+      "owner_name": {"type": "string", "pattern": "^Carol Hansen$"},
       "modifier_id": {"type": "null"},
       "modifier_name": {"type": "null"},
       "dav_permissions": {"type": "string", "pattern":"^<requester-dav-permissions>$"},
@@ -1096,7 +1096,7 @@ Feature: retrieve file information of a single file, using the file ID
       }
       }
       """
-    When user "Alice" gets the information of the file "/file.txt"
+    When user "Carol" gets the information of the file "/file.txt"
     Then the HTTP status code should be "200"
     And the ocs data of the response should match
       """"
@@ -1119,8 +1119,8 @@ Feature: retrieve file information of a single file, using the file ID
       "statuscode" : {"type" : "number", "enum": [200]},
       "size" : {"type" : "integer", "enum": [9] },
       "name": {"type": "string", "pattern": "^file.txt$"},
-      "owner_id": {"type": "string", "pattern": "^Alice$"},
-      "owner_name": {"type": "string", "pattern": "^Alice Hansen$"},
+      "owner_id": {"type": "string", "pattern": "^Carol$"},
+      "owner_name": {"type": "string", "pattern": "^Carol Hansen$"},
       "modifier_id": {"type": "null"},
       "modifier_name": {"type": "null"},
       "dav_permissions": {"type": "string", "pattern":"^<owner-dav-permissions>$"},
@@ -1140,11 +1140,11 @@ Feature: retrieve file information of a single file, using the file ID
 
 
   Scenario Outline: get file info of a folder shared with different permissions
-    Given user "Alice" has been created with display-name "Alice Hansen"
+    Given user "Carol" has been created with display-name "Carol Hansen"
     And user "Brian" has been created
-    And user "Alice" has created folder "/folder"
-    And user "Alice" has uploaded file with content "some data" to "/folder/file.txt"
-    And user "Alice" has shared folder "/folder" with user "Brian" with "<share-permission>" permissions
+    And user "Carol" has created folder "/folder"
+    And user "Carol" has uploaded file with content "some data" to "/folder/file.txt"
+    And user "Carol" has shared folder "/folder" with user "Brian" with "<share-permission>" permissions
     When user "Brian" gets the information of the folder "/folder"
     Then the HTTP status code should be "200"
     And the ocs data of the response should match
@@ -1168,8 +1168,8 @@ Feature: retrieve file information of a single file, using the file ID
       "statuscode" : {"type" : "number", "enum": [200]},
       "size" : {"type" : "integer", "enum": [9] },
       "name": {"type": "string", "pattern": "^folder$"},
-      "owner_id": {"type": "string", "pattern": "^Alice$"},
-      "owner_name": {"type": "string", "pattern": "^Alice Hansen$"},
+      "owner_id": {"type": "string", "pattern": "^Carol$"},
+      "owner_name": {"type": "string", "pattern": "^Carol Hansen$"},
       "modifier_id": {"type": "null"},
       "modifier_name": {"type": "null"},
       "dav_permissions": {"type": "string", "pattern":"^<requester-dav-permissions>$"},
@@ -1177,7 +1177,7 @@ Feature: retrieve file information of a single file, using the file ID
       }
       }
       """
-    When user "Alice" gets the information of the file "/folder"
+    When user "Carol" gets the information of the file "/folder"
     Then the HTTP status code should be "200"
     And the ocs data of the response should match
       """"
@@ -1200,8 +1200,8 @@ Feature: retrieve file information of a single file, using the file ID
       "statuscode" : {"type" : "number", "enum": [200]},
       "size" : {"type" : "integer", "enum": [9] },
       "name": {"type": "string", "pattern": "^folder$"},
-      "owner_id": {"type": "string", "pattern": "^Alice$"},
-      "owner_name": {"type": "string", "pattern": "^Alice Hansen$"},
+      "owner_id": {"type": "string", "pattern": "^Carol$"},
+      "owner_name": {"type": "string", "pattern": "^Carol Hansen$"},
       "modifier_id": {"type": "null"},
       "modifier_name": {"type": "null"},
       "dav_permissions": {"type": "string", "pattern":"^<owner-dav-permissions>$"},

--- a/tests/acceptance/features/api/getFileinfoByFileIDAPI.feature
+++ b/tests/acceptance/features/api/getFileinfoByFileIDAPI.feature
@@ -230,37 +230,6 @@ Feature: retrieve file information of a single file, using the file ID
     Given user "Carol" has been created
     When user "Brian" gets the information of the file with the id "9999999999999"
     Then the HTTP status code should be "401"
-    And the ocs data of the response should match
-      """"
-      {
-      "type": "object",
-      "required": [
-      "status",
-      "statuscode"
-      ],
-      "not": {
-      "required": [
-      "id",
-      "size",
-      "name",
-      "mtime",
-      "ctime",
-      "mimetype",
-      "owner_id",
-      "owner_name",
-      "modifier_id",
-      "modifier_name",
-      "trashed",
-      "dav_permissions",
-      "path"
-      ]
-      },
-      "properties": {
-      "status": {"type": "string", "pattern": "^Not Found$"},
-      "statuscode" : {"type" : "number", "enum": [404]}
-      }
-      }
-      """
 
   Scenario: get information of a file received as a share
     Given user "Carol" has been created

--- a/tests/acceptance/features/api/getFileinfoByFileIDAPI.feature
+++ b/tests/acceptance/features/api/getFileinfoByFileIDAPI.feature
@@ -228,8 +228,39 @@ Feature: retrieve file information of a single file, using the file ID
 
   Scenario: get information of a non-existing file
     Given user "Carol" has been created
-    When user "Brian" gets the information of the file with the id "9999999999999"
-    Then the HTTP status code should be "401"
+    When user "Carol" gets the information of the file with the id "9999999999999"
+    Then the HTTP status code should be "404"
+    And the ocs data of the response should match
+      """"
+      {
+      "type": "object",
+      "required": [
+      "status",
+      "statuscode"
+      ],
+      "not": {
+      "required": [
+      "id",
+      "size",
+      "name",
+      "mtime",
+      "ctime",
+      "mimetype",
+      "owner_id",
+      "owner_name",
+      "modifier_id",
+      "modifier_name",
+      "trashed",
+      "dav_permissions",
+      "path"
+      ]
+      },
+      "properties": {
+      "status": {"type": "string", "pattern": "^Not Found$"},
+      "statuscode" : {"type" : "number", "enum": [404]}
+      }
+      }
+      """
 
   Scenario: get information of a file received as a share
     Given user "Carol" has been created

--- a/tests/acceptance/features/api/getFilesinfoByFileIDsAPI.feature
+++ b/tests/acceptance/features/api/getFilesinfoByFileIDsAPI.feature
@@ -1,19 +1,19 @@
 Feature: retrieve information of multiple files using the file IDs
 
   Scenario: get information of four files, one own, one received as share, one trashed, one not accessible
-    Given user "Alice" has been created
+    Given user "Carol" has been created
     And user "Brian" has been created with display-name "Brian Adams"
-    And user "Alice" has uploaded file with content "some data" to "file.txt"
+    And user "Carol" has uploaded file with content "some data" to "file.txt"
     And user "Brian" has uploaded file with content "some data" to "fromBrian.txt"
-    And user "Alice" has uploaded file with content "more data" to "trashed.txt"
+    And user "Carol" has uploaded file with content "more data" to "trashed.txt"
     And user "Brian" has uploaded file with content "some data" to "private.txt"
-    And user "Alice" has uploaded file with content "some data" to "fully-deleted.txt"
-    And user "Brian" has shared file "/fromBrian.txt" with user "Alice"
-    And user "Alice" has deleted file "fully-deleted.txt"
-    And user "Alice" has emptied the trash-bin
-    And user "Alice" has deleted file "trashed.txt"
-    And user "Alice" has renamed file "/fromBrian.txt" to "/renamedByAlice.txt"
-    When user "Alice" gets the information of all files created in this scenario
+    And user "Carol" has uploaded file with content "some data" to "fully-deleted.txt"
+    And user "Brian" has shared file "/fromBrian.txt" with user "Carol"
+    And user "Carol" has deleted file "fully-deleted.txt"
+    And user "Carol" has emptied the trash-bin
+    And user "Carol" has deleted file "trashed.txt"
+    And user "Carol" has renamed file "/fromBrian.txt" to "/renamedByCarol.txt"
+    When user "Carol" gets the information of all files created in this scenario
     Then the HTTP status code should be "200"
     And the ocs data of the response should match
     """"
@@ -55,8 +55,8 @@ Feature: retrieve information of multiple files using the file IDs
               "ctime" : {"type" : "integer", "enum": [0]},
               "name": {"type": "string", "pattern": "^file.txt$"},
               "mimetype": {"type": "string", "pattern": "^text\/plain$"},
-              "owner_id": {"type": "string", "pattern": "^Alice$"},
-              "owner_name": {"type": "string", "pattern": "^Alice$"},
+              "owner_id": {"type": "string", "pattern": "^Carol$"},
+              "owner_name": {"type": "string", "pattern": "^Carol$"},
               "modifier_id": {"type": "null"},
               "modifier_name": {"type": "null"},
               "trashed": {"type": "boolean", "enum": [false]},
@@ -98,7 +98,7 @@ Feature: retrieve information of multiple files using the file IDs
               "modifier_name": {"type": "null"},
               "trashed": {"type": "boolean", "enum": [false]},
               "dav_permissions": {"type": "string", "pattern":"^SRGNVW$"},
-              "path": {"type": "string", "pattern":"^files\/renamedByAlice.txt$"}
+              "path": {"type": "string", "pattern":"^files\/renamedByCarol.txt$"}
             }
           },
           "%ids[2]%": {
@@ -129,8 +129,8 @@ Feature: retrieve information of multiple files using the file IDs
               "ctime" : {"type" : "integer", "enum": [0]},
               "name": {"type": "string", "pattern": "^trashed.txt.d\\d{10}$"},
               "mimetype": {"type": "string", "pattern": "^text\/plain$"},
-              "owner_id": {"type": "string", "pattern": "^Alice$"},
-              "owner_name": {"type": "string", "pattern": "^Alice$"},
+              "owner_id": {"type": "string", "pattern": "^Carol$"},
+              "owner_name": {"type": "string", "pattern": "^Carol$"},
               "modifier_id": {"type": "null"},
               "modifier_name": {"type": "null"},
               "trashed": {"type": "boolean", "enum": [true]},

--- a/tests/acceptance/features/api/setup.feature
+++ b/tests/acceptance/features/api/setup.feature
@@ -171,8 +171,8 @@ Feature: setup the integration through an API
       | ""                                                                                                                                                                                            |
 
   Scenario: non-admin user tries to create the setup
-    Given user "Alice" has been created
-    When the user "Alice" sends a POST request to the "setup" endpoint with this data:
+    Given user "Carol" has been created
+    When the user "Carol" sends a POST request to the "setup" endpoint with this data:
       """
       {
       "values" : {
@@ -392,8 +392,8 @@ Feature: setup the integration through an API
 
 
   Scenario: non-admin tries to update the setup
-    Given user "Alice" has been created
-    When the user "Alice" sends a PATCH request to the "setup" endpoint with this data:
+    Given user "Carol" has been created
+    When the user "Carol" sends a PATCH request to the "setup" endpoint with this data:
       """
       {
         "values": {
@@ -446,8 +446,8 @@ Feature: setup the integration through an API
 
 
   Scenario: Trying to reset the integration as non-admin
-    Given user "Alice" has been created
-    When the user "Alice" sends a DELETE request to the "setup" endpoint
+    Given user "Carol" has been created
+    When the user "Carol" sends a DELETE request to the "setup" endpoint
     Then the HTTP status code should be "403"
 
   # this test wil not pass locally if your system already has a `OpenProject` user/group setup
@@ -502,13 +502,13 @@ Feature: setup the integration through an API
     Then user "OpenProject" should have a folder called "OpenProject"
 
     # folders inside the OpenProject folder can only be deleted/renamed by the OpenProject user
-    Given user "Alice" has been created
-    And user "Alice" has been added to the group "OpenProject"
+    Given user "Carol" has been created
+    And user "Carol" has been added to the group "OpenProject"
     And user "OpenProject" has created folder "/OpenProject/project-abc"
-    Then user "Alice" should have a folder called "OpenProject/project-abc"
-    When user "Alice" deletes folder "/OpenProject/project-abc"
+    Then user "Carol" should have a folder called "OpenProject/project-abc"
+    When user "Carol" deletes folder "/OpenProject/project-abc"
     Then the HTTP status code should be 500
-    When user "Alice" renames folder "/OpenProject/project-abc" to "/OpenProject/project-123"
+    When user "Carol" renames folder "/OpenProject/project-abc" to "/OpenProject/project-123"
     Then the HTTP status code should be 500
     When user "OpenProject" renames folder "/OpenProject/project-abc" to "/OpenProject/project-123"
     Then the HTTP status code should be 201
@@ -517,9 +517,9 @@ Feature: setup the integration through an API
 
     # folders 2 levels down inside the OpenProject folder can be deleted by any user even if the parent is also called "OpenProject"
     Given user "OpenProject" has created folder "/OpenProject/OpenProject/project-abc"
-    When user "Alice" renames folder "/OpenProject/OpenProject/project-abc" to "/OpenProject/OpenProject/project-123"
+    When user "Carol" renames folder "/OpenProject/OpenProject/project-abc" to "/OpenProject/OpenProject/project-123"
     Then the HTTP status code should be 201
-    When user "Alice" deletes folder "/OpenProject/OpenProject/project-123"
+    When user "Carol" deletes folder "/OpenProject/OpenProject/project-123"
     Then the HTTP status code should be 204
 
     # a user, who is not in the OpenProject group can delete/rename items inside a folder that is called OpenProject

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -85,7 +85,7 @@ class FeatureContext implements Context {
 	 */
 	public function userHasBeenCreated(string $user, string $displayName = null):void {
 		// delete the user if it exists
-//		$this->theAdministratorDeletesTheUser($user);
+		// $this->theAdministratorDeletesTheUser($user);
 		$userAttributes['userid'] = $user;
 		$userAttributes['password'] = $this->getRegularUserPassword();
 		if ($displayName !== null) {

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -19,6 +19,7 @@ class FeatureContext implements Context {
 	 * list of users that were created on the local server during test runs
 	 * key is the lowercase username, value is an array of user attributes
 	 */
+	/** @var array<mixed> */
 	private array $createdUsers = [];
 	private string $regularUserPassword = '';
 	private string $adminUsername = '';

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -85,7 +85,7 @@ class FeatureContext implements Context {
 	 */
 	public function userHasBeenCreated(string $user, string $displayName = null):void {
 		// delete the user if it exists
-		$this->theAdministratorDeletesTheUser($user);
+//		$this->theAdministratorDeletesTheUser($user);
 		$userAttributes['userid'] = $user;
 		$userAttributes['password'] = $this->getRegularUserPassword();
 		if ($displayName !== null) {

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -85,7 +85,7 @@ class FeatureContext implements Context {
 	 */
 	public function userHasBeenCreated(string $user, string $displayName = null):void {
 		// delete the user if it exists
-		// $this->theAdministratorDeletesTheUser($user);
+		$this->theAdministratorDeletesTheUser($user);
 		$userAttributes['userid'] = $user;
 		$userAttributes['password'] = $this->getRegularUserPassword();
 		if ($displayName !== null) {


### PR DESCRIPTION
In test we clear user before we make them but we don't clear it in the after scenario.
In this PR we remove the user's in the after scenario as well. 

We have noticed some of the flaky tests in the CI https://github.com/nextcloud/integration_openproject/actions/runs/4911413323/jobs/8770565064

User `alice`  is created by default when the docker container is started https://github.com/juliushaertl/nextcloud-docker-dev/blob/d63dd0b14516e531714844c33421c7be24689b09/docker/bin/bootstrap.sh#L296

And since we're also creating user with the same name maybe the tests are getting confused. This PR changes all the occurrences of user `Alice` to user `Carol`. I think it's better to not use `Alice` user in tests

Related workpackage [OP#48128]: https://community.openproject.org/projects/nextcloud-integration/work_packages/48128