### PR TITLE
[OP#48842] Add new parameter in unit test client

### DIFF
--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -232,8 +232,40 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$client = new GuzzleClient();
 		$clientConfigMock = $this->getMockBuilder(IConfig::class)->getMock();
 
-
-		if (version_compare(OC_Util::getVersionString(), '27') >= 0) {
+		if (version_compare(OC_Util::getVersionString(), '28') >= 0) {
+			$clientConfigMock
+				->method('getSystemValueBool')
+				->withConsecutive(
+					['allow_local_remote_servers', false],
+					['installed', false],
+					['allow_local_remote_servers', false],
+					['allow_local_remote_servers', false],
+					['installed', false],
+					['allow_local_remote_servers', false],
+					['allow_local_remote_servers', false],
+					['installed', false],
+					['allow_local_remote_servers', false]
+				)
+				->willReturnOnConsecutiveCalls(
+					true,
+					true,
+					true,
+					true,
+					true,
+					true,
+					true,
+					true,
+					true
+				);
+			//changed from nextcloud 26
+			// @phpstan-ignore-next-line
+			$ocClient = new Client(
+				$clientConfigMock,                                             // @phpstan-ignore-line
+				$certificateManager,                                           // @phpstan-ignore-line
+				$client,                                                       // @phpstan-ignore-line
+				$this->createMock(IRemoteHostValidator::class), // @phpstan-ignore-line
+				$this->createMock(LoggerInterface::class));               // @phpstan-ignore-line
+		} elseif (version_compare(OC_Util::getVersionString(), '27') >= 0) {
 			$clientConfigMock
 			->method('getSystemValueBool')
 			->withConsecutive(


### PR DESCRIPTION
[OP#48842] : https://community.openproject.org/projects/nextcloud-integration/work_packages/details/48842

A new parameter got added in the constructor of  `client` in nextcloud master so unit tests were failing so this PR fixes that