### PR TITLE
[OP#49381] drop support for nc 23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,9 @@ jobs:
     name: unit tests and linting
     strategy:
       matrix:
-        nextcloudVersion: [ stable23, stable24, stable25, stable26, stable27, master ]
+        nextcloudVersion: [ stable24, stable25, stable26, stable27, master ]
         phpVersion: [ 7.4, 8.0, 8.1 ]
         exclude:
-          - nextcloudVersion: stable23
-            phpVersion: 8.1
           - nextcloudVersion: stable24
             phpVersion: 8.1
           - nextcloudVersion: stable26
@@ -170,14 +168,11 @@ jobs:
     name: API tests
     strategy:
       matrix:
-        nextcloudVersion: [ stable23, stable24, stable25, stable26, stable27, master ]
+        nextcloudVersion: [ stable24, stable25, stable26, stable27, master ]
         phpVersionMajor: [ 7, 8 ]
         phpVersionMinor: [ 4, 1 ]
         database: [pgsql, mysql]
         exclude:
-          - nextcloudVersion: stable23
-            phpVersionMajor: 8
-            phpVersionMinor: 1
           - nextcloudVersion: stable24
             phpVersionMajor: 8
             phpVersionMinor: 1

--- a/README.md
+++ b/README.md
@@ -383,12 +383,12 @@ e.g:
 ```yaml
 services:
   nextcloud:
-    image: nextcloud:23-apache
+    image: nextcloud:24-apache
     ports:
       - "8080:80"
 
   cron:
-    image: nextcloud:23-apache
+    image: nextcloud:24-apache
 ```
 
 Please note:

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -35,7 +35,7 @@ For more information on how to set up and use the OpenProject application, pleas
 	<screenshot>https://github.com/nextcloud/integration_openproject/raw/master/img/screenshot1.png</screenshot>
 	<screenshot>https://github.com/nextcloud/integration_openproject/raw/master/img/screenshot2.png</screenshot>
 	<dependencies>
-		<nextcloud min-version="23" max-version="28"/>
+		<nextcloud min-version="24" max-version="28"/>
 	</dependencies>
 	<background-jobs>
 		<job>OCA\OpenProject\BackgroundJob\RemoveExpiredDirectUploadTokens</job>


### PR DESCRIPTION
Related work package: https://community.openproject.org/projects/nextcloud-integration/work_packages/49381

As a general rule, Nextcloud Enterprise always supports the last three major releases. That might be longer than the non-entprise releases. As nextcloud 26 is released we can drop support for nextcloud 23