### PR TITLE
Add support for nextcloud master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     name: unit tests and linting
     strategy:
       matrix:
-        nextcloudVersion: [ stable23, stable24, stable25, stable26, master ]
+        nextcloudVersion: [ stable23, stable24, stable25, stable26, stable27, master ]
         phpVersion: [ 7.4, 8.0, 8.1 ]
         exclude:
           - nextcloudVersion: stable23
@@ -23,6 +23,8 @@ jobs:
           - nextcloudVersion: stable24
             phpVersion: 8.1
           - nextcloudVersion: stable26
+            phpVersion: 7.4
+          - nextcloudVersion: stable27
             phpVersion: 7.4
           - nextcloudVersion: master
             phpVersion: 7.4
@@ -154,7 +156,7 @@ jobs:
     name: API tests
     strategy:
       matrix:
-        nextcloudVersion: [ stable23, stable24, stable25, stable26, master ]
+        nextcloudVersion: [ stable23, stable24, stable25, stable26, stable27, master ]
         phpVersionMajor: [ 7, 8 ]
         phpVersionMinor: [ 4, 1 ]
         database: [pgsql, mysql]
@@ -166,6 +168,14 @@ jobs:
             phpVersionMajor: 8
             phpVersionMinor: 1
           - nextcloudVersion: stable26
+            phpVersionMajor: 7
+          - phpVersionMajor: 7
+            phpVersionMinor: 0
+          - phpVersionMajor: 7
+            phpVersionMinor: 1
+          - phpVersionMajor: 8
+            phpVersionMinor: 4
+          - nextcloudVersion: stable27
             phpVersionMajor: 7
           - phpVersionMajor: 7
             phpVersionMinor: 0

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -35,7 +35,7 @@ For more information on how to set up and use the OpenProject application, pleas
 	<screenshot>https://github.com/nextcloud/integration_openproject/raw/master/img/screenshot1.png</screenshot>
 	<screenshot>https://github.com/nextcloud/integration_openproject/raw/master/img/screenshot2.png</screenshot>
 	<dependencies>
-		<nextcloud min-version="23" max-version="27"/>
+		<nextcloud min-version="23" max-version="28"/>
 	</dependencies>
 	<background-jobs>
 		<job>OCA\OpenProject\BackgroundJob\RemoveExpiredDirectUploadTokens</job>


### PR DESCRIPTION
The Nextcloud server is now `28` https://github.com/nextcloud/server/blob/master/version.php
so we add support for `28` 

needs https://github.com/nextcloud/groupfolders/pull/2393 to be merged first