### PR TITLE
rely on foldername not fileID for delete protection of project folders

### DIFF
--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -192,7 +192,6 @@ class ConfigController extends Controller {
 				throw new InvalidArgumentException('Invalid key');
 			}
 		}
-		$openProjectGroupFolderFileId = null;
 
 		if (key_exists('setup_group_folder', $values) && $values['setup_group_folder']) {
 			$isSystemReady = $this->openprojectAPIService->isSystemReadyForGroupFolderSetUp();
@@ -202,7 +201,7 @@ class ConfigController extends Controller {
 				$group = $this->groupManager->createGroup(Application::OPEN_PROJECT_ENTITIES_NAME);
 				$group->addUser($user);
 				$this->subAdminManager->createSubAdmin($user, $group);
-				$openProjectGroupFolderFileId = $this->openprojectAPIService->createGroupfolder();
+				$this->openprojectAPIService->createGroupfolder();
 			}
 		}
 
@@ -311,8 +310,7 @@ class ConfigController extends Controller {
 		$this->config->deleteAppValue(Application::APP_ID, 'oPOAuthTokenRevokeStatus');
 		return [
 			"status" => OpenProjectAPIService::isAdminConfigOk($this->config),
-			"oPOAuthTokenRevokeStatus" => $oPOAuthTokenRevokeStatus,
-			"oPGroupFolderFileId" => $openProjectGroupFolderFileId
+			"oPOAuthTokenRevokeStatus" => $oPOAuthTokenRevokeStatus
 		];
 	}
 
@@ -523,9 +521,6 @@ class ConfigController extends Controller {
 			$result = $this->recreateOauthClientInformation();
 			if ($status['oPOAuthTokenRevokeStatus'] !== '') {
 				$result['openproject_revocation_status'] = $status['oPOAuthTokenRevokeStatus'];
-			}
-			if ($status['oPGroupFolderFileId'] !== null) {
-				$result['openproject_groupfolder_id'] = $status['oPGroupFolderFileId'];
 			}
 			return new DataResponse($result);
 		} catch (OpenprojectGroupfolderSetupConflictException $e) {

--- a/lib/Listener/BeforeNodeInsideOpenProjectGroupfilderChangedListener.php
+++ b/lib/Listener/BeforeNodeInsideOpenProjectGroupfilderChangedListener.php
@@ -49,7 +49,7 @@ class BeforeNodeInsideOpenProjectGroupfilderChangedListener implements IEventLis
 		}
 		$currentUserId = $this->userSession->getUser()->getUID();
 		if (
-			$this->openprojectAPIService->isGroupFolderSetup() &&
+			$this->openprojectAPIService->isProjectFoldersSetupComplete() &&
 			preg_match('/.*\/files\/' .  Application::OPEN_PROJECT_ENTITIES_NAME . '$/', $parentNode->getPath()) === 1 &&
 			$currentUserId !== Application::OPEN_PROJECT_ENTITIES_NAME &&
 			$this->groupManager->isInGroup($currentUserId, Application::OPEN_PROJECT_ENTITIES_NAME)

--- a/lib/Listener/BeforeNodeInsideOpenProjectGroupfilderChangedListener.php
+++ b/lib/Listener/BeforeNodeInsideOpenProjectGroupfilderChangedListener.php
@@ -10,7 +10,6 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Files\Events\Node\BeforeNodeDeletedEvent;
 use OCP\Files\Events\Node\BeforeNodeRenamedEvent;
-use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IUserSession;
 

--- a/lib/Listener/BeforeNodeInsideOpenProjectGroupfilderChangedListener.php
+++ b/lib/Listener/BeforeNodeInsideOpenProjectGroupfilderChangedListener.php
@@ -29,21 +29,15 @@ class BeforeNodeInsideOpenProjectGroupfilderChangedListener implements IEventLis
 	 * @var IUserSession
 	 */
 	private $userSession;
-	/**
-	 * @var IConfig
-	 */
-	private $config;
 
 	public function __construct(
 		OpenProjectAPIService $openprojectAPIService,
 		IUserSession $userSession,
-		IGroupManager $groupManager,
-		IConfig $config
+		IGroupManager $groupManager
 	) {
 		$this->openprojectAPIService = $openprojectAPIService;
 		$this->userSession = $userSession;
 		$this->groupManager = $groupManager;
-		$this->config = $config;
 	}
 
 	public function handle(Event $event): void {

--- a/lib/Listener/BeforeNodeInsideOpenProjectGroupfilderChangedListener.php
+++ b/lib/Listener/BeforeNodeInsideOpenProjectGroupfilderChangedListener.php
@@ -56,11 +56,8 @@ class BeforeNodeInsideOpenProjectGroupfilderChangedListener implements IEventLis
 		}
 		$currentUserId = $this->userSession->getUser()->getUID();
 		if (
-			$this->openprojectAPIService->isProjectFoldersSetupComplete() &&
-			$parentNode->getId() === (int)$this->config->getAppValue(
-				Application::APP_ID,
-				'openproject_groupfolder_id',
-			) &&
+			$this->openprojectAPIService->isGroupFolderSetup() &&
+			preg_match('/.*\/files\/' .  Application::OPEN_PROJECT_ENTITIES_NAME . '$/', $parentNode->getPath()) === 1 &&
 			$currentUserId !== Application::OPEN_PROJECT_ENTITIES_NAME &&
 			$this->groupManager->isInGroup($currentUserId, Application::OPEN_PROJECT_ENTITIES_NAME)
 		) {

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -931,7 +931,7 @@ class OpenProjectAPIService {
 	 * @throws NotFoundException
 	 * @throws NoUserException
 	 */
-	public function createGroupfolder(): int {
+	public function createGroupfolder(): void {
 		if (version_compare(OC_Util::getVersionString(), '27') >= 0) {
 			// @phpstan-ignore-next-line - make phpstan not complain if groupfolders app does not exist
 			$groupfoldersFolderManager = new FolderManager($this->dbConnection, $this->groupManager, $this->mimeTypeLoader, $this->logger);
@@ -961,14 +961,6 @@ class OpenProjectAPIService {
 			Application::OPEN_PROJECT_ENTITIES_NAME,
 			true
 		);
-		$userFolder = $this->storage->getUserFolder(Application::OPEN_PROJECT_ENTITIES_NAME);
-		$openProjectFolder = $userFolder->get(Application::OPEN_PROJECT_ENTITIES_NAME);
-		$this->config->setAppValue(
-			Application::APP_ID,
-			'openproject_groupfolder_id',
-			(string)$openProjectFolder->getId()
-		);
-		return $openProjectFolder->getId();
 	}
 
 	// @phpstan-ignore-next-line - make phpstan not complain if groupfolders app does not exist

--- a/tests/acceptance/features/api/setup.feature
+++ b/tests/acceptance/features/api/setup.feature
@@ -480,8 +480,7 @@ Feature: setup the integration through an API
           "nextcloud_oauth_client_name": {"type": "string", "pattern": "^OpenProject client$"},
           "openproject_redirect_uri": {"type": "string", "pattern": "^http:\/\/some-host.de\/oauth_clients\/[A-Za-z0-9]+\/callback$"},
           "nextcloud_client_id": {"type": "string", "pattern": "[A-Za-z0-9]+"},
-          "nextcloud_client_secret": {"type": "string", "pattern": "[A-Za-z0-9]+"},
-          "openproject_groupfolder_id": {"type": "integer"}
+          "nextcloud_client_secret": {"type": "string", "pattern": "[A-Za-z0-9]+"}
       },
       "not": {
       "required": [

--- a/tests/lib/Controller/ConfigControllerTest.php
+++ b/tests/lib/Controller/ConfigControllerTest.php
@@ -558,8 +558,7 @@ class ConfigControllerTest extends TestCase {
 		$this->assertSame(
 			[
 				'status' => $adminConfigStatus,
-				'oPOAuthTokenRevokeStatus' => '',
-				'oPGroupFolderFileId' => null
+				'oPOAuthTokenRevokeStatus' => ''
 			],
 			$result->getData()
 		);


### PR DESCRIPTION
Relying on the fileID might be problematic because the admin might have deleted the OpenProject groupfolder and recreated it, in that case the fileID would have changed, but we would not know about it
Signed-off-by: Artur Neumann <artur@jankaritech.com>
