### PR TITLE
[OP#48849] Use psalm as static code analysis tool for nextcloud master / fix phpunit tests / fix op user can be disabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,8 +75,14 @@ jobs:
           cd server && git submodule update --init
           ./occ maintenance:install --admin-pass=admin
 
-      - name: PHP stan
-        run: make phpstan
+      - name: PHP code analysis
+        run: |
+          if [[ ${{ matrix.nextcloudVersion }} == "master" ]]
+          then
+            make psalm
+          else
+            make phpstan
+          fi
 
       - name: PHP code style
         run: composer run cs:check || ( echo 'Please run `composer run cs:fix` to format your code' && exit 1 )

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
 		"phpstan/phpstan-phpunit": "^1.0",
 		"phpstan/extension-installer": "^1.1",
 		"behat/behat": "^3.10",
-		"helmich/phpunit-json-assert": "^3.4"
+		"helmich/phpunit-json-assert": "^3.4",
+		"vimeo/psalm": "5.0.0"
 	},
 	"scripts": {
 		"cs:fix": "php-cs-fixer fix",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cc2e607146701bef546d5dc2a149b9bd",
+    "content-hash": "e5ff8d436d8036f1da1545d4456ddcf9",
     "packages": [],
     "packages-dev": [
         {
@@ -1241,6 +1241,79 @@
             "time": "2013-09-20T18:59:12+00:00"
         },
         {
+            "name": "composer/package-versions-deprecated",
+            "version": "1.11.99.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/package-versions-deprecated.git",
+                "reference": "b4f54f74ef3453349c24a845d22392cd31e65f1d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/package-versions-deprecated/zipball/b4f54f74ef3453349c24a845d22392cd31e65f1d",
+                "reference": "b4f54f74ef3453349c24a845d22392cd31e65f1d",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1.0 || ^2.0",
+                "php": "^7 || ^8"
+            },
+            "replace": {
+                "ocramius/package-versions": "1.11.99"
+            },
+            "require-dev": {
+                "composer/composer": "^1.9.3 || ^2.0@dev",
+                "ext-zip": "^1.13",
+                "phpunit/phpunit": "^6.5 || ^7"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PackageVersions\\Installer",
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PackageVersions\\": "src/PackageVersions"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be"
+                }
+            ],
+            "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
+            "support": {
+                "issues": "https://github.com/composer/package-versions-deprecated/issues",
+                "source": "https://github.com/composer/package-versions-deprecated/tree/1.11.99.5"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-01-17T14:14:24+00:00"
+        },
+        {
             "name": "composer/pcre",
             "version": "1.0.1",
             "source": {
@@ -1503,6 +1576,43 @@
             "time": "2019-12-03T09:12:46+00:00"
         },
         {
+            "name": "dnoegel/php-xdg-base-dir",
+            "version": "v0.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dnoegel/php-xdg-base-dir.git",
+                "reference": "8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dnoegel/php-xdg-base-dir/zipball/8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd",
+                "reference": "8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~7.0|~6.0|~5.0|~4.8.35"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "XdgBaseDir\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "implementation of xdg base directory specification for php",
+            "support": {
+                "issues": "https://github.com/dnoegel/php-xdg-base-dir/issues",
+                "source": "https://github.com/dnoegel/php-xdg-base-dir/tree/v0.1.1"
+            },
+            "time": "2019-12-04T15:06:13+00:00"
+        },
+        {
             "name": "doctrine/annotations",
             "version": "1.13.2",
             "source": {
@@ -1718,6 +1828,107 @@
                 }
             ],
             "time": "2022-01-12T08:27:12+00:00"
+        },
+        {
+            "name": "felixfbecker/advanced-json-rpc",
+            "version": "v3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/felixfbecker/php-advanced-json-rpc.git",
+                "reference": "b5f37dbff9a8ad360ca341f3240dc1c168b45447"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/felixfbecker/php-advanced-json-rpc/zipball/b5f37dbff9a8ad360ca341f3240dc1c168b45447",
+                "reference": "b5f37dbff9a8ad360ca341f3240dc1c168b45447",
+                "shasum": ""
+            },
+            "require": {
+                "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
+                "php": "^7.1 || ^8.0",
+                "phpdocumentor/reflection-docblock": "^4.3.4 || ^5.0.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "AdvancedJsonRpc\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Felix Becker",
+                    "email": "felix.b@outlook.com"
+                }
+            ],
+            "description": "A more advanced JSONRPC implementation",
+            "support": {
+                "issues": "https://github.com/felixfbecker/php-advanced-json-rpc/issues",
+                "source": "https://github.com/felixfbecker/php-advanced-json-rpc/tree/v3.2.1"
+            },
+            "time": "2021-06-11T22:34:44+00:00"
+        },
+        {
+            "name": "felixfbecker/language-server-protocol",
+            "version": "v1.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/felixfbecker/php-language-server-protocol.git",
+                "reference": "6e82196ffd7c62f7794d778ca52b69feec9f2842"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/felixfbecker/php-language-server-protocol/zipball/6e82196ffd7c62f7794d778ca52b69feec9f2842",
+                "reference": "6e82196ffd7c62f7794d778ca52b69feec9f2842",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "*",
+                "squizlabs/php_codesniffer": "^3.1",
+                "vimeo/psalm": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "LanguageServerProtocol\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Felix Becker",
+                    "email": "felix.b@outlook.com"
+                }
+            ],
+            "description": "PHP classes for the Language Server Protocol",
+            "keywords": [
+                "language",
+                "microsoft",
+                "php",
+                "server"
+            ],
+            "support": {
+                "issues": "https://github.com/felixfbecker/php-language-server-protocol/issues",
+                "source": "https://github.com/felixfbecker/php-language-server-protocol/tree/v1.5.2"
+            },
+            "time": "2022-03-02T22:36:06+00:00"
         },
         {
             "name": "friendsofphp/php-cs-fixer",
@@ -2703,6 +2914,57 @@
             "time": "2020-11-13T09:40:50+00:00"
         },
         {
+            "name": "netresearch/jsonmapper",
+            "version": "v4.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cweiske/jsonmapper.git",
+                "reference": "f60565f8c0566a31acf06884cdaa591867ecc956"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/f60565f8c0566a31acf06884cdaa591867ecc956",
+                "reference": "f60565f8c0566a31acf06884cdaa591867ecc956",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-reflection": "*",
+                "ext-spl": "*",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~7.5 || ~8.0 || ~9.0",
+                "squizlabs/php_codesniffer": "~3.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "JsonMapper": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "OSL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Weiske",
+                    "email": "cweiske@cweiske.de",
+                    "homepage": "http://github.com/cweiske/jsonmapper/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Map nested JSON structures onto PHP classes",
+            "support": {
+                "email": "cweiske@cweiske.de",
+                "issues": "https://github.com/cweiske/jsonmapper/issues",
+                "source": "https://github.com/cweiske/jsonmapper/tree/v4.2.0"
+            },
+            "time": "2023-04-09T17:37:40+00:00"
+        },
+        {
             "name": "nextcloud/coding-standard",
             "version": "v1.0.0",
             "source": {
@@ -2798,6 +3060,59 @@
                 "source": "https://github.com/nikic/PHP-Parser/tree/v4.13.2"
             },
             "time": "2021-11-30T19:35:32+00:00"
+        },
+        {
+            "name": "openlss/lib-array2xml",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nullivex/lib-array2xml.git",
+                "reference": "a91f18a8dfc69ffabe5f9b068bc39bb202c81d90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nullivex/lib-array2xml/zipball/a91f18a8dfc69ffabe5f9b068bc39bb202c81d90",
+                "reference": "a91f18a8dfc69ffabe5f9b068bc39bb202c81d90",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "LSS": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Bryan Tong",
+                    "email": "bryan@nullivex.com",
+                    "homepage": "https://www.nullivex.com"
+                },
+                {
+                    "name": "Tony Butler",
+                    "email": "spudz76@gmail.com",
+                    "homepage": "https://www.nullivex.com"
+                }
+            ],
+            "description": "Array2XML conversion library credit to lalit.org",
+            "homepage": "https://www.nullivex.com",
+            "keywords": [
+                "array",
+                "array conversion",
+                "xml",
+                "xml conversion"
+            ],
+            "support": {
+                "issues": "https://github.com/nullivex/lib-array2xml/issues",
+                "source": "https://github.com/nullivex/lib-array2xml/tree/master"
+            },
+            "time": "2019-03-29T20:06:56+00:00"
         },
         {
             "name": "pact-foundation/pact-php",
@@ -6384,16 +6699,16 @@
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.24.0",
+            "version": "v1.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "57b712b08eddb97c762a8caa32c84e037892d2e9"
+                "reference": "7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/57b712b08eddb97c762a8caa32c84e037892d2e9",
-                "reference": "57b712b08eddb97c762a8caa32c84e037892d2e9",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936",
+                "reference": "7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936",
                 "shasum": ""
             },
             "require": {
@@ -6402,7 +6717,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.23-dev"
+                    "dev-main": "1.27-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -6447,7 +6762,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.24.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.27.0"
             },
             "funding": [
                 {
@@ -6463,7 +6778,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-09-13T13:58:33+00:00"
+            "time": "2022-11-03T14:55:06+00:00"
         },
         {
             "name": "symfony/polyfill-php81",
@@ -7138,6 +7453,110 @@
             "time": "2021-07-28T10:34:58+00:00"
         },
         {
+            "name": "vimeo/psalm",
+            "version": "5.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vimeo/psalm.git",
+                "reference": "4e177bf0c9f03c17d2fbfd83b7cc9c47605274d8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/4e177bf0c9f03c17d2fbfd83b7cc9c47605274d8",
+                "reference": "4e177bf0c9f03c17d2fbfd83b7cc9c47605274d8",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^2.4.2",
+                "amphp/byte-stream": "^1.5",
+                "composer/package-versions-deprecated": "^1.10.0",
+                "composer/semver": "^1.4 || ^2.0 || ^3.0",
+                "composer/xdebug-handler": "^2.0 || ^3.0",
+                "dnoegel/php-xdg-base-dir": "^0.1.1",
+                "ext-ctype": "*",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "felixfbecker/advanced-json-rpc": "^3.1",
+                "felixfbecker/language-server-protocol": "^1.5.2",
+                "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
+                "nikic/php-parser": "^4.13",
+                "openlss/lib-array2xml": "^1.0",
+                "php": "^7.4 || ~8.0.0 || ~8.1.0 || ~8.2.0",
+                "sebastian/diff": "^4.0",
+                "symfony/console": "^4.1.6 || ^5.0 || ^6.0",
+                "symfony/filesystem": "^5.4 || ^6.0",
+                "symfony/polyfill-php80": "^1.25"
+            },
+            "provide": {
+                "psalm/psalm": "self.version"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.4",
+                "brianium/paratest": "^6.0",
+                "ext-curl": "*",
+                "mockery/mockery": "^1.5",
+                "nunomaduro/mock-final-classes": "^1.1",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpdoc-parser": "^1.6",
+                "phpunit/phpunit": "^9.5",
+                "psalm/plugin-mockery": "^1.1",
+                "psalm/plugin-phpunit": "^0.18",
+                "slevomat/coding-standard": "^8.4",
+                "squizlabs/php_codesniffer": "^3.6",
+                "symfony/process": "^4.4 || ^5.0 || ^6.0"
+            },
+            "suggest": {
+                "ext-curl": "In order to send data to shepherd",
+                "ext-igbinary": "^2.0.5 is required, used to serialize caching data"
+            },
+            "bin": [
+                "psalm",
+                "psalm-language-server",
+                "psalm-plugin",
+                "psalm-refactor",
+                "psalter"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev",
+                    "dev-4.x": "4.x-dev",
+                    "dev-3.x": "3.x-dev",
+                    "dev-2.x": "2.x-dev",
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psalm\\": "src/Psalm/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matthew Brown"
+                }
+            ],
+            "description": "A static analysis tool for finding errors in PHP applications",
+            "keywords": [
+                "code",
+                "inspection",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/vimeo/psalm/issues",
+                "source": "https://github.com/vimeo/psalm/tree/5.0.0"
+            },
+            "time": "2022-11-30T06:06:01+00:00"
+        },
+        {
             "name": "webmozart/assert",
             "version": "1.10.0",
             "source": {
@@ -7203,5 +7622,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -35,6 +35,7 @@ use OCA\OpenProject\Service\OauthService;
 use OCA\OpenProject\Service\OpenProjectAPIService;
 use OCA\OpenProject\AppInfo\Application;
 use OCA\OpenProject\Exception\OpenprojectErrorException;
+use OCP\PreConditionNotMetException;
 use OCP\Security\ISecureRandom;
 use Psr\Log\LoggerInterface;
 
@@ -489,7 +490,8 @@ class ConfigController extends Controller {
 	}
 
 	/**
-	 * @return array{error?: string, user_name?: string, statusCode?: int}
+	 * @return array<mixed>
+	 * @throws PreConditionNotMetException
 	 */
 	private function storeUserInfo(): array {
 		$info = $this->openprojectAPIService->request($this->userId, 'users/me');

--- a/lib/Controller/FilesController.php
+++ b/lib/Controller/FilesController.php
@@ -170,10 +170,10 @@ class FilesController extends OCSController {
 	}
 	/**
 	 * @param int $fileId
-	 * @return array{'status': string, 'statuscode': int, 'id'?: int, 'name'?:string,
-	 *               'mtime'?: int, 'ctime'?: int, 'mimetype'?: string, 'path'?: string,
-	 *               'size'?: int, 'owner_name'?: string, 'owner_id'?: string, 'trashed'?: bool,
-	 *               'modifier_name'?: string, 'modifier_id'?: string}
+	 * @return array<mixed>
+	 *
+	 *
+	 *
 	 */
 	private function compileFileInfo($fileId) {
 		$file = null;
@@ -281,7 +281,6 @@ class FilesController extends OCSController {
 			$this->richObjectValidator,
 			$this->logger
 		);
-
 		// @phpstan-ignore-next-line - make phpstan not complain if activity app does not exist
 		$userSettings = new UserSettings($this->activityManager, $this->config);
 		if (!method_exists($activityData, 'get') ||

--- a/lib/Listener/BeforeGroupDeletedListener.php
+++ b/lib/Listener/BeforeGroupDeletedListener.php
@@ -34,6 +34,9 @@ use Psr\Log\LoggerInterface;
 use OCP\AppFramework\OCS\OCSBadRequestException;
 use OCA\OpenProject\AppInfo\Application;
 
+/**
+ * @template-implements IEventListener<Event>
+ */
 class BeforeGroupDeletedListener implements IEventListener {
 
 	/**

--- a/lib/Listener/BeforeNodeInsideOpenProjectGroupfilderChangedListener.php
+++ b/lib/Listener/BeforeNodeInsideOpenProjectGroupfilderChangedListener.php
@@ -13,6 +13,9 @@ use OCP\Files\Events\Node\BeforeNodeRenamedEvent;
 use OCP\IGroupManager;
 use OCP\IUserSession;
 
+/**
+ * @template-implements IEventListener<Event>
+ */
 class BeforeNodeInsideOpenProjectGroupfilderChangedListener implements IEventListener {
 	/**
 	 * @var OpenProjectAPIService

--- a/lib/Listener/BeforeUserDeletedListener.php
+++ b/lib/Listener/BeforeUserDeletedListener.php
@@ -34,6 +34,9 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use Psr\Log\LoggerInterface;
 
+/**
+ * @template-implements IEventListener<Event>
+ */
 class BeforeUserDeletedListener implements IEventListener {
 
 	/**

--- a/lib/Listener/LoadSidebarScript.php
+++ b/lib/Listener/LoadSidebarScript.php
@@ -38,6 +38,9 @@ use OCP\IRequest;
 use OCP\IUserSession;
 use OCP\Util;
 
+/**
+ * @template-implements IEventListener<Event>
+ */
 class LoadSidebarScript implements IEventListener {
 
 	/**

--- a/lib/Listener/OpenProjectReferenceListener.php
+++ b/lib/Listener/OpenProjectReferenceListener.php
@@ -28,6 +28,9 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Util;
 
+/**
+ * @template-implements IEventListener<Event>
+ */
 class OpenProjectReferenceListener implements IEventListener {
 	public function handle(Event $event): void {
 		// @phpstan-ignore-next-line - make phpstan not complain in nextcloud version other than 26

--- a/lib/Listener/UserChangedListener.php
+++ b/lib/Listener/UserChangedListener.php
@@ -34,6 +34,9 @@ use OCP\User\Events\UserChangedEvent;
 use Psr\Log\LoggerInterface;
 use OCP\AppFramework\OCS\OCSBadRequestException;
 
+/**
+ * @template-implements IEventListener<Event>
+ */
 class UserChangedListener implements IEventListener {
 
 	/**
@@ -61,6 +64,7 @@ class UserChangedListener implements IEventListener {
 			$feature = $event->getFeature();
 			if ($feature === 'enabled' && !$event->getValue()) {
 				$this->logger->info('User openproject cannot be disabled');
+				$event->getUser()->setEnabled();
 				throw new OCSBadRequestException();
 			}
 		}

--- a/lib/Reference/WorkPackageReferenceProvider.php
+++ b/lib/Reference/WorkPackageReferenceProvider.php
@@ -175,7 +175,7 @@ class WorkPackageReferenceProvider extends ADiscoverableReferenceProvider implem
 	 */
 	public function getCacheKey(string $referenceId): ?string {
 		$wpId = $this->getWorkPackageIdFromUrl($referenceId);
-		return $wpId ?? $referenceId;
+		return (string) $wpId ?? $referenceId;
 	}
 
 	/**

--- a/makefile
+++ b/makefile
@@ -59,6 +59,10 @@ npm-dev:
 phpstan:
 	composer run phpstan
 
+.PHONY: psalm
+psalm:
+	vendor/bin/psalm
+
 .PHONY: phpunit
 phpunit:
 	vendor/phpunit/phpunit/phpunit

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0"?>
+<psalm
+	errorLevel="6"
+	resolveFromConfigFile="true"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns="https://getpsalm.org/schema/config"
+	xsi:schemaLocation="https://getpsalm.org/schema/config"
+	findUnusedBaselineEntry="false"
+	findUnusedCode="false"
+	autoloader="bootstrap.php"
+>
+    <projectFiles>
+        <directory name="lib" />
+		<directory name="tests" />
+        <ignoreFiles>
+            <directory name="vendor" />
+        </ignoreFiles>
+    </projectFiles>
+	<issueHandlers>
+		<UndefinedClass>
+			<errorLevel type="suppress">
+				<referencedClass name="OC\Http\Client\LocalAddressChecker" />
+				<!-- these are classes form activity app, which isn't cloned while doing static code analysis -->
+				<referencedClass name="OCA\Activity\UserSettings" />
+				<referencedClass name="OCA\Activity\GroupHelperDisabled" />
+				<referencedClass name="OCA\Activity\Data" />
+				<!-- this is a class form groupsfolder app, which isn't available while doing static code analysis -->
+				<referencedClass name="OCA\GroupFolders\Folder\FolderManager" />
+				<referencedClass name="Helmich\JsonAssert\JsonAssertions" />
+			</errorLevel>
+		</UndefinedClass>
+		<TooFewArguments>
+			<errorLevel type="suppress">
+				<!-- supress because constructor needs more arguments on nc version 27 > and the code has conditions to handel this for lower versions-->
+				<referencedFunction name="OCA\GroupFolders\Folder\FolderManager::__construct"/>
+				<referencedFunction name="OC\Http\Client\Client::__construct"/>
+				<referencedFunction name="OCA\DAV\Controller\DirectController::__construct"/>
+			</errorLevel>
+		</TooFewArguments>
+		<UndefinedDocblockClass>
+			<errorLevel type="suppress">
+				<referencedClass name="OC\Http\Client\LocalAddressChecker" />
+			</errorLevel>
+		</UndefinedDocblockClass>
+		<InvalidArgument>
+			<errorLevel type="suppress">
+				<referencedFunction name="OC\Http\Client\Client::__construct"/>
+				<!-- setBody() expects iterable but we want to have raw data here and it seems to work fine-->
+				<referencedFunction name="PhpPact\Consumer\Model\ProviderResponse::setBody"/>
+			</errorLevel>
+		</InvalidArgument>
+		<NoValue>
+			<errorLevel type="suppress">
+				<!-- make psalm not complain if activity app does not exist -->
+				<file name="lib/Controller/FilesController.php"/>
+			</errorLevel>
+		</NoValue>
+		<UndefinedDocblockClass>
+			<errorLevel type="suppress">
+				<!-- make psalm not complain if groupfolders app does not exist -->
+				<referencedClass name="OCA\GroupFolders\Folder\FolderManager"/>
+				<referencedClass name="OC\Http\Client\LocalAddressChecker"/>
+			</errorLevel>
+		</UndefinedDocblockClass>
+	</issueHandlers>
+</psalm>

--- a/tests/acceptance/features/bootstrap/DirectUploadContext.php
+++ b/tests/acceptance/features/bootstrap/DirectUploadContext.php
@@ -66,6 +66,8 @@ class DirectUploadContext implements Context {
 	/**
 	 * @When /^an anonymous user sends a multipart form data POST request to the "([^"]*)" endpoint with:$/
 	 *
+	 * @psalm-suppress TooManyTemplateParams
+	 *
 	 * @param string $endpoint
 	 * @param TableNode<mixed> $formData
 	 * @return void
@@ -107,6 +109,8 @@ class DirectUploadContext implements Context {
 	/**
 	 * @Given /^an anonymous user has sent a multipart form data POST request to the "([^"]*)" endpoint with:$/
 	 *
+	 * @psalm-suppress TooManyTemplateParams
+	 *
 	 * @param string $endpoint
 	 * @param TableNode<mixed> $formData
 	 * @return void
@@ -138,6 +142,8 @@ class DirectUploadContext implements Context {
 
 	/**
 	 * @When /^an anonymous user sends an OPTIONS request to the "([^"]*)" endpoint with these headers:$/
+	 *
+	 * @psalm-suppress TooManyTemplateParams
 	 *
 	 * @param string $endpoint
 	 * @param TableNode<mixed> $headersTable

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -516,6 +516,8 @@ class FeatureContext implements Context {
 	/**
 	 * @Then the following headers should be set
 	 *
+	 * @psalm-suppress TooManyTemplateParams
+	 *
 	 * taken from https://github.com/owncloud/core/blob/3d517563ddddc3e9f22c57e9fd15ba48210553c5/tests/acceptance/features/bootstrap/WebDav.php#L1668-L1708
 	 * @param TableNode<mixed> $table
 	 *
@@ -584,6 +586,9 @@ class FeatureContext implements Context {
 	/**
 	 * Verify that the tableNode contains expected headers
 	 * taken from https://github.com/owncloud/core/blob/8fa69f84526c7a5a6780b378eeaf9cabb7d46e56/tests/acceptance/features/bootstrap/FeatureContext.php#L3940-L3971
+	 *
+	 * @psalm-suppress TooManyTemplateParams
+	 *
 	 * @param TableNode<mixed> $table
 	 * @param array<mixed>|null $requiredHeader
 	 * @param array<mixed>|null $allowedHeader
@@ -941,6 +946,8 @@ class FeatureContext implements Context {
 
 	/**
 	 * Verify that the tableNode contains expected rows
+	 *
+	 * @psalm-suppress TooManyTemplateParams
 	 *
 	 * @param TableNode<mixed> $table
 	 * @param array<string> $requiredRows

--- a/tests/lib/Controller/OpenProjectAPIControllerTest.php
+++ b/tests/lib/Controller/OpenProjectAPIControllerTest.php
@@ -956,7 +956,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 			'state=[a-z0-9]{10}&' .
 			'code_challenge=[a-zA-Z0-9\-_]{43}&' .
 			'code_challenge_method=S256$/',
-			$result->getData()
+			(string) $result->getData()
 		);
 	}
 }

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -232,8 +232,40 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$client = new GuzzleClient();
 		$clientConfigMock = $this->getMockBuilder(IConfig::class)->getMock();
 
-
-		if (version_compare(OC_Util::getVersionString(), '27') >= 0) {
+		if (version_compare(OC_Util::getVersionString(), '28') >= 0) {
+			$clientConfigMock
+				->method('getSystemValueBool')
+				->withConsecutive(
+					['allow_local_remote_servers', false],
+					['installed', false],
+					['allow_local_remote_servers', false],
+					['allow_local_remote_servers', false],
+					['installed', false],
+					['allow_local_remote_servers', false],
+					['allow_local_remote_servers', false],
+					['installed', false],
+					['allow_local_remote_servers', false]
+				)
+				->willReturnOnConsecutiveCalls(
+					true,
+					true,
+					true,
+					true,
+					true,
+					true,
+					true,
+					true,
+					true
+				);
+			//changed from nextcloud 26
+			// @phpstan-ignore-next-line
+			$ocClient = new Client(
+				$clientConfigMock,                                             // @phpstan-ignore-line
+				$certificateManager,                                           // @phpstan-ignore-line
+				$client,                                                       // @phpstan-ignore-line
+				$this->createMock(IRemoteHostValidator::class), // @phpstan-ignore-line
+				$this->createMock(LoggerInterface::class));               // @phpstan-ignore-line
+		} elseif (version_compare(OC_Util::getVersionString(), '27') >= 0) {
 			$clientConfigMock
 			->method('getSystemValueBool')
 			->withConsecutive(


### PR DESCRIPTION
Related work packages:
1. https://community.openproject.org/projects/nextcloud-integration/work_packages/48849
2. https://community.openproject.org/projects/nextcloud-integration/work_packages/48842
3. https://community.openproject.org/projects/nextcloud-integration/work_packages/48861

## Description
**1.** The type of `data`  that we pass to `DataResponse()` was changed to `psalm-type` `DataResponseType` recently

https://github.com/nextcloud/server/blob/5d9d37e2c5d928288220d17160e9b6e29f064eb8/lib/public/AppFramework/Http/DataResponse.php#L34

The `phpstan` was complaining because it doesn't understand this type and is treating it as `class` which it can't find. In order to fix this issue this PR uses `pslam` as static code analysis tool for `master` branch of `nextcloud` 

> Note that this change was only made in `master` of nextcloud so it doesn't affect other versions. Thus we use `phpstan` for other versions.

Some of the known errors are also suppressed in `pslam` like for when `activity` app or `groupfolders` app is not available. Some changes are made in the return type in order to make both `pslam` and `phpstan` happy.


**2.** Changes of this PR https://github.com/nextcloud/integration_openproject/pull/430 is also cherrypicked here because the CI won't be green without it. Basically, a new parameter got added in the constructor of client in nextcloud master so unit tests were failing so this PR fixes that

**3.** Another error is that the `OpenProject` user gets disabled even when there's an error message. This resulted into api test failing because we test there that the user cannot be disabled. This also only started happening recently and only reproducible in the master was fixed here because CI won't be green without it. 