### PR TITLE
[OP#49182] Fix the form heading index colour in different themes

### DIFF
--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -4,7 +4,9 @@
 		<div class="openproject-server-host">
 			<FormHeading index="1"
 				:title="t('integration_openproject', 'OpenProject server')"
-				:is-complete="isServerHostFormComplete" />
+				:is-complete="isServerHostFormComplete"
+				:is-dark-theme="isDarkTheme" />
+
 			<FieldValue v-if="isServerHostFormInView"
 				is-required
 				class="pb-1"
@@ -56,7 +58,8 @@
 			<FormHeading index="2"
 				:title="t('integration_openproject', 'OpenProject OAuth settings')"
 				:is-complete="isOPOAuthFormComplete"
-				:is-disabled="isOPOAuthFormInDisableMode" />
+				:is-disabled="isOPOAuthFormInDisableMode"
+				:is-dark-theme="isDarkTheme" />
 			<div v-if="isServerHostFormComplete">
 				<FieldValue v-if="isOPOAuthFormInView"
 					is-required
@@ -109,7 +112,8 @@
 			<FormHeading index="3"
 				:title="t('integration_openproject', 'Nextcloud OAuth client')"
 				:is-complete="isNcOAuthFormComplete"
-				:is-disabled="isNcOAuthFormInDisableMode" />
+				:is-disabled="isNcOAuthFormInDisableMode"
+				:is-dark-theme="isDarkTheme" />
 			<div v-if="state.nc_oauth_client">
 				<TextInput v-if="isNcOAuthFormInEdit"
 					id="nextcloud-oauth-client-id"
@@ -262,7 +266,8 @@
 			<FormHeading index="5"
 				:title="t('integration_openproject', 'Project folders application connection')"
 				:is-complete="isOPUserAppPasswordFormComplete"
-				:is-disabled="isOPUserAppPasswordInDisableMode" />
+				:is-disabled="isOPUserAppPasswordInDisableMode"
+				:is-dark-theme="isDarkTheme" />
 			<div v-if="state.app_password_set">
 				<TextInput v-if="isOPUserAppPasswordFormInEdit"
 					id="openproject-system-password"
@@ -408,6 +413,7 @@ export default {
 			textLabelProjectFolderSetupButton: null,
 			// pointer for which form the request is coming
 			isFormStep: null,
+			isDarkTheme: null,
 		}
 	},
 	computed: {
@@ -528,13 +534,12 @@ export default {
 		isResetButtonDisabled() {
 			return !(this.state.openproject_client_id || this.state.openproject_client_secret || this.state.openproject_instance_url)
 		},
-		isDarkTheme() {
-			return !!document.querySelector("body[data-themes*='dark']")
-
-		},
 	},
 	created() {
 		this.init()
+	},
+	mounted() {
+		this.isDarkTheme = window.getComputedStyle(this.$el).getPropertyValue('--background-invert-if-dark') === 'invert(100%)'
 	},
 	methods: {
 		init() {

--- a/src/components/admin/FormHeading.vue
+++ b/src/components/admin/FormHeading.vue
@@ -10,7 +10,12 @@
 		<div v-else-if="isComplete" class="complete">
 			<CheckBoldIcon fill-color="#FFFFFF" :size="12" />
 		</div>
-		<div v-else class="index">
+		<div v-else
+			class="index"
+			:class="{
+				'index-dark-mode': isDarkTheme,
+				'index-light-mode': !isDarkTheme
+			}">
 			{{ index }}
 		</div>
 		<div class="title"
@@ -124,7 +129,6 @@ export default {
 		text-align: center;
 		border-radius: 50%;
 		background: var(--color-loading-dark);
-		color: white;
 	}
 	.title {
 		font-weight: 700;
@@ -134,10 +138,12 @@ export default {
 	}
 }
 
-body[data-themes*='dark'] {
-	.index {
-		color: #000000;
-	}
+.index-dark-mode{
+  color: #000000;
+}
+
+.index-light-mode{
+  color: #FFFFFF;
 }
 
 .form-heading.disabled {

--- a/src/components/admin/FormHeading.vue
+++ b/src/components/admin/FormHeading.vue
@@ -138,12 +138,12 @@ export default {
 	}
 }
 
-.index-dark-mode{
-  color: #000000;
+.index-dark-mode {
+	color: #000000;
 }
 
-.index-light-mode{
-  color: #FFFFFF;
+.index-light-mode {
+	color: #FFFFFF;
 }
 
 .form-heading.disabled {

--- a/tests/jest/components/__snapshots__/AdminSettings.spec.js.snap
+++ b/tests/jest/components/__snapshots__/AdminSettings.spec.js.snap
@@ -33,7 +33,7 @@ exports[`AdminSettings.vue Nextcloud OAuth values form view mode with complete v
 exports[`AdminSettings.vue OpenProject OAuth values form edit mode should show the form and hide the field values 1`] = `
 <div class="openproject-oauth-values">
   <div class="form-heading">
-    <div class="index">
+    <div class="index index-light-mode">
       2
     </div>
     <div class="title">

--- a/tests/jest/components/admin/__snapshots__/FormHeading.spec.js.snap
+++ b/tests/jest/components/admin/__snapshots__/FormHeading.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`FormHeading.vue is complete prop should hide the checkmark icon and show the index if not complete 1`] = `
 <div class="form-heading">
-  <div class="index">
+  <div class="index index-light-mode">
     1
   </div>
   <div class="title">
@@ -22,7 +22,7 @@ exports[`FormHeading.vue is complete prop should show checkmark icon, add green 
 
 exports[`FormHeading.vue is disabled prop should add disabled class to the form heading 1`] = `
 <div class="form-heading disabled">
-  <div class="index">
+  <div class="index index-light-mode">
     1
   </div>
   <div class="title">


### PR DESCRIPTION
Related workpackage[OP#49182]: https://community.openproject.org/projects/nextcloud-integration/work_packages/49182

Our previous fix for fixing the colours of labels in different themes didn't work if the nextcloud theme was selected to be system default theme and the system theme was dark theme. This PR fixes that.

## Before 
### system default theme with system having dark theme

![Screenshot from 2023-08-08 15-27-20](https://github.com/nextcloud/integration_openproject/assets/41103328/b42fc79c-531e-4537-b2f4-bb60328beeb9)


## Now 
### system default theme with system having dark theme

![Screenshot from 2023-08-08 14-58-24](https://github.com/nextcloud/integration_openproject/assets/41103328/3360390c-5ff2-4f33-9ea5-0084a24f01f1)

### dark theme 
![Screenshot from 2023-08-08 14-58-53](https://github.com/nextcloud/integration_openproject/assets/41103328/3aa66c5c-a12f-4ffe-b5f9-948eb33bdc8a)

### dark theme high contrast 

![Screenshot from 2023-08-08 14-59-04](https://github.com/nextcloud/integration_openproject/assets/41103328/1f1b5f2b-6861-43aa-8f2b-586c1e87d38f)


### light theme
![Screenshot from 2023-08-08 14-58-42](https://github.com/nextcloud/integration_openproject/assets/41103328/a3a2b2e7-3200-4d8d-9533-dec3b74ab0c2)


### light theme high contrast
![Screenshot from 2023-08-08 14-59-18](https://github.com/nextcloud/integration_openproject/assets/41103328/40e1cd60-5082-44da-91d4-33c281df65b1)
