### PR TITLE
[OP#48843] Use the empty content component of this repo 

### DIFF
--- a/lib/Controller/OpenProjectAPIController.php
+++ b/lib/Controller/OpenProjectAPIController.php
@@ -125,7 +125,9 @@ class OpenProjectAPIController extends Controller {
 	 * @return DataResponse
 	 */
 	public function getNotifications(): DataResponse {
-		if ($this->accessToken === '' || !OpenProjectAPIService::validateURL($this->openprojectUrl)) {
+		if ($this->accessToken === '') {
+			return new DataResponse('', Http::STATUS_UNAUTHORIZED);
+		} elseif (!OpenProjectAPIService::validateURL($this->openprojectUrl)) {
 			return new DataResponse('', Http::STATUS_BAD_REQUEST);
 		}
 		$result = $this->openprojectAPIService->getNotifications($this->userId);
@@ -153,11 +155,12 @@ class OpenProjectAPIController extends Controller {
 	 * @return DataResponse
 	 */
 	public function getSearchedWorkPackages(?string $searchQuery = null, ?int $fileId = null): DataResponse {
-		if ($this->accessToken === '' || !OpenProjectAPIService::validateURL($this->openprojectUrl)) {
-			return new DataResponse(
-				'invalid open project configuration', Http::STATUS_UNAUTHORIZED
-			);
+		if ($this->accessToken === '') {
+			return new DataResponse('', Http::STATUS_UNAUTHORIZED);
+		} elseif (!OpenProjectAPIService::validateURL($this->openprojectUrl)) {
+			return new DataResponse('', Http::STATUS_BAD_REQUEST);
 		}
+
 		$result = $this->openprojectAPIService->searchWorkPackage(
 			$this->userId,
 			$searchQuery,
@@ -185,7 +188,9 @@ class OpenProjectAPIController extends Controller {
 	 * @return DataResponse
 	 */
 	public function linkWorkPackageToFile(int $workpackageId, int $fileId, string $fileName) {
-		if ($this->accessToken === '' || !OpenProjectAPIService::validateURL($this->openprojectUrl)) {
+		if ($this->accessToken === '') {
+			return new DataResponse('', Http::STATUS_UNAUTHORIZED);
+		} elseif (!OpenProjectAPIService::validateURL($this->openprojectUrl)) {
 			return new DataResponse('', Http::STATUS_BAD_REQUEST);
 		}
 
@@ -212,7 +217,9 @@ class OpenProjectAPIController extends Controller {
 	 * @return DataResponse
 	 */
 	public function markNotificationAsRead(int $workpackageId) {
-		if ($this->accessToken === '' || !OpenProjectAPIService::validateURL($this->openprojectUrl)) {
+		if ($this->accessToken === '') {
+			return new DataResponse('', Http::STATUS_UNAUTHORIZED);
+		} elseif (!OpenProjectAPIService::validateURL($this->openprojectUrl)) {
 			return new DataResponse('', Http::STATUS_BAD_REQUEST);
 		}
 		try {
@@ -240,7 +247,9 @@ class OpenProjectAPIController extends Controller {
 	 * @return DataResponse
 	 */
 	public function getWorkPackageFileLinks(int $id): DataResponse {
-		if ($this->accessToken === '' || !OpenProjectAPIService::validateURL($this->openprojectUrl)) {
+		if ($this->accessToken === '') {
+			return new DataResponse('', Http::STATUS_UNAUTHORIZED);
+		} elseif (!OpenProjectAPIService::validateURL($this->openprojectUrl)) {
 			return new DataResponse('', Http::STATUS_BAD_REQUEST);
 		}
 
@@ -265,7 +274,9 @@ class OpenProjectAPIController extends Controller {
 	 * @return DataResponse
 	 */
 	public function deleteFileLink(int $id): DataResponse {
-		if ($this->accessToken === '' || !OpenProjectAPIService::validateURL($this->openprojectUrl)) {
+		if ($this->accessToken === '') {
+			return new DataResponse('', Http::STATUS_UNAUTHORIZED);
+		} elseif (!OpenProjectAPIService::validateURL($this->openprojectUrl)) {
 			return new DataResponse('', Http::STATUS_BAD_REQUEST);
 		}
 
@@ -294,9 +305,12 @@ class OpenProjectAPIController extends Controller {
 	 * @return DataResponse
 	 */
 	public function getOpenProjectWorkPackageStatus(string $id): DataResponse {
-		if ($this->accessToken === '' || !OpenProjectAPIService::validateURL($this->openprojectUrl)) {
+		if ($this->accessToken === '') {
+			return new DataResponse('', Http::STATUS_UNAUTHORIZED);
+		} elseif (!OpenProjectAPIService::validateURL($this->openprojectUrl)) {
 			return new DataResponse('', Http::STATUS_BAD_REQUEST);
 		}
+
 		$result = $this->openprojectAPIService->getOpenProjectWorkPackageStatus(
 			$this->userId, $id
 		);
@@ -318,9 +332,12 @@ class OpenProjectAPIController extends Controller {
 	 * @return DataResponse
 	 */
 	public function getOpenProjectWorkPackageType(string $id): DataResponse {
-		if ($this->accessToken === '' || !OpenProjectAPIService::validateURL($this->openprojectUrl)) {
+		if ($this->accessToken === '') {
+			return new DataResponse('', Http::STATUS_UNAUTHORIZED);
+		} elseif (!OpenProjectAPIService::validateURL($this->openprojectUrl)) {
 			return new DataResponse('', Http::STATUS_BAD_REQUEST);
 		}
+
 		$result = $this->openprojectAPIService->getOpenProjectWorkPackageType(
 			$this->userId, $id
 		);

--- a/src/components/tab/EmptyContent.vue
+++ b/src/components/tab/EmptyContent.vue
@@ -2,7 +2,8 @@
 	<div class="empty-content">
 		<div class="empty-content--wrapper">
 			<div class="empty-content--icon">
-				<LinkPlusIcon v-if="!!isAdminConfigOk && isStateOk" :size="60" />
+				<CheckIcon v-if="isStateOk && dashboard" :size="60" />
+				<LinkPlusIcon v-else-if="!!isAdminConfigOk && isStateOk && !dashboard" :size="60" />
 				<LinkOffIcon v-else :size="60" />
 			</div>
 			<div v-if="!!isAdminConfigOk" class="empty-content--message">
@@ -23,6 +24,7 @@
 <script>
 import LinkPlusIcon from 'vue-material-design-icons/LinkPlus.vue'
 import LinkOffIcon from 'vue-material-design-icons/LinkOff.vue'
+import CheckIcon from 'vue-material-design-icons/Check.vue'
 import { generateUrl } from '@nextcloud/router'
 import { translate as t } from '@nextcloud/l10n'
 import OAuthConnectButton from '../OAuthConnectButton.vue'
@@ -30,7 +32,7 @@ import { STATE } from '../../utils.js'
 
 export default {
 	name: 'EmptyContent',
-	components: { OAuthConnectButton, LinkPlusIcon, LinkOffIcon },
+	components: { OAuthConnectButton, LinkPlusIcon, LinkOffIcon, CheckIcon },
 	props: {
 		state: {
 			type: String,
@@ -50,6 +52,10 @@ export default {
 			default() {
 				return {}
 			},
+		},
+		dashboard: {
+			type: Boolean,
+			default: false,
 		},
 	},
 	data() {
@@ -72,12 +78,15 @@ export default {
 			} else if (this.state === STATE.FAILED_FETCHING_WORKPACKAGES) {
 				return t('integration_openproject', 'Could not fetch work packages from OpenProject')
 			} else if (this.isStateOk) {
+				if (this.dashboard) {
+					return t('integration_openproject', 'No OpenProject notifications!')
+				}
 				return t('integration_openproject', 'No OpenProject links yet')
 			}
 			return t('integration_openproject', 'Unexpected Error')
 		},
 		emptyContentSubTitleMessage() {
-			if (this.isStateOk) {
+			if (this.isStateOk && !this.dashboard) {
 				return t('integration_openproject', 'To add a link, use the search bar above to find the desired work package')
 			}
 			return ''
@@ -103,7 +112,6 @@ export default {
 		img {
 			height: 50px;
 			width: 50px;
-			filter: var(--background-invert-if-dark);
 		}
 	}
 	&--message {

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -6,42 +6,31 @@
 		:loading="isLoading"
 		@markAsRead="onMarkAsRead">
 		<template #empty-content>
-			<NcEmptyContent v-if="emptyContentMessage"
-				:description="!!isAdminConfigOk ? emptyContentMessage : undefined">
-				<template #icon>
-					<CheckBoldIcon v-if="isStateOk" :size="70" />
-					<LinkOffIcon v-else :size="70" />
-				</template>
-				<template #action>
-					<div v-if="showOauthConnect" class="connect-button">
-						<OAuthConnectButton :is-admin-config-ok="isAdminConfigOk" />
-					</div>
-				</template>
-			</NcEmptyContent>
+			<EmptyContent v-if="emptyContentMessage"
+				id="openproject-empty-content"
+				:state="state"
+				:dashboard="true"
+				:is-admin-config-ok="isAdminConfigOk" />
 		</template>
 	</NcDashboardWidget>
 </template>
 
 <script>
 import axios from '@nextcloud/axios'
-import CheckBoldIcon from 'vue-material-design-icons/CheckBold.vue'
-import LinkOffIcon from 'vue-material-design-icons/LinkOff.vue'
 import { generateUrl } from '@nextcloud/router'
 import NcDashboardWidget from '@nextcloud/vue/dist/Components/NcDashboardWidget.js'
 import { showError, showSuccess } from '@nextcloud/dialogs'
-import NcEmptyContent from '@nextcloud/vue/dist/Components/NcEmptyContent.js'
 import { loadState } from '@nextcloud/initial-state'
-import OAuthConnectButton from '../components/OAuthConnectButton.vue'
 import { checkOauthConnectionResult, STATE } from '../utils.js'
 import { translate as t } from '@nextcloud/l10n'
+import EmptyContent from '../components/tab/EmptyContent.vue'
 
 export default {
 	name: 'Dashboard',
 
 	components: {
-		NcDashboardWidget, NcEmptyContent, OAuthConnectButton, CheckBoldIcon, LinkOffIcon,
+		EmptyContent, NcDashboardWidget,
 	},
-
 	props: {
 		title: {
 			type: String,

--- a/tests/lib/Controller/OpenProjectAPIControllerTest.php
+++ b/tests/lib/Controller/OpenProjectAPIControllerTest.php
@@ -115,6 +115,32 @@ class OpenProjectAPIControllerTest extends TestCase {
 			'test'
 		);
 		$response = $controller->getNotifications();
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+	}
+
+
+	/**
+	 * @return void
+	 */
+	public function testGetNotificationsBadOPInstanceUrl() {
+		$this->configMock = $this->getMockBuilder(IConfig::class)->getMock();
+		$this->configMock
+			->method('getAppValue')
+			->withConsecutive(
+				['integration_openproject', 'openproject_instance_url'],
+			)->willReturnOnConsecutiveCalls('http:openproject.org');
+		$this->getUserValueMock();
+		$service = $this->createMock(OpenProjectAPIService::class);
+		$controller = new OpenProjectAPIController(
+			'integration_openproject',
+			$this->requestMock,
+			$this->configMock,
+			$service,
+			$this->urlGeneratorMock,
+			$this->loggerMock,
+			'test'
+		);
+		$response = $controller->getNotifications();
 		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
 	}
 
@@ -281,6 +307,31 @@ class OpenProjectAPIControllerTest extends TestCase {
 	/**
 	 * @return void
 	 */
+	public function testGetSearchedWorkPackagesBadOPInstanceUrl(): void {
+		$this->configMock = $this->getMockBuilder(IConfig::class)->getMock();
+		$this->configMock
+			->method('getAppValue')
+			->withConsecutive(
+				['integration_openproject', 'openproject_instance_url'],
+			)->willReturnOnConsecutiveCalls('http:openproject');
+		$this->getUserValueMock();
+		$service = $this->createMock(OpenProjectAPIService::class);
+		$controller = new OpenProjectAPIController(
+			'integration_openproject',
+			$this->requestMock,
+			$this->configMock,
+			$service,
+			$this->urlGeneratorMock,
+			$this->loggerMock,
+			'test'
+		);
+		$response = $controller->getSearchedWorkPackages('test');
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+	}
+
+	/**
+	 * @return void
+	 */
 	public function testGetSearchedWorkPackagesErrorResponse(): void {
 		$this->getUserValueMock();
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
@@ -353,7 +404,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 			'test'
 		);
 		$response = $controller->getOpenProjectWorkPackageStatus('7');
-		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
 	}
 
 	/**
@@ -380,6 +431,34 @@ class OpenProjectAPIControllerTest extends TestCase {
 		$response = $controller->getOpenProjectWorkPackageStatus('7');
 		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
 		$this->assertSame(['error' => 'something went wrong'], $response->getData());
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testGetOpenProjectWorkPackageStatusBadOPInstanceUrl(): void {
+		$this->configMock = $this->getMockBuilder(IConfig::class)->getMock();
+		$this->configMock
+			->method('getAppValue')
+			->withConsecutive(
+				['integration_openproject', 'openproject_instance_url'],
+			)->willReturnOnConsecutiveCalls('http:openproject');
+		$this->getUserValueMock();
+		$service = $this->getMockBuilder(OpenProjectAPIService::class)
+			->disableOriginalConstructor()
+			->getMock();
+
+		$controller = new OpenProjectAPIController(
+			'integration_openproject',
+			$this->requestMock,
+			$this->configMock,
+			$service,
+			$this->urlGeneratorMock,
+			$this->loggerMock,
+			'test'
+		);
+		$response = $controller->getOpenProjectWorkPackageStatus('7');
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
 	}
 
 	/**
@@ -427,7 +506,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 			'test'
 		);
 		$response = $controller->getOpenProjectWorkPackageType('3');
-		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
 	}
 
 	/**
@@ -454,6 +533,34 @@ class OpenProjectAPIControllerTest extends TestCase {
 		$response = $controller->getOpenProjectWorkPackageType('3');
 		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
 		$this->assertSame(['error' => 'something went wrong'], $response->getData());
+	}
+	
+	/**
+	 * @return void
+	 */
+	public function testGetOpenProjectWorkPackageTypeBadOPInstanceUrl(): void {
+		$this->configMock = $this->getMockBuilder(IConfig::class)->getMock();
+		$this->configMock
+			->method('getAppValue')
+			->withConsecutive(
+				['integration_openproject', 'openproject_instance_url'],
+			)->willReturnOnConsecutiveCalls('http:openproject');
+		$this->getUserValueMock();
+		$service = $this->getMockBuilder(OpenProjectAPIService::class)
+			->disableOriginalConstructor()
+			->getMock();
+
+		$controller = new OpenProjectAPIController(
+			'integration_openproject',
+			$this->requestMock,
+			$this->configMock,
+			$service,
+			$this->urlGeneratorMock,
+			$this->loggerMock,
+			'test'
+		);
+		$response = $controller->getOpenProjectWorkPackageType('3');
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
 	}
 
 	/**
@@ -511,7 +618,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 			'test'
 		);
 		$response = $controller->getWorkPackageFileLinks(7);
-		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
 	}
 
 	/**
@@ -607,7 +714,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 			'test'
 		);
 		$response = $controller->deleteFileLink(7);
-		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
 	}
 
 	/**


### PR DESCRIPTION
Related work package [OP#48843] - https://community.openproject.org/projects/nextcloud-integration/work_packages/48843

We have our own `EmptyContent` component but in the dashboard, we were using Nextcloud's one. So in this PR, I made the necessary changes to use our `EmptyContent` component everywhere.  

We were also throwing `400` for when the user didn't have the `access token` to OpenProject but that's not the right status code in this case so this PR changes the status code to `401` 
