### PR TITLE
[OP#48397]Show navigation link to admin if integration setup is not done

### DIFF
--- a/src/components/OAuthConnectButton.vue
+++ b/src/components/OAuthConnectButton.vue
@@ -15,6 +15,7 @@ import OpenInNewIcon from 'vue-material-design-icons/OpenInNew.vue'
 import { generateUrl } from '@nextcloud/router'
 import { showError } from '@nextcloud/dialogs'
 import { getCurrentUser } from '@nextcloud/auth'
+import { translate as t } from '@nextcloud/l10n'
 import '@nextcloud/dialogs/styles/toast.scss'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import dompurify from 'dompurify'
@@ -42,8 +43,7 @@ export default {
 
 	computed: {
 		adminConfigNotOkMessage() {
-			const user = getCurrentUser()
-			if (user.isAdmin) {
+			if (getCurrentUser().isAdmin) {
 				const linkText = t('integration_openproject', 'Administration Settings > OpenProject')
 				const url = generateUrl('/settings/admin/openproject')
 				const htmlLink = `<a class="link" href="${url}" target="_blank" title="${linkText}">${linkText}</a>`

--- a/src/components/OAuthConnectButton.vue
+++ b/src/components/OAuthConnectButton.vue
@@ -7,18 +7,17 @@
 		</template>
 		{{ t('integration_openproject', 'Connect to OpenProject') }}
 	</NcButton>
-	<div v-else class="oauth-connect--message">
-		{{ adminConfigNotOkMessage }}
-	</div>
+	<div v-else class="oauth-connect--message" v-html="adminConfigNotOkMessage" /> <!-- eslint-disable-line vue/no-v-html -->
 </template>
 <script>
 import axios from '@nextcloud/axios'
 import OpenInNewIcon from 'vue-material-design-icons/OpenInNew.vue'
 import { generateUrl } from '@nextcloud/router'
 import { showError } from '@nextcloud/dialogs'
+import { getCurrentUser } from '@nextcloud/auth'
 import '@nextcloud/dialogs/styles/toast.scss'
-import { translate as t } from '@nextcloud/l10n'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
+import dompurify from 'dompurify'
 
 export default {
 	name: 'OAuthConnectButton',
@@ -43,6 +42,15 @@ export default {
 
 	computed: {
 		adminConfigNotOkMessage() {
+			const user = getCurrentUser()
+			if (user.isAdmin) {
+				const linkText = t('integration_openproject', 'Administration Settings > OpenProject')
+				const url = generateUrl('/settings/admin/openproject')
+				const htmlLink = `<a class="link" href="${url}" target="_blank" title="${linkText}">${linkText}</a>`
+				const hintText = t('integration_openproject', 'Some OpenProject integration application settings are not working. '
+				+ 'Click here {htmlLink} to set them up properly.', { htmlLink }, null, { escape: false, sanitize: false })
+				return dompurify.sanitize(hintText, { ADD_ATTR: ['target'] })
+			}
 			return t('integration_openproject', 'Some OpenProject integration application settings are not working.'
 				+ ' Please contact your Nextcloud administrator.')
 		},
@@ -92,5 +100,11 @@ export default {
 		padding: 0 18px;
 		line-height: 1.4rem;
 	}
+}
+</style>
+<style>
+.link {
+	color: #1a67a3 !important;
+	font-style: italic;
 }
 </style>

--- a/src/components/OAuthConnectButton.vue
+++ b/src/components/OAuthConnectButton.vue
@@ -48,7 +48,7 @@ export default {
 				const url = generateUrl('/settings/admin/openproject')
 				const htmlLink = `<a class="link" href="${url}" target="_blank" title="${linkText}">${linkText}</a>`
 				const hintText = t('integration_openproject', 'Some OpenProject integration application settings are not working. '
-				+ 'Click here {htmlLink} to set them up properly.', { htmlLink }, null, { escape: false, sanitize: false })
+				+ 'Configure the OpenProject integration in: {htmlLink}', { htmlLink }, null, { escape: false, sanitize: false })
 				return dompurify.sanitize(hintText, { ADD_ATTR: ['target'] })
 			}
 			return t('integration_openproject', 'Some OpenProject integration application settings are not working.'

--- a/tests/jest/components/OAuthConnectButton.spec.js
+++ b/tests/jest/components/OAuthConnectButton.spec.js
@@ -4,9 +4,11 @@ import { mount, createLocalVue } from '@vue/test-utils'
 import OAuthConnectButton from '../../../src/components/OAuthConnectButton.vue'
 import axios from '@nextcloud/axios'
 import * as dialogs from '@nextcloud/dialogs'
+import { getCurrentUser } from '@nextcloud/auth'
 
 jest.mock('@nextcloud/axios')
 jest.mock('@nextcloud/dialogs')
+jest.mock('@nextcloud/auth')
 
 const realLocation = global.window.location
 const localVue = createLocalVue()
@@ -21,8 +23,19 @@ describe('OAuthConnectButton.vue', () => {
 		jest.clearAllMocks()
 	})
 	describe('when the admin config is not okay', () => {
-		it('should show message', async () => {
+		it('should show message for normal user', async () => {
+			getCurrentUser.mockReturnValue(() => {
+				return '{"isAdmin": false}'
+			})
 			wrapper = getWrapper({ isAdminConfigOk: false })
+			expect(wrapper).toMatchSnapshot()
+		})
+
+		it('should show message for admin user', async () => {
+			getCurrentUser.mockReturnValue(() => {
+				return '{"isAdmin": true}'
+			})
+			wrapper = getWrapper({ isAdminConfigOk: false }, true)
 			expect(wrapper).toMatchSnapshot()
 		})
 	})
@@ -85,6 +98,9 @@ function getWrapper(props = {}) {
 		localVue,
 		mocks: {
 			t: (app, msg) => msg,
+			generateUrl() {
+				return '/'
+			},
 		},
 		propsData: {
 			isAdminConfigOk: true,

--- a/tests/jest/components/OAuthConnectButton.spec.js
+++ b/tests/jest/components/OAuthConnectButton.spec.js
@@ -24,18 +24,16 @@ describe('OAuthConnectButton.vue', () => {
 	})
 	describe('when the admin config is not okay', () => {
 		it('should show message for normal user', async () => {
-			getCurrentUser.mockReturnValue(() => {
-				return '{"isAdmin": false}'
-			})
+			const returnValue = { isAdmin: false }
+			getCurrentUser.mockReturnValue(returnValue)
 			wrapper = getWrapper({ isAdminConfigOk: false })
 			expect(wrapper).toMatchSnapshot()
 		})
 
 		it('should show message for admin user', async () => {
-			getCurrentUser.mockReturnValue(() => {
-				return '{"isAdmin": true}'
-			})
-			wrapper = getWrapper({ isAdminConfigOk: false }, true)
+			const returnValue = { isAdmin: true }
+			getCurrentUser.mockReturnValue(returnValue)
+			wrapper = getWrapper({ isAdminConfigOk: false })
 			expect(wrapper).toMatchSnapshot()
 		})
 	})

--- a/tests/jest/components/__snapshots__/OAuthConnectButton.spec.js.snap
+++ b/tests/jest/components/__snapshots__/OAuthConnectButton.spec.js.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`OAuthConnectButton.vue when the admin config is not okay should show message for admin user 1`] = `<div class="oauth-connect--message">Some OpenProject integration application settings are not working. Click here {htmlLink} to set them up properly.</div>`;
+exports[`OAuthConnectButton.vue when the admin config is not okay should show message for admin user 1`] = `<div class="oauth-connect--message">Some OpenProject integration application settings are not working. Configure the OpenProject integration in: {htmlLink}</div>`;
 
 exports[`OAuthConnectButton.vue when the admin config is not okay should show message for normal user 1`] = `<div class="oauth-connect--message">Some OpenProject integration application settings are not working. Please contact your Nextcloud administrator.</div>`;

--- a/tests/jest/components/__snapshots__/OAuthConnectButton.spec.js.snap
+++ b/tests/jest/components/__snapshots__/OAuthConnectButton.spec.js.snap
@@ -1,7 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`OAuthConnectButton.vue when the admin config is not okay should show message 1`] = `
-<div class="oauth-connect--message">
-  Some OpenProject integration application settings are not working. Please contact your Nextcloud administrator.
-</div>
-`;
+exports[`OAuthConnectButton.vue when the admin config is not okay should show message for admin user 1`] = `<div class="oauth-connect--message">Some OpenProject integration application settings are not working. Please contact your Nextcloud administrator.</div>`;
+
+exports[`OAuthConnectButton.vue when the admin config is not okay should show message for normal user 1`] = `<div class="oauth-connect--message">Some OpenProject integration application settings are not working. Please contact your Nextcloud administrator.</div>`;

--- a/tests/jest/components/__snapshots__/OAuthConnectButton.spec.js.snap
+++ b/tests/jest/components/__snapshots__/OAuthConnectButton.spec.js.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`OAuthConnectButton.vue when the admin config is not okay should show message for admin user 1`] = `<div class="oauth-connect--message">Some OpenProject integration application settings are not working. Please contact your Nextcloud administrator.</div>`;
+exports[`OAuthConnectButton.vue when the admin config is not okay should show message for admin user 1`] = `<div class="oauth-connect--message">Some OpenProject integration application settings are not working. Click here {htmlLink} to set them up properly.</div>`;
 
 exports[`OAuthConnectButton.vue when the admin config is not okay should show message for normal user 1`] = `<div class="oauth-connect--message">Some OpenProject integration application settings are not working. Please contact your Nextcloud administrator.</div>`;

--- a/tests/jest/views/ProjectsTab.spec.js
+++ b/tests/jest/views/ProjectsTab.spec.js
@@ -7,7 +7,9 @@ import * as initialState from '@nextcloud/initial-state'
 import { STATE } from '../../../src/utils.js'
 import workPackagesSearchResponse from '../fixtures/workPackagesSearchResponse.json'
 import { workpackageHelper } from '../../../src/utils/workpackageHelper.js'
+import { getCurrentUser } from '@nextcloud/auth'
 
+jest.mock('@nextcloud/auth')
 jest.mock('@nextcloud/axios')
 jest.mock('@nextcloud/dialogs')
 jest.mock('@nextcloud/l10n', () => ({
@@ -242,6 +244,9 @@ describe('ProjectsTab.vue', () => {
 			expect(wrapper.vm.state).toBe(STATE.OK)
 		})
 		it('sets the "error" state if the admin config is not okay', async () => {
+			getCurrentUser.mockReturnValue(() => {
+				return '{"isAdmin": false}'
+			})
 			const wrapper = mountWrapper()
 			axios.get
 				.mockImplementation(() => Promise.resolve({ status: 200, data: [] }))
@@ -582,7 +587,6 @@ function mountWrapper() {
 		stubs: {
 			SearchInput: true,
 			NcAvatar: true,
-			EmptyContent: false,
 		},
 		data: () => ({
 			error: '',

--- a/tests/jest/views/ProjectsTab.spec.js
+++ b/tests/jest/views/ProjectsTab.spec.js
@@ -244,9 +244,8 @@ describe('ProjectsTab.vue', () => {
 			expect(wrapper.vm.state).toBe(STATE.OK)
 		})
 		it('sets the "error" state if the admin config is not okay', async () => {
-			getCurrentUser.mockReturnValue(() => {
-				return '{"isAdmin": false}'
-			})
+			const returnValue = { isAdmin: false }
+			getCurrentUser.mockReturnValue(returnValue)
 			const wrapper = mountWrapper()
 			axios.get
 				.mockImplementation(() => Promise.resolve({ status: 200, data: [] }))

--- a/tests/jest/views/__snapshots__/ProjectsTab.spec.js.snap
+++ b/tests/jest/views/__snapshots__/ProjectsTab.spec.js.snap
@@ -50,9 +50,7 @@ exports[`ProjectsTab.vue fetchWorkpackages sets the "error" state if the admin c
       <div class="empty-content--icon"><span aria-hidden="true" role="img" class="material-design-icon link-off-icon"><svg fill="currentColor" width="60" height="60" viewBox="0 0 24 24" class="material-design-icon__svg"><path d="M17,7H13V8.9H17C18.71,8.9 20.1,10.29 20.1,12C20.1,13.43 19.12,14.63 17.79,15L19.25,16.44C20.88,15.61 22,13.95 22,12A5,5 0 0,0 17,7M16,11H13.81L15.81,13H16V11M2,4.27L5.11,7.38C3.29,8.12 2,9.91 2,12A5,5 0 0,0 7,17H11V15.1H7C5.29,15.1 3.9,13.71 3.9,12C3.9,10.41 5.11,9.1 6.66,8.93L8.73,11H8V13H10.73L13,15.27V17H14.73L18.74,21L20,19.74L3.27,3L2,4.27Z"><!----></path></svg></span></div>
       <!---->
       <div class="empty-content--connect-button">
-        <div class="oauth-connect--message">
-          Some OpenProject integration application settings are not working. Please contact your Nextcloud administrator.
-        </div>
+        <!---->
       </div>
     </div>
   </div>

--- a/tests/jest/views/__snapshots__/ProjectsTab.spec.js.snap
+++ b/tests/jest/views/__snapshots__/ProjectsTab.spec.js.snap
@@ -50,7 +50,7 @@ exports[`ProjectsTab.vue fetchWorkpackages sets the "error" state if the admin c
       <div class="empty-content--icon"><span aria-hidden="true" role="img" class="material-design-icon link-off-icon"><svg fill="currentColor" width="60" height="60" viewBox="0 0 24 24" class="material-design-icon__svg"><path d="M17,7H13V8.9H17C18.71,8.9 20.1,10.29 20.1,12C20.1,13.43 19.12,14.63 17.79,15L19.25,16.44C20.88,15.61 22,13.95 22,12A5,5 0 0,0 17,7M16,11H13.81L15.81,13H16V11M2,4.27L5.11,7.38C3.29,8.12 2,9.91 2,12A5,5 0 0,0 7,17H11V15.1H7C5.29,15.1 3.9,13.71 3.9,12C3.9,10.41 5.11,9.1 6.66,8.93L8.73,11H8V13H10.73L13,15.27V17H14.73L18.74,21L20,19.74L3.27,3L2,4.27Z"><!----></path></svg></span></div>
       <!---->
       <div class="empty-content--connect-button">
-        <!---->
+        <div class="oauth-connect--message">Some OpenProject integration application settings are not working. Please contact your Nextcloud administrator.</div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Related workpackage[OP#48397] : https://community.openproject.org/projects/nextcloud-integration/work_packages/48397

In the personal section of a user, if the user is an admin, show them navigation to the admin settings if the setup seems to be not complete. For the normal user the message is not changed.

## Admin user
![Screenshot from 2023-06-22 09-34-03](https://github.com/nextcloud/integration_openproject/assets/41103328/2e87aeff-0f67-4378-bf45-04f7d8fe535b)



## Normal user
![Screenshot from 2023-06-20 12-23-25](https://github.com/nextcloud/integration_openproject/assets/41103328/f2217625-836f-4e5d-bf23-32a0e3242011)
