### PR TITLE
[#49133] throw better error message when admin tries to delete/disable OP user/group

### DIFF
--- a/lib/Listener/BeforeGroupDeletedListener.php
+++ b/lib/Listener/BeforeGroupDeletedListener.php
@@ -59,8 +59,10 @@ class BeforeGroupDeletedListener implements IEventListener {
 
 		$group = $event->getGroup();
 		if ($group->getGID() === Application::OPEN_PROJECT_ENTITIES_NAME) {
-			$this->logger->info('Group openproject cannot be deleted');
-			throw new OCSBadRequestException();
+			$this->logger->error('Group "OpenProject" is needed to be protected by the app "OpenProject Integration", thus cannot be deleted. Please check the documentation "https://www.openproject.org/docs/system-admin-guide/integrations/nextcloud/#troubleshooting" for further information.');
+			throw new OCSBadRequestException('<p>&nbsp;Group "OpenProject" is needed to be protected by the app "OpenProject Integration", thus cannot be deleted.
+			Please check the <a style="color:var(--color-primary-default)" href="https://www.openproject.org/docs/system-admin-guide/integrations/nextcloud/#troubleshooting"
+			target="_blank"><u>troubleshooting guide</u></a> for further information.</p>');
 		}
 	}
 }

--- a/lib/Listener/BeforeUserDeletedListener.php
+++ b/lib/Listener/BeforeUserDeletedListener.php
@@ -57,8 +57,10 @@ class BeforeUserDeletedListener implements IEventListener {
 		}
 		$user = $event->getUser();
 		if ($user->getUID() === Application::OPEN_PROJECT_ENTITIES_NAME) {
-			$this->logger->info('User openproject cannot be deleted');
-			throw new OCSBadRequestException();
+			$this->logger->error('User "OpenProject" is needed to be protected by the app "OpenProject Integration", thus cannot be deleted. Please check the documentation "https://www.openproject.org/docs/system-admin-guide/integrations/nextcloud/#troubleshooting" for further information.');
+			throw new OCSBadRequestException('<p>&nbsp;User "OpenProject" is needed to be protected by the app "OpenProject Integration", thus cannot be deleted.
+			Please check the <a style="color:var(--color-primary-default)" href="https://www.openproject.org/docs/system-admin-guide/integrations/nextcloud/#troubleshooting"
+			target="_blank"><u>troubleshooting guide</u></a> for further information.</p>');
 		}
 	}
 }

--- a/lib/Listener/UserChangedListener.php
+++ b/lib/Listener/UserChangedListener.php
@@ -63,9 +63,12 @@ class UserChangedListener implements IEventListener {
 		if ($event->getUser()->getUID() === Application::OPEN_PROJECT_ENTITIES_NAME) {
 			$feature = $event->getFeature();
 			if ($feature === 'enabled' && !$event->getValue()) {
-				$this->logger->info('User openproject cannot be disabled');
+				$this->logger->error('User "OpenProject" is needed to be protected by the app "OpenProject Integration", thus cannot be disabled. Please check the documentation "https://www.openproject.org/docs/system-admin-guide/integrations/nextcloud/#troubleshooting" for further information.');
 				$event->getUser()->setEnabled();
-				throw new OCSBadRequestException();
+				throw new OCSBadRequestException('<p>&nbsp;User "OpenProject" is needed to be protected by the
+				app "OpenProject Integration", thus cannot be disabled.
+				Please check the <a style="color:var(--color-primary-default)" href="https://www.openproject.org/docs/system-admin-guide/integrations/nextcloud/#troubleshooting"
+				target="_blank"><u>troubleshooting guide</u></a> for further information.</p>');
 			}
 		}
 	}


### PR DESCRIPTION
Related workpackage[OP#49133]: https://community.openproject.org/work_packages/49133

We are protecting user/group Openproject from being deleted/disabled but the error message displayed is `An error occurred during the request. Unable to proceed` which is vague. So show proper error messages so that it's known that this user is protected.

In this PR, we let the user know that the OP user/group is protected and redirect them towards open project troubleshooting docs for further information


The error message displayed now is

![Screenshot from 2023-07-21 12-47-45](https://github.com/nextcloud/integration_openproject/assets/41103328/e6f32668-a3db-441d-a417-603a458c15a3)

