### PR TITLE
fix failing phpunit tests in stable27

### DIFF
--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -232,7 +232,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$client = new GuzzleClient();
 		$clientConfigMock = $this->getMockBuilder(IConfig::class)->getMock();
 
-		if (version_compare(OC_Util::getVersionString(), '28') >= 0) {
+		if (version_compare(OC_Util::getVersionString(), '27') >= 0) {
 			$clientConfigMock
 				->method('getSystemValueBool')
 				->withConsecutive(
@@ -265,39 +265,6 @@ class OpenProjectAPIServiceTest extends TestCase {
 				$client,                                                       // @phpstan-ignore-line
 				$this->createMock(IRemoteHostValidator::class), // @phpstan-ignore-line
 				$this->createMock(LoggerInterface::class));               // @phpstan-ignore-line
-		} elseif (version_compare(OC_Util::getVersionString(), '27') >= 0) {
-			$clientConfigMock
-			->method('getSystemValueBool')
-			->withConsecutive(
-				['allow_local_remote_servers', false],
-				['installed', false],
-				['allow_local_remote_servers', false],
-				['allow_local_remote_servers', false],
-				['installed', false],
-				['allow_local_remote_servers', false],
-				['allow_local_remote_servers', false],
-				['installed', false],
-				['allow_local_remote_servers', false]
-			)
-				->willReturnOnConsecutiveCalls(
-					true,
-					true,
-					true,
-					true,
-					true,
-					true,
-					true,
-					true,
-					true
-				);
-			//changed from nextcloud 26
-			// @phpstan-ignore-next-line
-			$ocClient = new Client(
-				$clientConfigMock,                                             // @phpstan-ignore-line
-				$certificateManager,                                           // @phpstan-ignore-line
-				$client,                                                       // @phpstan-ignore-line
-				$this->createMock(IRemoteHostValidator::class)                 // @phpstan-ignore-line
-			);
 		} elseif (version_compare(OC_Util::getVersionString(), '26') >= 0) {
 			$clientConfigMock
 			->method('getSystemValueBool')


### PR DESCRIPTION
Forward port: https://github.com/nextcloud/integration_openproject/pull/454 

[OP#49613]: https://community.openproject.org/projects/nextcloud-integration/work_packages/details/49613

Php unit test started failing in stable27 because the constructor of `Client` required 5 parameters,
https://github.com/nextcloud/server/blob/231cec61ef4892889b4291f80fb76a1483bef6b2/lib/private/Http/Client/Client.php#L63
 this is same as stable28 so this PR makes the check for nextcloud `>=stable27` to have same configuration

```bash
OCA\OpenProject\Service\OpenProjectAPIServiceTest::testValidateOpenProjectURL with data set #0 ('http://127.0.0.1', true)

39ArgumentCountError: Too few arguments to function OC\Http\Client\Client::__construct(), 4 passed in /home/runner/work/integration_openproject/integration_openproject/server/apps/integration_openproject/tests/lib/Service/OpenProjectAPIServiceTest.php on line 299 and exactly 5 expected
```