### PR TITLE
Installed additional module, authenticated docker hub for more image pull

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
             phpVersion: 7.4
           - nextcloudVersion: master
             phpVersion: 7.4
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -39,6 +39,7 @@ jobs:
           php-version: ${{ matrix.phpVersion }}
           tools: composer, phpunit
           coverage: xdebug
+          extensions: gd, sqlite3
 
       - name: Get composer cache directory
         id: composer-cache
@@ -109,6 +110,13 @@ jobs:
           lcov-file: ./server/apps/integration_openproject/coverage/jest/lcov.info
           delete-old-comments: true
           title: "JS Code Coverage"
+
+      - name: Setup .NET Core # this is required to execute Convert PHP cobertura coverage to lcov step
+        if: ${{ github.event_name == 'pull_request' && matrix.nextcloudVersion == 'master' && matrix.phpVersion == '8.1' }}
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 6.0.101
+          dotnet-quality: 'ga'
 
       - name: Convert PHP cobertura coverage to lcov
         if: ${{ github.event_name == 'pull_request' && matrix.nextcloudVersion == 'master' && matrix.phpVersion == '8.1' }}
@@ -191,8 +199,13 @@ jobs:
             phpVersionMinor: 1
           - phpVersionMajor: 8
             phpVersionMinor: 4
-    runs-on: ubuntu-latest
-    container: ubuntu:latest
+    runs-on: ubuntu-20.04
+    container:
+      image: ubuntu:latest
+      credentials:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
     defaults:
       run:
         working-directory: integration_openproject
@@ -217,6 +230,9 @@ jobs:
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: nextcloud
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       database-mysql:
         image: mariadb:10.5
@@ -225,9 +241,15 @@ jobs:
           MYSQL_PASSWORD: 'nextcloud'
           MYSQL_USER: 'nextcloud'
           MYSQL_DATABASE: 'nextcloud'
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       redis:
         image: redis:7
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
### Description
1.The php gd extension is required for the CI and also extension sqlite3 is need in order to install nextcloud in sqlite to run unit tests. This PR adds those modules. Other wise CI gives error like below:
```
PHP module GD not installed.
Please ask your server administrator to install the module.

An unhandled exception has been thrown:
Exception: Environment not properly prepared. in /home/runner/actions-
```

2. Also this PR authenticates to docker in the CI to increase the limit of the image pull for different services in the github actions workflow. Other wise CI gives error like below:
```
 Error response from daemon: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
  Error: Docker pull failed with exit code 1
```

3. Also added `sqlite3` extension to be able to install the `nextcloud` with it

4. Also adds new step to set up .NET core required to execute the `Convert PHP cobertura coverage to lcov` step in CI
5. Bump `ubuntu` to `20.04` since it exists with error `disk quota exceeded`.