### PR TITLE
[OP#48744] Show proper error message when the openproject server is not reachable

### DIFF
--- a/src/components/tab/EmptyContent.vue
+++ b/src/components/tab/EmptyContent.vue
@@ -113,15 +113,13 @@ export default {
 			line-height: 1.4rem;
 			font-weight: 600;
 			padding: 4px 12px 12px 12px;
-			color: #333333;
 		}
 		&--sub-title {
 			font-size: 1rem;
 			line-height: 1.4rem;
 			text-align: center;
 			font-weight: 400;
-			color: #878787;
-			padding: 0px 18px;
+			padding: 0 18px;
 		}
 	}
 	&--connect-button {
@@ -129,12 +127,6 @@ export default {
 		display: flex;
 		align-items: center;
 		justify-content: center;
-	}
-}
-
-body.theme--dark, body[data-theme-dark], body[data-theme-dark-highcontrast] {
-	.empty-content--message--title {
-		color: #cfcfcf;
 	}
 }
 </style>

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -208,7 +208,7 @@ export default {
 				}
 			}).catch((error) => {
 				clearInterval(this.loop)
-				if (error.response && error.response.status === 404) {
+				if (error.response && (error.response.status === 404 || error.response.status === 503)) {
 					this.state = STATE.CONNECTION_ERROR
 				} else if (error.response && error.response.status === 401) {
 					showError(t('integration_openproject', 'Failed to get OpenProject notifications'))

--- a/src/views/ProjectsTab.vue
+++ b/src/views/ProjectsTab.vue
@@ -272,7 +272,7 @@ export default {
 			} catch (error) {
 				if (error.response && error.response.status === 401) {
 					this.state = STATE.NO_TOKEN
-				} else if (error.response && error.response.status === 404) {
+				} else if (error.response && (error.response.status === 404 || error.response.status === 503)) {
 					this.state = STATE.CONNECTION_ERROR
 				} else if (error.response && error.response.status === 500) {
 					this.state = STATE.ERROR


### PR DESCRIPTION
[OP#48744] : https://community.openproject.org/projects/nextcloud-integration/work_packages/48744

## Before
### Project tab
![Screenshot from 2023-06-26 17-17-23](https://github.com/nextcloud/integration_openproject/assets/41103328/b1fc8ed8-4288-4445-b110-eed5745914d9)


### Dashboard
![Screenshot from 2023-06-26 17-17-04](https://github.com/nextcloud/integration_openproject/assets/41103328/bfcb0dc0-7444-4819-83ff-f6c05bd85045)


## After 
### Project tab
![Screenshot from 2023-06-30 15-02-32](https://github.com/nextcloud/integration_openproject/assets/41103328/05c3c01e-bda2-4d38-a4a0-bae3352a195f)

### Dashboard
![Screenshot from 2023-06-30 15-02-48](https://github.com/nextcloud/integration_openproject/assets/41103328/8faec8c6-8319-46ec-b2d6-87a4637e025b)

