### PR TITLE
[OP#49295]Change NCMultiselect to NcSelect

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -14,6 +14,6 @@ module.exports = {
 	coverageDirectory: '<rootDir>/coverage/jest/',
 	coverageReporters: ['lcov', 'html', 'text'],
 	transformIgnorePatterns: [
-		'node_modules/(?!vue-material-design-icons)',
+		'node_modules/(?!(vue-material-design-icons|@nextcloud/vue-select)/)',
 	]
 }

--- a/src/components/tab/SearchInput.vue
+++ b/src/components/tab/SearchInput.vue
@@ -202,5 +202,8 @@ export default {
 		padding: 30px;
 		text-align: center;
 	}
+	.vs__dropdown-option {
+		padding: 0 !important;
+	}
 }
 </style>

--- a/src/components/tab/SearchInput.vue
+++ b/src/components/tab/SearchInput.vue
@@ -1,27 +1,23 @@
 <template>
 	<div id="searchBar">
-		<NcMultiselect ref="workPackageMultiSelect"
+		<NcSelect ref="workPackageMultiSelect"
 			class="searchInput"
 			:placeholder="placeholder"
 			:options="filterSearchResultsByFileId"
 			:user-select="true"
 			label="displayName"
-			track-by="id"
-			:internal-search="false"
-			open-direction="below"
 			:loading="isStateLoading"
-			:preselect-first="true"
-			:preserve-search="true"
-			@search-change="asyncFind"
-			@change="linkWorkPackageToFile">
-			<template #option="{option}">
+			:filterable="false"
+			@search="asyncFind"
+			@option:selected="linkWorkPackageToFile">
+			<template #option="option">
 				<WorkPackage :key="option.id"
 					:workpackage="option" />
 			</template>
-			<template #noOptions>
+			<template #no-options>
 				{{ noOptionsText }}
 			</template>
-		</NcMultiselect>
+		</NcSelect>
 		<div v-if="!isStateOk"
 			class="stateMsg text-center">
 			{{ stateMessages }}
@@ -33,7 +29,7 @@
 import debounce from 'lodash/debounce.js'
 import axios from '@nextcloud/axios'
 import { generateUrl } from '@nextcloud/router'
-import NcMultiselect from '@nextcloud/vue/dist/Components/NcMultiselect.js'
+import NcSelect from '@nextcloud/vue/dist/Components/NcSelect.js'
 import WorkPackage from './WorkPackage.vue'
 import { showError, showSuccess } from '@nextcloud/dialogs'
 import '@nextcloud/dialogs/styles/toast.scss'
@@ -46,8 +42,8 @@ const DEBOUNCE_THRESHOLD = 500
 export default {
 	name: 'SearchInput',
 	components: {
-		NcMultiselect,
 		WorkPackage,
+		NcSelect,
 	},
 	props: {
 		fileInfo: {

--- a/src/components/tab/SearchInput.vue
+++ b/src/components/tab/SearchInput.vue
@@ -1,6 +1,6 @@
 <template>
 	<div id="searchBar">
-		<NcSelect ref="workPackageMultiSelect"
+		<NcSelect ref="workPackageSelect"
 			class="searchInput"
 			:placeholder="placeholder"
 			:options="filterSearchResultsByFileId"
@@ -99,8 +99,8 @@ export default {
 	methods: {
 		emptySearchInput() {
 			// FIXME: https://github.com/shentao/vue-multiselect/issues/633
-			if (this.$refs.workPackageMultiSelect?.$refs?.VueMultiselect?.search) {
-				this.$refs.workPackageMultiSelect.$refs.VueMultiselect.search = ''
+			if (this.$refs.workPackageSelect?.$refs?.VueMultiselect?.search) {
+				this.$refs.workPackageSelect.$refs.VueMultiselect.search = ''
 			}
 		},
 		resetState() {

--- a/src/components/tab/SearchInput.vue
+++ b/src/components/tab/SearchInput.vue
@@ -5,9 +5,11 @@
 			:placeholder="placeholder"
 			:options="filterSearchResultsByFileId"
 			:user-select="true"
+			:append-to-body="false"
 			label="displayName"
 			:loading="isStateLoading"
 			:filterable="false"
+			:clear-search-on-blur="() => false"
 			@search="asyncFind"
 			@option:selected="linkWorkPackageToFile">
 			<template #option="option">
@@ -199,18 +201,6 @@ export default {
 	.stateMsg {
 		padding: 30px;
 		text-align: center;
-	}
-	.multiselect {
-		.multiselect__content-wrapper {
-			border-radius: var(--border-radius-large);
-			.multiselect__content {
-				.multiselect__element {
-					span {
-						padding: 0 !important;
-					}
-				}
-			}
-		}
 	}
 }
 </style>

--- a/tests/jest/components/tab/SearchInput.spec.js
+++ b/tests/jest/components/tab/SearchInput.spec.js
@@ -74,7 +74,7 @@ describe('SearchInput.vue', () => {
 		})
 	})
 
-	describe('work packages multiselect', () => {
+	describe('work packages select', () => {
 		describe('search input', () => {
 			it('should reset the state if search value length becomes lesser than search char limit', async () => {
 				const axiosSpy = jest.spyOn(axios, 'get')
@@ -176,8 +176,8 @@ describe('SearchInput.vue', () => {
 				await wrapper.setData({
 					searchResults: [],
 				})
-				const multiSelectCont = wrapper.find(workpackagesListSelector)
-				expect(multiSelectCont).toMatchSnapshot()
+				const ncSelectContent = wrapper.find(workpackagesListSelector)
+				expect(ncSelectContent).toMatchSnapshot()
 			})
 			it('should display correct options list of search results', async () => {
 				jest.spyOn(axios, 'get')
@@ -191,9 +191,9 @@ describe('SearchInput.vue', () => {
 				await wrapper.setData({
 					searchResults: workPackagesSearchResponse,
 				})
-				const multiSelectContent = wrapper.find(workpackagesListSelector)
-				expect(multiSelectContent.exists()).toBeTruthy()
-				const workPackages = multiSelectContent.findAll(workPackageStubSelector)
+				const ncSelectContent = wrapper.find(workpackagesListSelector)
+				expect(ncSelectContent.exists()).toBeTruthy()
+				const workPackages = ncSelectContent.findAll(workPackageStubSelector)
 				expect(workPackages).toHaveLength(workPackagesSearchResponse.length)
 				for (let i = 0; i < workPackagesSearchResponse.length; i++) {
 					expect(workPackages.at(i).props()).toMatchSnapshot()
@@ -422,8 +422,8 @@ describe('SearchInput.vue', () => {
 				axiosGetSpy.mockRestore()
 			})
 			it('should emit an action', async () => {
-				const multiselectItem = wrapper.find(firstWorkPackageSelector)
-				await multiselectItem.trigger('click')
+				const ncSelectItem = wrapper.find(firstWorkPackageSelector)
+				await ncSelectItem.trigger('click')
 				const savedEvent = wrapper.emitted('saved')
 				expect(savedEvent).toHaveLength(1)
 				expect(savedEvent[0]).toEqual([{ fileId: 111, id: 999 }])
@@ -433,8 +433,8 @@ describe('SearchInput.vue', () => {
 					.mockImplementationOnce(() => Promise.resolve({
 						status: 200,
 					}))
-				const multiselectItem = wrapper.find(firstWorkPackageSelector)
-				await multiselectItem.trigger('click')
+				const ncSelectItem = wrapper.find(firstWorkPackageSelector)
+				await ncSelectItem.trigger('click')
 				const expectedParams = new URLSearchParams()
 				expectedParams.append('workpackageId', 999)
 				expectedParams.append('fileId', 111)
@@ -447,10 +447,10 @@ describe('SearchInput.vue', () => {
 				postSpy.mockRestore()
 			})
 			it('should reset the state of the search input', async () => {
-				const multiselectItem = wrapper.find(firstWorkPackageSelector)
+				const ncSelectItem = wrapper.find(firstWorkPackageSelector)
 				expect(wrapper.vm.searchResults.length).toBe(1)
 				expect(wrapper.find('input').element.value).toBe('orga')
-				await multiselectItem.trigger('click')
+				await ncSelectItem.trigger('click')
 				expect(wrapper.vm.searchResults.length).toBe(0)
 				expect(wrapper.find('input').element.value).toBe('')
 
@@ -460,8 +460,8 @@ describe('SearchInput.vue', () => {
 				err.response = { status: 422 }
 				axios.post.mockRejectedValueOnce(err)
 				const showErrorSpy = jest.spyOn(dialogs, 'showError')
-				const multiselectItem = wrapper.find(firstWorkPackageSelector)
-				await multiselectItem.trigger('click')
+				const ncSelectItem = wrapper.find(firstWorkPackageSelector)
+				await ncSelectItem.trigger('click')
 				await localVue.nextTick()
 				expect(showErrorSpy).toBeCalledTimes(1)
 				showErrorSpy.mockRestore()

--- a/tests/jest/components/tab/SearchInput.spec.js
+++ b/tests/jest/components/tab/SearchInput.spec.js
@@ -53,12 +53,12 @@ describe('SearchInput.vue', () => {
 	let wrapper
 
 	const stateSelector = '.stateMsg'
-	const multiSelectContentSelector = '.multiselect__content'
+	const workpackagesListSelector = '[role="listbox"]'
 	const workPackageStubSelector = 'workpackage-stub'
-	const inputSelector = '.multiselect__input'
+	const inputSelector = '.searchInput input'
 	const assigneeSelector = '.filterAssignee'
-	const loadingIconSelector = '.multiselect__spinner'
-	const multiSelectItemSelector = '.multiselect__option'
+	const loadingIconSelector = '.vs__spinner'
+	const firstWorkPackageSelector = '.searchInput .vs__dropdown-option'
 
 	afterEach(() => {
 		wrapper.destroy()
@@ -176,15 +176,22 @@ describe('SearchInput.vue', () => {
 				await wrapper.setData({
 					searchResults: [],
 				})
-				const multiSelectCont = wrapper.find(multiSelectContentSelector)
+				const multiSelectCont = wrapper.find(workpackagesListSelector)
 				expect(multiSelectCont).toMatchSnapshot()
 			})
 			it('should display correct options list of search results', async () => {
+				jest.spyOn(axios, 'get')
+					.mockImplementationOnce(() => Promise.resolve({
+						status: 200,
+						data: [],
+					}))
+				wrapper = mountSearchInput({ id: 1234, name: 'file.txt' })
+				const inputField = wrapper.find(inputSelector)
+				await inputField.setValue(' ')
 				await wrapper.setData({
-					fileInfo: { id: 1234 },
 					searchResults: workPackagesSearchResponse,
 				})
-				const multiSelectContent = wrapper.find(multiSelectContentSelector)
+				const multiSelectContent = wrapper.find(workpackagesListSelector)
 				expect(multiSelectContent.exists()).toBeTruthy()
 				const workPackages = multiSelectContent.findAll(workPackageStubSelector)
 				expect(workPackages).toHaveLength(workPackagesSearchResponse.length)
@@ -200,8 +207,15 @@ describe('SearchInput.vue', () => {
 				expect(assignee.exists()).toBeFalsy()
 			})
 			it('should only use the options from the latest search response', async () => {
+				jest.spyOn(axios, 'get')
+					.mockImplementationOnce(() => Promise.resolve({
+						status: 200,
+						data: [],
+					}))
+				wrapper = mountSearchInput({ id: 111, name: 'file.txt' })
+				const inputField = wrapper.find(inputSelector)
+				await inputField.setValue(' ')
 				await wrapper.setData({
-					fileInfo: { id: 111 },
 					searchResults: workPackageObjectsInSearchResults,
 				})
 				expect(wrapper.findAll(workPackageStubSelector).length).toBe(3)
@@ -408,7 +422,7 @@ describe('SearchInput.vue', () => {
 				axiosGetSpy.mockRestore()
 			})
 			it('should emit an action', async () => {
-				const multiselectItem = wrapper.find(multiSelectItemSelector)
+				const multiselectItem = wrapper.find(firstWorkPackageSelector)
 				await multiselectItem.trigger('click')
 				const savedEvent = wrapper.emitted('saved')
 				expect(savedEvent).toHaveLength(1)
@@ -419,7 +433,7 @@ describe('SearchInput.vue', () => {
 					.mockImplementationOnce(() => Promise.resolve({
 						status: 200,
 					}))
-				const multiselectItem = wrapper.find(multiSelectItemSelector)
+				const multiselectItem = wrapper.find(firstWorkPackageSelector)
 				await multiselectItem.trigger('click')
 				const expectedParams = new URLSearchParams()
 				expectedParams.append('workpackageId', 999)
@@ -433,7 +447,7 @@ describe('SearchInput.vue', () => {
 				postSpy.mockRestore()
 			})
 			it('should reset the state of the search input', async () => {
-				const multiselectItem = wrapper.find(multiSelectItemSelector)
+				const multiselectItem = wrapper.find(firstWorkPackageSelector)
 				expect(wrapper.vm.searchResults.length).toBe(1)
 				expect(wrapper.find('input').element.value).toBe('orga')
 				await multiselectItem.trigger('click')
@@ -446,7 +460,7 @@ describe('SearchInput.vue', () => {
 				err.response = { status: 422 }
 				axios.post.mockRejectedValueOnce(err)
 				const showErrorSpy = jest.spyOn(dialogs, 'showError')
-				const multiselectItem = wrapper.find(multiSelectItemSelector)
+				const multiselectItem = wrapper.find(firstWorkPackageSelector)
 				await multiselectItem.trigger('click')
 				await localVue.nextTick()
 				expect(showErrorSpy).toBeCalledTimes(1)

--- a/tests/jest/components/tab/__snapshots__/SearchInput.spec.js.snap
+++ b/tests/jest/components/tab/__snapshots__/SearchInput.spec.js.snap
@@ -36,15 +36,7 @@ Object {
 }
 `;
 
-exports[`SearchInput.vue work packages multiselect search list should not be displayed if the search results is empty 1`] = `
-<ul role="listbox" id="listbox-null" class="multiselect__content" style="display: block;">
-  <!---->
-  <li style="display: none;"><span class="multiselect__option"><span>No results</span></span></li>
-  <li><span class="multiselect__option">
-			Start typing to search
-		</span></li>
-</ul>
-`;
+exports[`SearchInput.vue work packages multiselect search list should not be displayed if the search results is empty 1`] = `<ul id="vs10__listbox" role="listbox" style="display: none; visibility: hidden;"></ul>`;
 
 exports[`SearchInput.vue work packages multiselect search list should only use the options from the latest search response 1`] = `
 Object {

--- a/tests/jest/components/tab/__snapshots__/SearchInput.spec.js.snap
+++ b/tests/jest/components/tab/__snapshots__/SearchInput.spec.js.snap
@@ -18,7 +18,7 @@ exports[`SearchInput.vue state messages no-token: should display the correct sta
 </div>
 `;
 
-exports[`SearchInput.vue work packages multiselect search list should display correct options list of search results 1`] = `
+exports[`SearchInput.vue work packages select search list should display correct options list of search results 1`] = `
 Object {
   "workpackage": Object {
     "assignee": "test",
@@ -36,9 +36,9 @@ Object {
 }
 `;
 
-exports[`SearchInput.vue work packages multiselect search list should not be displayed if the search results is empty 1`] = `<ul id="vs10__listbox" role="listbox" style="display: none; visibility: hidden;"></ul>`;
+exports[`SearchInput.vue work packages select search list should not be displayed if the search results is empty 1`] = `<ul id="vs10__listbox" role="listbox" style="display: none; visibility: hidden;"></ul>`;
 
-exports[`SearchInput.vue work packages multiselect search list should only use the options from the latest search response 1`] = `
+exports[`SearchInput.vue work packages select search list should only use the options from the latest search response 1`] = `
 Object {
   "workpackage": Object {
     "assignee": "some assignee",


### PR DESCRIPTION
### Description
This PR replaces the deprecated version of `NcMultiSelect` to `NcSelect` nextcloud-vue component.

### Related Work Packages
https://community.openproject.org/projects/nextcloud-integration/work_packages/49295/activity?query_id=3787

### Before:

![Screenshot from 2023-07-31 14-38-57](https://github.com/nextcloud/integration_openproject/assets/46086950/dba50eb6-6a4c-4103-abc0-5f79792665f3)


### After:

![Screenshot from 2023-07-31 14-38-14](https://github.com/nextcloud/integration_openproject/assets/46086950/22209990-addd-4b91-9c6d-cd64e8062b74)

 