### PR TITLE
[OP#48106] link previews UI implementation

### DIFF
--- a/lib/Reference/WorkPackageReferenceProvider.php
+++ b/lib/Reference/WorkPackageReferenceProvider.php
@@ -151,7 +151,7 @@ class WorkPackageReferenceProvider extends ADiscoverableReferenceProvider implem
 				// this is the data you will get in your custom reference widget
 				$reference->setRichObject(
 					self::RICH_OBJECT_TYPE,
-					$wpInfo
+					$wpInfo['entry']
 				);
 				return $reference;
 			}

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -1155,6 +1155,7 @@ class OpenProjectAPIService {
 		$result['title'] = $this->getSubline($searchResult[0]);
 		$result['description'] = $this->getMainText($searchResult[0]);
 		$result['imageUrl'] = $this->getOpenProjectUserAvatarUrl($searchResult[0]);
+		$result['entry'] = $searchResult[0];
 		return $result;
 	}
 

--- a/src/components/PersonalSettings.vue
+++ b/src/components/PersonalSettings.vue
@@ -72,11 +72,6 @@ export default {
 		},
 	},
 	watch: {
-		'state.notification_enabled'(newVal) {
-			this.saveOptions({
-				notification_enabled: newVal ? '1' : '0',
-			})
-		},
 		'state.search_enabled'(newVal) {
 			this.saveOptions({
 				search_enabled: newVal ? '1' : '0',

--- a/src/utils/workpackageHelper.js
+++ b/src/utils/workpackageHelper.js
@@ -27,7 +27,7 @@ export const workpackageHelper = {
 			? href.replace(/.*\//, '')
 			: null
 	},
-	async getAdditionalMetaData(workPackage) {
+	async getAdditionalMetaData(workPackage, linkableWorkpackage = false) {
 		if (typeof workPackage._links.status.href !== 'string'
 			|| workPackage._links.status.href === ''
 			|| typeof workPackage._links.type.href !== 'string'
@@ -41,11 +41,14 @@ export const workpackageHelper = {
 			|| workPackage._links.status.title === ''
 			|| typeof workPackage._links.type.title !== 'string'
 			|| workPackage._links.type.title === ''
-			|| typeof workPackage.fileId !== 'number'
-			|| workPackage.fileId <= 0
 		) {
 			throw new Error('missing data in workpackage object')
 		}
+
+		if (linkableWorkpackage && typeof workPackage.fileId !== 'number' && workPackage.fileId <= 0) {
+			throw new Error('missing data in workpackage object')
+		}
+
 		const statusId = this.replaceHrefToGetId(workPackage._links.status.href)
 		const typeId = this.replaceHrefToGetId(workPackage._links.type.href)
 		const userId = this.replaceHrefToGetId(workPackage._links.assignee.href)

--- a/src/views/ProjectsTab.vue
+++ b/src/views/ProjectsTab.vue
@@ -252,7 +252,7 @@ export default {
 							// and came back to a file that was selected before and so work-packages are already
 							// in the list. In that case don't even try to fetch all the additional meta data
 							if (!this.workpackageAlreadyInList(workPackage)) {
-								workPackage = await workpackageHelper.getAdditionalMetaData(workPackage)
+								workPackage = await workpackageHelper.getAdditionalMetaData(workPackage, true)
 								// check again, the WP might have been added by an outstanding request
 								// from another file or the file might have changed while fetching metadata
 								if (

--- a/src/views/WorkPackageReferenceWidget.vue
+++ b/src/views/WorkPackageReferenceWidget.vue
@@ -31,9 +31,9 @@
 				{{ t('integration_openproject', 'OpenProject settings') }}
 			</a>
 		</div>
-		<div v-else class="work-package-wrapper">
-			{{ richObject.title }}
-		</div>
+		<WorkPackage :id="'workpackage-'+ richObject.id"
+			class="work-package-reference__link-preview"
+			:workpackage="workpackage" />
 	</div>
 </template>
 
@@ -41,6 +41,8 @@
 import CloseIcon from 'vue-material-design-icons/Close.vue'
 import OpenInNewIcon from 'vue-material-design-icons/OpenInNew.vue'
 import { generateUrl } from '@nextcloud/router'
+import WorkPackage from '../components/tab/WorkPackage.vue'
+import { workpackageHelper } from '../utils/workpackageHelper.js'
 
 export default {
 	name: 'WorkPackageReferenceWidget',
@@ -48,6 +50,7 @@ export default {
 	components: {
 		OpenInNewIcon,
 		CloseIcon,
+		WorkPackage,
 	},
 
 	props: {
@@ -68,6 +71,7 @@ export default {
 	data() {
 		return {
 			settingsUrl: generateUrl('/settings/user/openproject'),
+			workpackage: null,
 		}
 	},
 
@@ -77,7 +81,14 @@ export default {
 		},
 	},
 
+	mounted() {
+		this.processWorkpackages()
+	},
+
 	methods: {
+		async processWorkpackages() {
+			this.workpackage = await workpackageHelper.getAdditionalMetaData(this.richObject)
+		},
 	},
 }
 </script>
@@ -86,7 +97,9 @@ export default {
 .work-package-reference {
 	width: 100%;
 	white-space: normal;
-	padding: 12px;
+	&__link-preview {
+		border-bottom: none;
+	}
 
 	a {
 		padding: 0 !important;
@@ -102,13 +115,6 @@ export default {
 		.icon {
 			margin-right: 8px;
 		}
-	}
-
-	.work-package-wrapper {
-		width: 100%;
-		display: flex;
-		align-items: start;
-
 	}
 
 	.settings-link {


### PR DESCRIPTION
Related workpackage: https://community.openproject.org/projects/nextcloud-integration/work_packages/48106/activity

The smart picker

![Screenshot from 2023-06-27 14-45-32](https://github.com/nextcloud/integration_openproject/assets/41103328/4383e592-99f1-4397-9fe5-0b6b415db7a8)


The link previews are as so

## Talk
![Screenshot from 2023-06-27 14-38-20](https://github.com/nextcloud/integration_openproject/assets/41103328/7497a127-293c-41b1-aaec-13f7ca9a2a2f)


## Text

![Screenshot from 2023-06-27 14-38-47](https://github.com/nextcloud/integration_openproject/assets/41103328/856469c9-3b06-4990-a617-dcbbcc55c298)

## Preview for user unauthenticated to openproject
![Screenshot from 2023-07-04 15-21-52](https://github.com/nextcloud/integration_openproject/assets/41103328/b9e46e9c-fd9e-4f4c-858c-093cda65fbd8)

## Preview for user authenticated to openproject
![Screenshot from 2023-07-04 15-22-00](https://github.com/nextcloud/integration_openproject/assets/41103328/47337da9-a6da-4166-8641-2bb81a021f9d)


## Prerequisite for testing 
1. Setup openproject to work with `https` https://www.openproject.org/docs/development/localhost-ssl/
2. Enable nextcloud talk app or text app
3. Enable global search for workpackages
4. the smart picker can be triggered by `/` command in talk chat or text editor

> Note: you might need to import the self signed certificate to nextcloud which can be done using 
```
sudo -u www-data ./occ security:certificates:import <path-to-certificate>
```