### PR TITLE
[OP#46179] Fix managed project folders label

### DIFF
--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -239,7 +239,7 @@
 				</div>
 				<div v-else class="project-folder-status">
 					<div class="project-folder-status-value">
-						<b>Automatic managed folders:</b> {{ opUserAppPassword ? t('integration_openproject', 'Active') : t('integration_openproject', 'Inactive') }}
+						<b>Automatically managed folders:</b> {{ opUserAppPassword ? t('integration_openproject', 'Active') : t('integration_openproject', 'Inactive') }}
 					</div>
 					<ProjectFolderError
 						v-if="state.app_password_set && !isProjectFolderSetupCorrect"

--- a/tests/jest/components/__snapshots__/AdminSettings.spec.js.snap
+++ b/tests/jest/components/__snapshots__/AdminSettings.spec.js.snap
@@ -103,7 +103,7 @@ exports[`AdminSettings.vue Project folders form (Project Folder Setup) view mode
   <formheading-stub index="4" title="Project folders (recommended)" issetupcompletewithoutprojectfolders="true" isprojectfoldersetupheading="true"></formheading-stub>
   <div>
     <div class="project-folder-status">
-      <div class="project-folder-status-value"><b>Automatic managed folders:</b> Inactive
+      <div class="project-folder-status-value"><b>Automatically managed folders:</b> Inactive
       </div>
       <!---->
       <div class="form-actions">


### PR DESCRIPTION
Part of: https://community.openproject.org/projects/nextcloud-integration/work_packages/46179

The label was "Automatic managed folders" but it should be "Automatically managed folder" so this PR fixes that

## Before
![Screenshot from 2023-08-07 14-24-07](https://github.com/nextcloud/integration_openproject/assets/41103328/bc591f11-f9f8-4532-91f9-1d19a38c9c44)

## After 
![Screenshot from 2023-08-07 14-33-51](https://github.com/nextcloud/integration_openproject/assets/41103328/9cac7aba-c3fd-4e07-99dc-6ee9c874716b)

