### PR TITLE
[OP#49435] Nextcloud oauth section should not be disabled when the user deletes the oauth credentials

### DIFF
--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -163,6 +163,15 @@
 					</NcButton>
 				</div>
 			</div>
+			<div v-if="!state.nc_oauth_client && isOPOAuthFormComplete && isOPOAuthFormInView">
+				<NcButton data-test-id="reset-nc-oauth-btn"
+					@click="resetNcOauthValues">
+					<template #icon>
+						<AutoRenewIcon :size="20" />
+					</template>
+					{{ t('integration_openproject', 'Replace Nextcloud OAuth values') }}
+				</NcButton>
+			</div>
 		</div>
 		<div class="project-folder-setup">
 			<FormHeading index="4"

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -163,7 +163,7 @@
 					</NcButton>
 				</div>
 			</div>
-			<div v-if="!state.nc_oauth_client && isOPOAuthFormComplete && isOPOAuthFormInView">
+			<div v-if="!state.nc_oauth_client && isOPOAuthFormComplete && isOPOAuthFormInView && showDefaultManagedProjectFolders">
 				<NcButton data-test-id="reset-nc-oauth-btn"
 					@click="resetNcOauthValues">
 					<template #icon>
@@ -585,7 +585,11 @@ export default {
 					this.formMode.ncOauth = F_MODES.VIEW
 					this.isFormCompleted.ncOauth = true
 					this.showDefaultManagedProjectFolders = true
-				} else if (!this.state.nc_oauth_client && this.state.openproject_instance_url && this.state.openproject_client_id && this.state.openproject_client_secret) {
+				} else if (!this.state.nc_oauth_client
+					&& this.state.openproject_instance_url
+					&& this.state.openproject_client_id
+					&& this.state.openproject_client_secret
+				    && (this.formMode.projectFolderSetUp === F_MODES.VIEW)) {
 					this.showDefaultManagedProjectFolders = true
 				}
 				if (this.formMode.ncOauth === F_MODES.VIEW) {

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -584,6 +584,9 @@ export default {
 				if (this.state.nc_oauth_client) {
 					this.formMode.ncOauth = F_MODES.VIEW
 					this.isFormCompleted.ncOauth = true
+					this.showDefaultManagedProjectFolders = true
+				} else if (!this.state.nc_oauth_client && this.state.openproject_instance_url && this.state.openproject_client_id && this.state.openproject_client_secret) {
+					this.showDefaultManagedProjectFolders = true
 				}
 				if (this.formMode.ncOauth === F_MODES.VIEW) {
 					this.showDefaultManagedProjectFolders = true

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -169,7 +169,7 @@
 					<template #icon>
 						<AutoRenewIcon :size="20" />
 					</template>
-					{{ t('integration_openproject', 'Replace Nextcloud OAuth values') }}
+					{{ t('integration_openproject', 'Create Nextcloud OAuth values') }}
 				</NcButton>
 			</div>
 		</div>
@@ -584,13 +584,15 @@ export default {
 				if (this.state.nc_oauth_client) {
 					this.formMode.ncOauth = F_MODES.VIEW
 					this.isFormCompleted.ncOauth = true
-					this.showDefaultManagedProjectFolders = true
-				} else if (!this.state.nc_oauth_client
+				}
+				if (!this.state.nc_oauth_client
 					&& this.state.openproject_instance_url
 					&& this.state.openproject_client_id
 					&& this.state.openproject_client_secret
-				    && (this.formMode.projectFolderSetUp === F_MODES.VIEW)) {
+				    && this.textLabelProjectFolderSetupButton === 'Keep current setup') {
 					this.showDefaultManagedProjectFolders = true
+					this.formMode.projectFolderSetUp = F_MODES.VIEW
+					this.isFormCompleted.projectFolderSetUp = true
 				}
 				if (this.formMode.ncOauth === F_MODES.VIEW) {
 					this.showDefaultManagedProjectFolders = true

--- a/tests/jest/components/AdminSettings.spec.js
+++ b/tests/jest/components/AdminSettings.spec.js
@@ -146,7 +146,7 @@ describe('AdminSettings.vue', () => {
 					openproject_client_id: 'abcd',
 					openproject_client_secret: 'abcdefgh',
 					nc_oauth_client: null,
-					showDefaultManagedProjectFolders: false,
+					fresh_project_folder_setup: true,
 				},
 				{
 					server: F_MODES.VIEW,
@@ -744,26 +744,30 @@ describe('AdminSettings.vue', () => {
 					expect(wrapper.vm.isFormCompleted.ncOauth).toBe(false)
 					wrapper.destroy()
 				})
+			})
+		})
+		describe('recreate button', () => {
+			it('should be displayed if nextcloud oauth credentials is empty and everything is set', async () => {
+				const wrapper = getMountedWrapper({
+					state: {
+						openproject_instance_url: 'http://openproject.com',
+						openproject_client_id: 'op-client-id',
+						openproject_client_secret: 'op-client-secret',
+						nc_oauth_client: null,
+					},
+					formMode: {
+						projectFolderSetUp: F_MODES.VIEW,
+					},
+					showDefaultManagedProjectFolders: true,
+					isFormCompleted: {
+						projectFolderSetUp: true,
+					},
 
-				it('should be displayed if nextcloud oauth credentials is empty and everything is set', async () => {
-					const wrapper = getMountedWrapper({
-						state: {
-							openproject_instance_url: 'http://openproject.com',
-							openproject_client_id: 'op-client-id',
-							openproject_client_secret: 'op-client-secret',
-							nc_oauth_client: {
-								nextcloud_client_id: '',
-								nextcloud_client_secret: '',
-							},
-							formMode: {
-								projectFolderSetUp: F_MODES.VIEW,
-							},
-
-						},
-					})
-					const resetButton = wrapper.find(selectors.resetNcOAuthFormButton)
-					expect(resetButton.isVisible()).toBe(true)
 				})
+				const resetButton = wrapper.find(selectors.resetNcOAuthFormButton)
+				expect(resetButton.isVisible()).toBe(true)
+				expect(resetButton.text()).toBe('Create Nextcloud OAuth values')
+				wrapper.destroy()
 			})
 		})
 		describe('edit mode', () => {

--- a/tests/jest/components/AdminSettings.spec.js
+++ b/tests/jest/components/AdminSettings.spec.js
@@ -146,6 +146,7 @@ describe('AdminSettings.vue', () => {
 					openproject_client_id: 'abcd',
 					openproject_client_secret: 'abcdefgh',
 					nc_oauth_client: null,
+					showDefaultManagedProjectFolders: false,
 				},
 				{
 					server: F_MODES.VIEW,
@@ -742,6 +743,26 @@ describe('AdminSettings.vue', () => {
 					expect(wrapper.vm.formMode.ncOauth).toBe(F_MODES.EDIT)
 					expect(wrapper.vm.isFormCompleted.ncOauth).toBe(false)
 					wrapper.destroy()
+				})
+
+				it('should be displayed if nextcloud oauth credentials is empty and everything is set', async () => {
+					const wrapper = getMountedWrapper({
+						state: {
+							openproject_instance_url: 'http://openproject.com',
+							openproject_client_id: 'op-client-id',
+							openproject_client_secret: 'op-client-secret',
+							nc_oauth_client: {
+								nextcloud_client_id: '',
+								nextcloud_client_secret: '',
+							},
+							formMode: {
+								projectFolderSetUp: F_MODES.VIEW,
+							},
+
+						},
+					})
+					const resetButton = wrapper.find(selectors.resetNcOAuthFormButton)
+					expect(resetButton.isVisible()).toBe(true)
 				})
 			})
 		})

--- a/tests/jest/components/__snapshots__/AdminSettings.spec.js.snap
+++ b/tests/jest/components/__snapshots__/AdminSettings.spec.js.snap
@@ -12,6 +12,7 @@ exports[`AdminSettings.vue Nextcloud OAuth values form edit mode should show the
       </ncbutton-stub>
     </div>
   </div>
+  <!---->
 </div>
 `;
 
@@ -27,6 +28,7 @@ exports[`AdminSettings.vue Nextcloud OAuth values form view mode with complete v
       </ncbutton-stub>
     </div>
   </div>
+  <!---->
 </div>
 `;
 


### PR DESCRIPTION
[OP#49435] https://community.openproject.org/work_packages/49435

## Behaviour

- Login as the administrator in nextcloud
- setup integration `Administration settings->Administration->OpenProject
- Go to Administration settings->Administration->security
- Delete the OpenProject client
- Go back to `Administration->OpenProject

## Previously 

The Nextcloud OAuth Client section is disabled and the only way to recreate it is by resetting the integration
![content](https://github.com/nextcloud/integration_openproject/assets/41103328/75f2fd7f-73a8-42b7-8eb6-1829fb040080)


## Now 
![Screenshot from 2023-08-18 12-55-18](https://github.com/nextcloud/integration_openproject/assets/41103328/96faa988-8ca3-48c6-9c02-c6379ccf99d8)
