### PR TITLE
[OP#49416] Encrypt the OAuth2 client secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' && matrix.nextcloudVersion == 'master' && matrix.phpVersion == '8.1' }}
         uses: VeryGoodOpenSource/very_good_coverage@v2
         with:
-          min_coverage: '57'
+          min_coverage: '56'
           path: './server/apps/integration_openproject/coverage/php/lcov.info'
 
   api-tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,7 +277,7 @@ jobs:
         with:
           php-version: ${{ format('{0}.{1}', matrix.phpVersionMajor,matrix.phpVersionMinor) }}
           tools: composer
-          extensions: intl, gd
+          extensions: intl
 
       - name: Get composer cache directory
         id: composer-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,7 +277,7 @@ jobs:
         with:
           php-version: ${{ format('{0}.{1}', matrix.phpVersionMajor,matrix.phpVersionMinor) }}
           tools: composer
-          extensions: intl
+          extensions: intl, gd
 
       - name: Get composer cache directory
         id: composer-cache

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -137,12 +137,11 @@
 					title="Nextcloud OAuth client secret"
 					is-required
 					encrypt-value
-					with-inspection
 					:value="ncClientSecret" />
 				<div class="form-actions">
 					<NcButton v-if="isNcOAuthFormInEdit"
 						type="primary"
-						:disabled="!ncClientId || !ncClientSecret"
+						:disabled="!ncClientId"
 						data-test-id="submit-nc-oauth-values-form-btn"
 						@click="setNCOAuthFormToViewMode">
 						<template #icon>
@@ -416,7 +415,8 @@ export default {
 			return this.state.nc_oauth_client?.nextcloud_client_id
 		},
 		ncClientSecret() {
-			return this.state.nc_oauth_client?.nextcloud_client_secret
+			return '*******'
+
 		},
 		opUserAppPassword() {
 			return this.state.app_password_set

--- a/tests/acceptance/features/api/setup.feature
+++ b/tests/acceptance/features/api/setup.feature
@@ -226,14 +226,12 @@ Feature: setup the integration through an API
     "required": [
         "nextcloud_oauth_client_name",
         "openproject_redirect_uri",
-        "nextcloud_client_id",
-        "nextcloud_client_secret"
+        "nextcloud_client_id"
       ],
       "properties": {
           "nextcloud_oauth_client_name": {"type": "string", "pattern": "^OpenProject client$"},
           "openproject_redirect_uri": {"type": "string", "pattern": "^http:\/\/.*\/oauth_clients\/[A-Za-z0-9]+\/callback$"},
-          "nextcloud_client_id": {"type": "string", "pattern": "[A-Za-z0-9]+"},
-          "nextcloud_client_secret": {"type": "string", "pattern": "[A-Za-z0-9]+"}
+          "nextcloud_client_id": {"type": "string", "pattern": "[A-Za-z0-9]+"}
       },
       "not": {
       "required": [
@@ -269,14 +267,12 @@ Feature: setup the integration through an API
     "required": [
         "nextcloud_oauth_client_name",
         "openproject_redirect_uri",
-        "nextcloud_client_id",
-        "nextcloud_client_secret"
+        "nextcloud_client_id"
       ],
       "properties": {
           "nextcloud_oauth_client_name": {"type": "string", "pattern": "^OpenProject client$"},
           "openproject_redirect_uri": {"type": "string", "pattern": "^http:\/\/.*\/oauth_clients\/[A-Za-z0-9]+\/callback$"},
-          "nextcloud_client_id": {"type": "string", "pattern": "[A-Za-z0-9]+"},
-          "nextcloud_client_secret": {"type": "string", "pattern": "[A-Za-z0-9]+"}
+          "nextcloud_client_id": {"type": "string", "pattern": "[A-Za-z0-9]+"}
       },
       "not": {
       "required": [
@@ -413,8 +409,7 @@ Feature: setup the integration through an API
       "required": [
           "nextcloud_oauth_client_name",
           "openproject_redirect_uri",
-          "nextcloud_client_id",
-          "nextcloud_client_secret"
+          "nextcloud_client_id"
         ]
       },
       "not": {

--- a/tests/acceptance/features/api/setup.feature
+++ b/tests/acceptance/features/api/setup.feature
@@ -654,14 +654,12 @@ Feature: setup the integration through an API
       "required": [
           "nextcloud_oauth_client_name",
           "openproject_redirect_uri",
-          "nextcloud_client_id",
-          "nextcloud_client_secret"
+          "nextcloud_client_id"
        ],
       "properties": {
           "nextcloud_oauth_client_name": {"type": "string", "pattern": "^OpenProject client$"},
           "openproject_redirect_uri": {"type": "string", "pattern": "^http:\/\/some-host.de\/oauth_clients\/[A-Za-z0-9]+\/callback$"},
           "nextcloud_client_id": {"type": "string", "pattern": "[A-Za-z0-9]+"},
-          "nextcloud_client_secret": {"type": "string", "pattern": "[A-Za-z0-9]+"},
           "openproject_user_app_password": {"type": "string", "pattern": "[A-Za-z0-9]+"}
       }
     }

--- a/tests/jest/components/__snapshots__/AdminSettings.spec.js.snap
+++ b/tests/jest/components/__snapshots__/AdminSettings.spec.js.snap
@@ -20,7 +20,7 @@ exports[`AdminSettings.vue Nextcloud OAuth values form view mode with complete v
   <formheading-stub index="3" title="Nextcloud OAuth client" iscomplete="true"></formheading-stub>
   <div>
     <fieldvalue-stub title="Nextcloud OAuth client ID" value="some-nc-client-id-here" isrequired="true"></fieldvalue-stub>
-    <fieldvalue-stub title="Nextcloud OAuth client secret" value="some-nc-client-secret-here" isrequired="true" encryptvalue="true" withinspection="true"></fieldvalue-stub>
+    <fieldvalue-stub title="Nextcloud OAuth client secret" value="*******" isrequired="true" encryptvalue="true"></fieldvalue-stub>
     <div class="form-actions">
       <ncbutton-stub type="secondary" nativetype="button" data-test-id="reset-nc-oauth-btn">
         Replace Nextcloud OAuth values


### PR DESCRIPTION
## Description
The server implemented the feature to encrypt the oauth client secret in https://github.com/nextcloud/server/pull/38398 
but these changes were not adapted to our app so the OAuth connection wasn't successful from the open project side.

As this feature is only available from the nextcloud 
- `>= 25.0.8`
- `>= 26.0.4`
- `>= 27.0.1`

So the necessary check to ensure the version of the server is made.

Also the client secret is displayed only once now, right after it's created. 


## Related workpackage
OP#49416 - https://community.openproject.org/projects/nextcloud-integration/work_packages/49416