### PR TITLE
[OP#48106] Enable links preview even when the global search for workpackages is not enabled

### DIFF
--- a/lib/Reference/WorkPackageReferenceProvider.php
+++ b/lib/Reference/WorkPackageReferenceProvider.php
@@ -80,20 +80,6 @@ class WorkPackageReferenceProvider extends ADiscoverableReferenceProvider implem
 	 * @inheritDoc
 	 */
 	public function getSupportedSearchProviderIds(): array {
-		if ($this->userId !== null) {
-			$ids = [];
-			// take the fallback value from the defaults
-			$searchEnabled = $this->config->getUserValue(
-				$this->userId,
-				Application::APP_ID,
-				'search_enabled',
-				$this->config->getAppValue(Application::APP_ID, 'default_enable_unified_search', '0')
-			);
-			if ($searchEnabled) {
-				$ids[] = 'openproject-search';
-			}
-			return $ids;
-		}
 		return ['openproject-search'];
 	}
 

--- a/lib/Search/OpenProjectSearchProvider.php
+++ b/lib/Search/OpenProjectSearchProvider.php
@@ -111,12 +111,21 @@ class OpenProjectSearchProvider implements IProvider {
 		$openprojectUrl = OpenProjectAPIService::sanitizeUrl($this->config->getAppValue(Application::APP_ID, 'openproject_instance_url'));
 		$accessToken = $this->config->getUserValue($user->getUID(), Application::APP_ID, 'token');
 
-		$searchEnabled = $this->config->getUserValue(
-			$user->getUID(),
-			Application::APP_ID, 'search_enabled',
-			$this->config->getAppValue(Application::APP_ID, 'default_enable_unified_search', '0')) === '1';
-		if ($accessToken === '' || !$searchEnabled) {
+		if ($accessToken === '') {
 			return SearchResult::paginated($this->getName(), [], 0);
+		}
+
+		$routeFrom = $query->getRoute();
+		$requestedFromSmartPicker = $routeFrom === '' || $routeFrom === 'smart-picker';
+
+		if (!$requestedFromSmartPicker) {
+			$searchEnabled = $this->config->getUserValue(
+					$user->getUID(),
+					Application::APP_ID, 'search_enabled',
+					$this->config->getAppValue(Application::APP_ID, 'default_enable_unified_search', '0')) === '1';
+			if (!$searchEnabled) {
+				return SearchResult::paginated($this->getName(), [], 0);
+			}
 		}
 
 		$searchResults = $this->service->searchWorkPackage($user->getUID(), $term, null, false);


### PR DESCRIPTION
Related workpackage: https://community.openproject.org/projects/nextcloud-integration/work_packages/48106/activity

Previously, the link previews were only displayed when the user `enables the global search for workpackages` settings. We decided that the links previews should be enabled by default so this PR removes that codependency.

## Demo


https://github.com/nextcloud/integration_openproject/assets/41103328/62f2dc36-7b14-4ecc-ab3f-527bbd116d67

