### PR TITLE
[OP#48255]Fix global search to display all the work packages available to the user

### DIFF
--- a/lib/Search/OpenProjectSearchProvider.php
+++ b/lib/Search/OpenProjectSearchProvider.php
@@ -125,7 +125,7 @@ class OpenProjectSearchProvider implements IProvider {
 			return SearchResult::paginated($this->getName(), [], 0);
 		}
 
-		$searchResults = $this->service->searchWorkPackage($user->getUID(), $term, null, true);
+		$searchResults = $this->service->searchWorkPackage($user->getUID(), $term, null, false);
 		$searchResults = array_slice($searchResults, $offset, $limit);
 
 		if (isset($searchResults['error'])) {

--- a/lib/Search/OpenProjectSearchProvider.php
+++ b/lib/Search/OpenProjectSearchProvider.php
@@ -125,7 +125,7 @@ class OpenProjectSearchProvider implements IProvider {
 			return SearchResult::paginated($this->getName(), [], 0);
 		}
 
-		$searchResults = $this->service->searchWorkPackage($user->getUID(), $term);
+		$searchResults = $this->service->searchWorkPackage($user->getUID(), $term, null, true);
 		$searchResults = array_slice($searchResults, $offset, $limit);
 
 		if (isset($searchResults['error'])) {

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -213,7 +213,7 @@ class OpenProjectAPIService {
 	 * @param string $userId
 	 * @param string|null $query
 	 * @param int|null $fileId
-	 * @param bool $isGlobalSearch
+	 * @param bool $onlyLinkableWorkPackages
 	 * @return array<mixed>
 	 * @throws \OCP\PreConditionNotMetException
 	 * @throws \Safe\Exceptions\JsonException
@@ -222,7 +222,7 @@ class OpenProjectAPIService {
 		string $userId,
 		string $query = null,
 		int $fileId = null,
-		bool $isGlobalSearch = false
+		bool $onlyLinkableWorkPackages = true
 	): array {
 		$resultsById = [];
 		$filters = [];
@@ -234,7 +234,7 @@ class OpenProjectAPIService {
 		if ($query !== null) {
 			$filters[] = ['typeahead' => ['operator' => '**', 'values' => [$query]]];
 		}
-		$resultsById = $this->searchRequest($userId, $filters, $isGlobalSearch);
+		$resultsById = $this->searchRequest($userId, $filters, $onlyLinkableWorkPackages);
 		if (isset($resultsById['error'])) {
 			return $resultsById;
 		}
@@ -244,15 +244,15 @@ class OpenProjectAPIService {
 	/**
 	 * @param string $userId
 	 * @param array<mixed> $filters
-	 * @param bool $isGlobalSearch
+	 * @param bool $onlyLinkableWorkPackages
 	 * @return array<mixed>
 	 * @throws \OCP\PreConditionNotMetException
 	 * @throws \Safe\Exceptions\JsonException
 	 */
-	private function searchRequest(string $userId, array $filters, bool $isGlobalSearch = false): array {
+	private function searchRequest(string $userId, array $filters, bool $onlyLinkableWorkPackages = true): array {
 		$resultsById = [];
 		$sortBy = [['updatedAt', 'desc']];
-		if (!$isGlobalSearch) {
+		if ($onlyLinkableWorkPackages) {
 			$filters[] = [
 				'linkable_to_storage_url' =>
 					['operator' => '=', 'values' => [urlencode($this->getBaseUrl())]]

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -246,6 +246,8 @@ class OpenProjectAPIService {
 	 * @param array<mixed> $filters
 	 * @param bool $isGlobalSearch
 	 * @return array<mixed>
+	 * @throws \OCP\PreConditionNotMetException
+	 * @throws \Safe\Exceptions\JsonException
 	 */
 	private function searchRequest(string $userId, array $filters, bool $isGlobalSearch = false): array {
 		$resultsById = [];

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -208,12 +208,12 @@ class OpenProjectAPIService {
 	public function getBaseUrl(): string {
 		return $this->urlGenerator->getBaseUrl();
 	}
+
 	/**
 	 * @param string $userId
 	 * @param string|null $query
 	 * @param int|null $fileId
-	 * @param int $offset
-	 * @param int $limit
+	 * @param bool $isGlobalSearch
 	 * @return array<mixed>
 	 * @throws \OCP\PreConditionNotMetException
 	 * @throws \Safe\Exceptions\JsonException
@@ -222,8 +222,7 @@ class OpenProjectAPIService {
 		string $userId,
 		string $query = null,
 		int $fileId = null,
-		int $offset = 0,
-		int $limit = 5
+		bool $isGlobalSearch = false
 	): array {
 		$resultsById = [];
 		$filters = [];
@@ -235,7 +234,7 @@ class OpenProjectAPIService {
 		if ($query !== null) {
 			$filters[] = ['typeahead' => ['operator' => '**', 'values' => [$query]]];
 		}
-		$resultsById = $this->searchRequest($userId, $filters);
+		$resultsById = $this->searchRequest($userId, $filters, $isGlobalSearch);
 		if (isset($resultsById['error'])) {
 			return $resultsById;
 		}
@@ -245,22 +244,22 @@ class OpenProjectAPIService {
 	/**
 	 * @param string $userId
 	 * @param array<mixed> $filters
+	 * @param bool $isGlobalSearch
 	 * @return array<mixed>
-	 * @throws \OCP\PreConditionNotMetException
-	 * @throws \Safe\Exceptions\JsonException
 	 */
-	private function searchRequest(string $userId, array $filters): array {
+	private function searchRequest(string $userId, array $filters, bool $isGlobalSearch = false): array {
 		$resultsById = [];
 		$sortBy = [['updatedAt', 'desc']];
-		$filters[] = [
-			'linkable_to_storage_url' =>
-				['operator' => '=', 'values' => [urlencode($this->getBaseUrl())]]
-		];
+		if (!$isGlobalSearch) {
+			$filters[] = [
+				'linkable_to_storage_url' =>
+					['operator' => '=', 'values' => [urlencode($this->getBaseUrl())]]
+			];
+		}
 
 		$params = [
 			'filters' => \Safe\json_encode($filters),
 			'sortBy' => \Safe\json_encode($sortBy),
-			// 'limit' => $limit,
 		];
 		$searchResult = $this->request($userId, 'work_packages', $params);
 

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -525,6 +525,30 @@ class OpenProjectAPIServiceTest extends TestCase {
 	}
 
 	/**
+	 * @param array<mixed> $response
+	 * @param array<mixed> $expectedResult
+	 * @return void
+	 * @dataProvider searchWorkPackageDataProvider
+	 */
+	public function testSearchWorkPackageNotLinkedToAStorage(array $response, array $expectedResult) {
+		$service = $this->getServiceMock();
+		$service->method('request')
+			->with(
+				'user', 'work_packages',
+				[
+					'filters' => '[' .
+						'{"typeahead":' .
+						'{"operator":"**","values":["search query"]}'.
+						'}]',
+					'sortBy' => '[["updatedAt","desc"]]',
+				]
+			)
+			->willReturn($response);
+		$result = $service->searchWorkPackage('user', 'search query', null, true);
+		$this->assertSame($expectedResult, $result);
+	}
+
+	/**
 	 * @return void
 	 */
 	public function testSearchWorkPackageByFileIdOnlyFileId() {

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -544,7 +544,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 				]
 			)
 			->willReturn($response);
-		$result = $service->searchWorkPackage('user', 'search query', null, true);
+		$result = $service->searchWorkPackage('user', 'search query', null, false);
 		$this->assertSame($expectedResult, $result);
 	}
 


### PR DESCRIPTION
Related work package [OP#48255] : https://community.openproject.org/projects/nextcloud-integration/work_packages/48255
Currently, the global search of the nextcloud search only searches for the work packages that are linkable by the user. This PR fixes it to return all the work packages that are available to the user

needs https://github.com/nextcloud/integration_openproject/pull/410 to be merged first