### PR TITLE
[OP#48255][Backport]Fix global search to display all the work packages available to the user 

### DIFF
--- a/lib/Search/OpenProjectSearchProvider.php
+++ b/lib/Search/OpenProjectSearchProvider.php
@@ -125,7 +125,7 @@ class OpenProjectSearchProvider implements IProvider {
 			return SearchResult::paginated($this->getName(), [], 0);
 		}
 
-		$searchResults = $this->service->searchWorkPackage($user->getUID(), $term);
+		$searchResults = $this->service->searchWorkPackage($user->getUID(), $term, null, false);
 		$searchResults = array_slice($searchResults, $offset, $limit);
 
 		if (isset($searchResults['error'])) {

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -158,8 +158,7 @@ class OpenProjectAPIService {
 	 * @param string $userId
 	 * @param string|null $query
 	 * @param int|null $fileId
-	 * @param int $offset
-	 * @param int $limit
+	 * @param bool $onlyLinkableWorkPackages
 	 * @return array<mixed>
 	 * @throws \OCP\PreConditionNotMetException
 	 * @throws \Safe\Exceptions\JsonException
@@ -168,8 +167,7 @@ class OpenProjectAPIService {
 		string $userId,
 		string $query = null,
 		int $fileId = null,
-		int $offset = 0,
-		int $limit = 5
+		bool $onlyLinkableWorkPackages = true
 	): array {
 		$resultsById = [];
 		$filters = [];
@@ -181,7 +179,7 @@ class OpenProjectAPIService {
 		if ($query !== null) {
 			$filters[] = ['typeahead' => ['operator' => '**', 'values' => [$query]]];
 		}
-		$resultsById = $this->searchRequest($userId, $filters);
+		$resultsById = $this->searchRequest($userId, $filters, $onlyLinkableWorkPackages);
 		if (isset($resultsById['error'])) {
 			return $resultsById;
 		}
@@ -191,17 +189,21 @@ class OpenProjectAPIService {
 	/**
 	 * @param string $userId
 	 * @param array<mixed> $filters
+	 * @param bool $onlyLinkableWorkPackages
+	 *
 	 * @return array<mixed>
 	 * @throws \OCP\PreConditionNotMetException
 	 * @throws \Safe\Exceptions\JsonException
 	 */
-	private function searchRequest(string $userId, array $filters): array {
+	private function searchRequest(string $userId, array $filters, bool $onlyLinkableWorkPackages = true): array {
 		$resultsById = [];
 		$sortBy = [['updatedAt', 'desc']];
-		$filters[] = [
-			'linkable_to_storage_url' =>
-				['operator' => '=', 'values' => [urlencode($this->getBaseUrl())]]
-		];
+		if ($onlyLinkableWorkPackages) {
+			$filters[] = [
+				'linkable_to_storage_url' =>
+					['operator' => '=', 'values' => [urlencode($this->getBaseUrl())]]
+			];
+		}
 
 		$params = [
 			'filters' => \Safe\json_encode($filters),

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -1825,4 +1825,29 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$this->expectException(OpenprojectErrorException::class);
 		$service->deleteFileLink(12345, 'testUser');
 	}
+
+
+	/**
+	 * @param array<mixed> $response
+	 * @param array<mixed> $expectedResult
+	 * @return void
+	 * @dataProvider searchWorkPackageDataProvider
+	 */
+	public function testSearchWorkPackageNotLinkedToAStorage(array $response, array $expectedResult) {
+		$service = $this->getServiceMock();
+		$service->method('request')
+			->with(
+				'user', 'work_packages',
+				[
+					'filters' => '[' .
+						'{"typeahead":' .
+						'{"operator":"**","values":["search query"]}'.
+						'}]',
+					'sortBy' => '[["updatedAt","desc"]]',
+				]
+			)
+			->willReturn($response);
+		$result = $service->searchWorkPackage('user', 'search query', null, false);
+		$this->assertSame($expectedResult, $result);
+	}
 }


### PR DESCRIPTION
Related work package [OP#48255] : https://community.openproject.org/projects/nextcloud-integration/work_packages/48255
Currently, the global search of the nextcloud search only searches for the work packages that are linkable by the user. This PR fixes it to return all the work packages that are available to the user

Backport: https://github.com/nextcloud/integration_openproject/pull/411