### PR TITLE
[OP#49182]Change the form heading index for dark theme

### DIFF
--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -168,7 +168,8 @@
 				:is-setup-complete-without-project-folders="isSetupCompleteWithoutProjectFolders"
 				:is-there-error-after-project-folder-and-app-password-setup="isThereErrorAfterProjectFolderAndAppPasswordSetup"
 				:is-complete="isProjectFolderSetupCompleted"
-				:is-disabled="isProjectFolderSetUpInDisableMode" />
+				:is-disabled="isProjectFolderSetUpInDisableMode"
+				:is-dark-theme="isDarkTheme" />
 			<div v-if="showDefaultManagedProjectFolders">
 				<div v-if="isProjectFolderSetupFormInEdit">
 					<NcCheckboxRadioSwitch type="switch" :checked.sync="isProjectFolderSwitchEnabled" @update:checked="changeProjectFolderSetUpState">
@@ -526,6 +527,10 @@ export default {
 		},
 		isResetButtonDisabled() {
 			return !(this.state.openproject_client_id || this.state.openproject_client_secret || this.state.openproject_instance_url)
+		},
+		isDarkTheme() {
+			return !!document.querySelector("body[data-themes*='dark']")
+
 		},
 	},
 	created() {

--- a/src/components/admin/FormHeading.vue
+++ b/src/components/admin/FormHeading.vue
@@ -130,6 +130,12 @@ export default {
 	}
 }
 
+body[data-themes*='dark'] {
+	.index {
+		color: #000000;
+	}
+}
+
 .form-heading.disabled {
 	.index {
 		background: #CCCCCC !important;

--- a/src/components/admin/FormHeading.vue
+++ b/src/components/admin/FormHeading.vue
@@ -2,7 +2,7 @@
 	<div class="form-heading"
 		:class="{'disabled': isDisabled}">
 		<div v-if="isProjectFolderSetupHeading && isSetupCompleteWithoutProjectFolders" class="setup-complete-without-project-folders">
-			<MinusThickIcon fill-color="#FFFFFF" :size="12" />
+			<MinusThickIcon :fill-color="isDarkTheme ? '#000000' : '#FFFFFF'" :size="12" />
 		</div>
 		<div v-else-if="isThereErrorAfterProjectFolderAndAppPasswordSetup" class="project-folder-setup-status">
 			<ExclamationThickIcon fill-color="#FFFFFF" :size="12" />
@@ -60,6 +60,10 @@ export default {
 			default: false,
 		},
 		isThereErrorAfterProjectFolderAndAppPasswordSetup: {
+			type: Boolean,
+			default: false,
+		},
+		isDarkTheme: {
 			type: Boolean,
 			default: false,
 		},


### PR DESCRIPTION
### Description
This PR fixes the form heading index coloring in the dark theme which was a more not visible in the UI.

### Related WP
 https://community.openproject.org/projects/nextcloud-integration/work_packages/49182/activity

### Before UI Changes
![Screenshot_from_2023-07-17_12-34-49](https://github.com/nextcloud/integration_openproject/assets/46086950/3050aa24-10e0-4236-bd9c-82c87142181e)



### After UI changes

![Screenshot from 2023-07-17 17-11-06](https://github.com/nextcloud/integration_openproject/assets/46086950/0d3b9930-72f5-4962-8d97-4821b1cc2d7f)



![Screenshot from 2023-07-17 17-11-27](https://github.com/nextcloud/integration_openproject/assets/46086950/a284f1fb-8eb5-4afb-bef7-2b26810b316e)



