### PR TITLE
improve check if the groupfolder is setup correctly

### DIFF
--- a/lib/Listener/BeforeNodeInsideOpenProjectGroupfilderChangedListener.php
+++ b/lib/Listener/BeforeNodeInsideOpenProjectGroupfilderChangedListener.php
@@ -56,7 +56,7 @@ class BeforeNodeInsideOpenProjectGroupfilderChangedListener implements IEventLis
 		}
 		$currentUserId = $this->userSession->getUser()->getUID();
 		if (
-			$this->openprojectAPIService->isGroupFolderSetup() &&
+			$this->openprojectAPIService->isProjectFoldersSetupComplete() &&
 			$parentNode->getId() === (int)$this->config->getAppValue(
 				Application::APP_ID,
 				'openproject_groupfolder_id',

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -1039,6 +1039,7 @@ class OpenProjectAPIService {
 				$folder['permissions'] === 31 &&
 				$folder['acl'] === true
 			) {
+				// @phpstan-ignore-next-line - make phpstan not complain if groupfolders app does not exist
 				if ($groupFolderManager->canManageACL(
 					$folder['folder_id'],
 					$this->userManager->get(Application::OPEN_PROJECT_ENTITIES_NAME)


### PR DESCRIPTION
Using the storage and the userfolder to check the groupfolder configuration seems to be bridle, because the user called OpenProject might not be completely finalized (first login not done) when we call this check. We didn't manage to finalize the login programmatically in a way, so that the groupfolders app would create the mounts etc, sometimes we are getting lock exceptions.
But luckily we don't need to rely on the userfolder, all the checks that we want, we can do through the `groupFolderManager`

This PR changes the code so that we have one function that checks:
 - if the group names OpenProject is managing a folder called OpenProject
 - if the permissions are set correctly
 - if the ACL is enabled and can be managed by the user OpenProject
It also renames the function to make clear what is about the configuration of the groupfolder app and what is about the complete project folder setup
Signed-off-by: Artur Neumann <artur@jankaritech.com>
