### PR TITLE
Add environment variable for retrying auto installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,7 @@ jobs:
           NEXTCLOUD_TRUSTED_DOMAINS: nextcloud
           VIRTUAL_HOST: "nextcloud"
           WITH_REDIS: "YES"
+          NEXTCLOUD_AUTOINSTALL_APPS_WAIT_TIME: 120
         volumes:
           - /home/runner/work/integration_openproject/integration_openproject:/var/www/html/apps-shared
 

--- a/src/views/ProjectsTab.vue
+++ b/src/views/ProjectsTab.vue
@@ -321,8 +321,8 @@ export default {
 		}
 		&--unlinkactionbutton {
 			position: absolute;
-			right:0;
-			top:0;
+			right: 0;
+			top: 0;
 			margin: 4px;
 			visibility: hidden;
 		}


### PR DESCRIPTION
This PR https://github.com/juliushaertl/nextcloud-docker-dev/pull/189 made the auto retry of app installation default to 0 so we add the environment variable to `120`.  