### PR TITLE
fix style lint in `src/views/ProjectsTab.vue`

### DIFF
--- a/src/views/ProjectsTab.vue
+++ b/src/views/ProjectsTab.vue
@@ -321,8 +321,8 @@ export default {
 		}
 		&--unlinkactionbutton {
 			position: absolute;
-			right:0;
-			top:0;
+			right: 0;
+			top: 0;
 			margin: 4px;
 			visibility: hidden;
 		}


### PR DESCRIPTION
These changes were made by https://github.com/nextcloud/integration_openproject/pull/407 but the linter didn't complain so weren't caught at the time of the merge of PR but now the linter is complaining. So this PR fixes that