### PR TITLE
[OP#49621] fix app password form becomes inactive

### DIFF
--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -1129,8 +1129,12 @@ class OpenProjectAPIService {
 	 */
 	public function deleteAppPassword(): void {
 		if ($this->hasAppPassword()) {
-			$tokenId = $this->tokenProvider->getTokenByUser(Application::OPEN_PROJECT_ENTITIES_NAME)[0]->getId();
-			$this->tokenProvider->invalidateTokenById(Application::OPEN_PROJECT_ENTITIES_NAME, $tokenId);
+			$tokens = $this->tokenProvider->getTokenByUser(Application::OPEN_PROJECT_ENTITIES_NAME);
+			foreach ($tokens as $token) {
+				if ($token->getName() === Application::OPEN_PROJECT_ENTITIES_NAME) {
+					$this->tokenProvider->invalidateTokenById(Application::OPEN_PROJECT_ENTITIES_NAME, $token->getId());
+				}
+			}
 		}
 	}
 
@@ -1140,7 +1144,13 @@ class OpenProjectAPIService {
 	 * @return bool
 	 */
 	public function hasAppPassword(): bool {
-		return sizeof($this->tokenProvider->getTokenByUser(Application::OPEN_PROJECT_ENTITIES_NAME)) === 1;
+		$tokens = $this->tokenProvider->getTokenByUser(Application::OPEN_PROJECT_ENTITIES_NAME);
+		foreach ($tokens as $token) {
+			if ($token->getName() === Application::OPEN_PROJECT_ENTITIES_NAME) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**

--- a/tests/acceptance/features/api/setup.feature
+++ b/tests/acceptance/features/api/setup.feature
@@ -538,10 +538,9 @@ Feature: setup the integration through an API
     And groupfolder "OpenProject" should be managed by the user "OpenProject"
     # the next step is only for the tests, because that user has a random password
     Given the administrator has changed the password of "OpenProject" to the default testing password
-    Then user "OpenProject" should have a folder called "OpenProject"
-
+    And user "OpenProject" should have a folder called "OpenProject"
     # folders inside the OpenProject folder can only be deleted/renamed by the OpenProject user
-    Given user "Carol" has been created
+    And user "Carol" has been created
     And user "Carol" has been added to the group "OpenProject"
     And user "OpenProject" has created folder "/OpenProject/project-abc"
     Then user "Carol" should have a folder called "OpenProject/project-abc"
@@ -635,9 +634,12 @@ Feature: setup the integration through an API
     When user "OpenProject" sends a "PROPFIND" request to "/remote.php/webdav" using current app password
     Then the HTTP status code should be "207"
 
+    # this is to provide test coverage for issues like this
+    # https://community.openproject.org/projects/nextcloud-integration/work_packages/49621
+    When a new browser session for "Openproject" starts
     # but other values can be updated by sending a PATCH request
     # also we can replace old app password by sending PATCH request to get new user app password
-    When the administrator sends a PATCH request to the "setup" endpoint with this data:
+    And the administrator sends a PATCH request to the "setup" endpoint with this data:
       """
       {
       "values" : {

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -1755,7 +1755,16 @@ class OpenProjectAPIServiceTest extends TestCase {
 			->method('getTokenByUser')
 			->with(Application::OPEN_PROJECT_ENTITIES_NAME)
 			->willReturn([$tokenMock]);
-		$service = $this->getServiceMock([], null, null, null, null, null, null, null, null, $tokenProviderMock);
+		$service = $this->getServiceMock([],
+			null,
+			null,
+			null,
+			null,
+			null,
+			null,
+			null,
+			null,
+			$tokenProviderMock);
 		$this->assertTrue($service->hasAppPassword());
 	}
 
@@ -1765,24 +1774,33 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$tokenMock1 = $this->getMockBuilder(IToken::class)->getMock();
 		$tokenMock1
 			->method('getName')
-			->willReturnOnConsecutiveCalls('session');
+			->willReturn('session');
 		$tokenMock2 = $this->getMockBuilder(IToken::class)->getMock();
 		$tokenMock2
 			->method('getName')
-			->willReturnOnConsecutiveCalls('test');
+			->willReturn('test');
 		$tokenMock3 = $this->getMockBuilder(IToken::class)->getMock();
 		$tokenMock3
 			->method('getName')
-			->willReturnOnConsecutiveCalls('new-token');
+			->willReturn('new-token');
 		$tokenMock4 = $this->getMockBuilder(IToken::class)->getMock();
 		$tokenMock4
 			->method('getName')
-			->willReturnOnConsecutiveCalls('OpenProject');
+			->willReturn('OpenProject');
 		$tokenProviderMock
 			->method('getTokenByUser')
 			->with(Application::OPEN_PROJECT_ENTITIES_NAME)
 			->willReturn([$tokenMock1,$tokenMock2,$tokenMock3,$tokenMock4]);
-		$service = $this->getServiceMock([], null, null, null, null, null, null, null, null, $tokenProviderMock);
+		$service = $this->getServiceMock([],
+			null,
+			null,
+			null,
+			null,
+			null,
+			null,
+			null,
+			null,
+			$tokenProviderMock);
 		$this->assertTrue($service->hasAppPassword());
 	}
 
@@ -1797,8 +1815,77 @@ class OpenProjectAPIServiceTest extends TestCase {
 			->method('getTokenByUser')
 			->with(Application::OPEN_PROJECT_ENTITIES_NAME)
 			->willReturn([$tokenMock]);
-		$service = $this->getServiceMock([], null, null, null, null, null, null, null, null, $tokenProviderMock);
+		$service = $this->getServiceMock([],
+			null,
+			null,
+			null,
+			null,
+			null,
+			null,
+			null,
+			null,
+			$tokenProviderMock);
 		$this->assertFalse($service->hasAppPassword());
+	}
+
+	public function testProjectFolderDeleteAppPassword(): void {
+		$tokenProviderMock = $this->getMockBuilder(IProvider::class)->disableOriginalConstructor()
+			->getMock();
+		$tokenMock1 = $this->getMockBuilder(IToken::class)->getMock();
+		$tokenMock1
+			->method('getName')
+			->willReturn('session');
+		$tokenMock1
+			->method('getId')
+			->willReturn(1);
+		$tokenMock2 = $this->getMockBuilder(IToken::class)->getMock();
+		$tokenMock2
+			->method('getName')
+			->willReturn('test');
+		$tokenMock2
+			->method('getId')
+			->willReturn(2);
+		$tokenMock3 = $this->getMockBuilder(IToken::class)->getMock();
+		$tokenMock3
+			->method('getName')
+			->willReturn('new-token');
+		$tokenMock3
+			->method('getId')
+			->willReturn(3);
+		$tokenMock4 = $this->getMockBuilder(IToken::class)->getMock();
+		$tokenMock4
+			->method('getName')
+			->willReturn('OpenProject');
+		$tokenMock4
+			->method('getId')
+			->willReturn(4);
+		$tokenMock5 = $this->getMockBuilder(IToken::class)->getMock();
+		$tokenMock5
+			->method('getName')
+			->willReturn('OpenProject');
+		$tokenMock5
+			->method('getId')
+			->willReturn(5);
+		$tokenProviderMock
+			->method('getTokenByUser')
+			->with(Application::OPEN_PROJECT_ENTITIES_NAME)
+			->willReturn([$tokenMock1,$tokenMock2,$tokenMock3,$tokenMock4,$tokenMock5]);
+		$service = $this->getServiceMock(['hasAppPassword'],
+			null,
+			null,
+			null,
+			null,
+			null,
+			null,
+			null,
+			null,
+			$tokenProviderMock)
+		;
+		$service->method('hasAppPassword')->willReturn(true);
+		$tokenProviderMock->expects($this->exactly(2))
+			->method('invalidateTokenById')
+			->withConsecutive([Application::OPEN_PROJECT_ENTITIES_NAME, 4], [Application::OPEN_PROJECT_ENTITIES_NAME, 5]);
+		$service->deleteAppPassword();
 	}
 
 	public function testLinkWorkPackageToFilePact(): void {

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -1759,6 +1759,33 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$this->assertTrue($service->hasAppPassword());
 	}
 
+	public function testProjectFolderHasMultipleAppPassword(): void {
+		$tokenProviderMock = $this->getMockBuilder(IProvider::class)->disableOriginalConstructor()
+			->getMock();
+		$tokenMock1 = $this->getMockBuilder(IToken::class)->getMock();
+		$tokenMock1
+			->method('getName')
+			->willReturnOnConsecutiveCalls('session');
+		$tokenMock2 = $this->getMockBuilder(IToken::class)->getMock();
+		$tokenMock2
+			->method('getName')
+			->willReturnOnConsecutiveCalls('test');
+		$tokenMock3 = $this->getMockBuilder(IToken::class)->getMock();
+		$tokenMock3
+			->method('getName')
+			->willReturnOnConsecutiveCalls('new-token');
+		$tokenMock4 = $this->getMockBuilder(IToken::class)->getMock();
+		$tokenMock4
+			->method('getName')
+			->willReturnOnConsecutiveCalls('OpenProject');
+		$tokenProviderMock
+			->method('getTokenByUser')
+			->with(Application::OPEN_PROJECT_ENTITIES_NAME)
+			->willReturn([$tokenMock1,$tokenMock2,$tokenMock3,$tokenMock4]);
+		$service = $this->getServiceMock([], null, null, null, null, null, null, null, null, $tokenProviderMock);
+		$this->assertTrue($service->hasAppPassword());
+	}
+
 	public function testProjectFolderHasAppPasswordNegativeCondition(): void {
 		$tokenProviderMock = $this->getMockBuilder(IProvider::class)->disableOriginalConstructor()
 			->getMock();


### PR DESCRIPTION
Fixes: https://community.openproject.org/projects/nextcloud-integration/work_packages/49621/

Our previous check for `hasAppPassword` expects the user "OpenProject" to have only one app password. But in cases where the user "OpenProject" has multiple app passwords for instance if the user is logged in somewhere it will create a session app password, this check will return `false` which will result in the project folder section in the administrative form being disabled.
```php
# previous code
return sizeof($this->tokenProvider->getTokenByUser(Application::OPEN_PROJECT_ENTITIES_NAME)) === 1;
```

So in this PR we loop through all the tokens and only return true if the token with the name "OpenProject" exists and also while deleting, delete all the tokens with the name "OpenProject". This fixes the issue we are facing