### PR TITLE
[OP#49038] Refactor the name of the project to follow upper camel case

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ Requirements:
   For more information
   see: [OpenProject documentation](https://www.openproject.org/docs/development/development-environment-ubuntu/)
 
-- OpenProject integration app
+- OpenProject Integration app
 
 ### Setup
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "integration_openproject",
 	"version": "0.0.1",
-	"description": "OpenProject integration",
+	"description": "OpenProject Integration",
 	"main": "index.js",
 	"directories": {
 		"test": "tests"

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -735,7 +735,7 @@ export default {
 		resetAllAppValuesConfirmation() {
 			OC.dialogs.confirmDestructive(
 				t('integration_openproject', 'Are you sure that you want to reset this app and delete all settings and all connections of all Nextcloud users to OpenProject?'),
-				t('integration_openproject', 'Reset OpenProject integration'),
+				t('integration_openproject', 'Reset OpenProject Integration'),
 				{
 					type: OC.dialogs.YES_NO_BUTTONS,
 					confirm: t('integration_openproject', 'Yes, reset'),

--- a/src/components/OAuthConnectButton.vue
+++ b/src/components/OAuthConnectButton.vue
@@ -47,11 +47,11 @@ export default {
 				const linkText = t('integration_openproject', 'Administration Settings > OpenProject')
 				const url = generateUrl('/settings/admin/openproject')
 				const htmlLink = `<a class="link" href="${url}" target="_blank" title="${linkText}">${linkText}</a>`
-				const hintText = t('integration_openproject', 'Some OpenProject integration application settings are not working. '
-				+ 'Configure the OpenProject integration in: {htmlLink}', { htmlLink }, null, { escape: false, sanitize: false })
+				const hintText = t('integration_openproject', 'Some OpenProject Integration application settings are not working. '
+				+ 'Configure the OpenProject Integration in: {htmlLink}', { htmlLink }, null, { escape: false, sanitize: false })
 				return dompurify.sanitize(hintText, { ADD_ATTR: ['target'] })
 			}
-			return t('integration_openproject', 'Some OpenProject integration application settings are not working.'
+			return t('integration_openproject', 'Some OpenProject Integration application settings are not working.'
 				+ ' Please contact your Nextcloud administrator.')
 		},
 	},

--- a/src/components/settings/SettingsTitle.vue
+++ b/src/components/settings/SettingsTitle.vue
@@ -12,7 +12,7 @@ export default {
 	name: 'SettingsTitle',
 	computed: {
 		title() {
-			return t('integration_openproject', 'OpenProject integration')
+			return t('integration_openproject', 'OpenProject Integration')
 		},
 	},
 }

--- a/testplan.md
+++ b/testplan.md
@@ -26,7 +26,7 @@
 #### Prerequisites
 
 - fresh NextCloud, without any previous history of having the app installed
-- install, but don't configure OpenProject integration app
+- install, but don't configure OpenProject Integration app
 
 ### Run tests as
 
@@ -46,8 +46,8 @@
 #### Prerequisites
 
 - NextCloud installed
-- OpenProject integration app installed
-- OpenProject integration app enabled
+- OpenProject Integration app installed
+- OpenProject Integration app enabled
 
 ### Run tests as
 
@@ -68,9 +68,9 @@
 #### Prerequisites
 
 - NextCloud installed
-- OpenProject integration app installed
-- OpenProject integration app enabled
-- OpenProject integration app configured as administrator
+- OpenProject Integration app installed
+- OpenProject Integration app enabled
+- OpenProject Integration app configured as administrator
 
 ### Run tests as
 1. normal user
@@ -93,9 +93,9 @@
 #### Prerequisites
 
 - NextCloud installed
-- OpenProject integration app installed
-- OpenProject integration app enabled
-- OpenProject integration app configured as administrator
+- OpenProject Integration app installed
+- OpenProject Integration app enabled
+- OpenProject Integration app configured as administrator
 - multiple NC users connected to OpenProject
 
 ### Run tests as
@@ -116,9 +116,9 @@
 ### Prerequisites
 
 - NextCloud installed
-- OpenProject integration app installed
-- OpenProject integration app enabled
-- OpenProject integration app configured as administrator
+- OpenProject Integration app installed
+- OpenProject Integration app enabled
+- OpenProject Integration app configured as administrator
 - multiple NC users connected to OpenProject
 
 ### Run tests as
@@ -154,7 +154,7 @@ variations: check different NC themes
 ### Prerequisites
 
 - notifications app installed and enabled https://github.com/nextcloud/notifications
-- enable notifications in "OpenProject integration" section of "Connected accounts"
+- enable notifications in "OpenProject Integration" section of "Connected accounts"
 
 #### Tests
 
@@ -170,7 +170,7 @@ variations: check different NC themes
 
 ### Prerequisites
 
-- enable unified search in "OpenProject integration" section of "Connected accounts"
+- enable unified search in "OpenProject Integration" section of "Connected accounts"
 
 | steps                                                      | expected outcome                             | result | comment |
 |------------------------------------------------------------|----------------------------------------------|--------|---------|

--- a/tests/jest/components/AdminSettings.spec.js
+++ b/tests/jest/components/AdminSettings.spec.js
@@ -1508,7 +1508,7 @@ describe('AdminSettings.vue', () => {
 					confirmClasses: 'error',
 					type: 70,
 				}
-				const expectedConfirmTitle = 'Reset OpenProject integration'
+				const expectedConfirmTitle = 'Reset OpenProject Integration'
 
 				expect(confirmSpy).toBeCalledTimes(1)
 				expect(confirmSpy).toBeCalledWith(

--- a/tests/jest/components/__snapshots__/OAuthConnectButton.spec.js.snap
+++ b/tests/jest/components/__snapshots__/OAuthConnectButton.spec.js.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`OAuthConnectButton.vue when the admin config is not okay should show message for admin user 1`] = `<div class="oauth-connect--message">Some OpenProject integration application settings are not working. Configure the OpenProject integration in: {htmlLink}</div>`;
+exports[`OAuthConnectButton.vue when the admin config is not okay should show message for admin user 1`] = `<div class="oauth-connect--message">Some OpenProject Integration application settings are not working. Configure the OpenProject Integration in: {htmlLink}</div>`;
 
-exports[`OAuthConnectButton.vue when the admin config is not okay should show message for normal user 1`] = `<div class="oauth-connect--message">Some OpenProject integration application settings are not working. Please contact your Nextcloud administrator.</div>`;
+exports[`OAuthConnectButton.vue when the admin config is not okay should show message for normal user 1`] = `<div class="oauth-connect--message">Some OpenProject Integration application settings are not working. Please contact your Nextcloud administrator.</div>`;

--- a/tests/jest/views/__snapshots__/ProjectsTab.spec.js.snap
+++ b/tests/jest/views/__snapshots__/ProjectsTab.spec.js.snap
@@ -50,7 +50,7 @@ exports[`ProjectsTab.vue fetchWorkpackages sets the "error" state if the admin c
       <div class="empty-content--icon"><span aria-hidden="true" role="img" class="material-design-icon link-off-icon"><svg fill="currentColor" width="60" height="60" viewBox="0 0 24 24" class="material-design-icon__svg"><path d="M17,7H13V8.9H17C18.71,8.9 20.1,10.29 20.1,12C20.1,13.43 19.12,14.63 17.79,15L19.25,16.44C20.88,15.61 22,13.95 22,12A5,5 0 0,0 17,7M16,11H13.81L15.81,13H16V11M2,4.27L5.11,7.38C3.29,8.12 2,9.91 2,12A5,5 0 0,0 7,17H11V15.1H7C5.29,15.1 3.9,13.71 3.9,12C3.9,10.41 5.11,9.1 6.66,8.93L8.73,11H8V13H10.73L13,15.27V17H14.73L18.74,21L20,19.74L3.27,3L2,4.27Z"><!----></path></svg></span></div>
       <!---->
       <div class="empty-content--connect-button">
-        <div class="oauth-connect--message">Some OpenProject integration application settings are not working. Please contact your Nextcloud administrator.</div>
+        <div class="oauth-connect--message">Some OpenProject Integration application settings are not working. Please contact your Nextcloud administrator.</div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Part of: https://community.openproject.org/projects/nextcloud-integration/work_packages/49038

As `OpenProject Integration` is the name of the app co it should start with upper case. There were places where this naming pattern wasn't followed so this PR fixes that.