### PR TITLE
[OP#48460]Do not show project folder when app password is in Edit mode

### DIFF
--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -616,11 +616,11 @@ export default {
 		async setNCOAuthFormToViewMode() {
 			this.formMode.ncOauth = F_MODES.VIEW
 			this.isFormCompleted.ncOauth = true
-			if (!this.isIntegrationComplete && this.formMode.projectFolderSetUp !== F_MODES.EDIT) {
+			if (!this.isIntegrationComplete && this.formMode.projectFolderSetUp !== F_MODES.EDIT && this.formMode.opUserAppPassword !== F_MODES.EDIT) {
+				this.formMode.projectFolderSetUp = F_MODES.EDIT
 				this.showDefaultManagedProjectFolders = true
 				this.isProjectFolderSwitchEnabled = true
 				this.textLabelProjectFolderSetupButton = this.buttonTextLabel.completeWithProjectFolderSetup
-				this.formMode.projectFolderSetUp = F_MODES.EDIT
 			}
 		},
 		setOPUserAppPasswordToViewMode() {


### PR DESCRIPTION
### Description
Fixed the related bug when `app password` and `NC oauth` filed is in edit mode that enables the project folder to edit mode.

### Related Work Package
https://community.openproject.org/projects/nextcloud-integration/work_packages/48460/activity?query_id=3714