### PR TITLE
Increase the version of the app to 2.4.1

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -19,7 +19,7 @@ On the OpenProject end, users are able to:
 
 For more information on how to set up and use the OpenProject application, please refer to [integration setup guide](https://www.openproject.org/docs/system-admin-guide/integrations/nextcloud/) for administrators and [the user guide](https://www.openproject.org/docs/user-guide/nextcloud-integration/).
 	]]></description>
-	<version>2.4.0</version>
+	<version>2.4.1</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>OpenProject</namespace>


### PR DESCRIPTION
The release of `2.4.0` didn't go through to the app store because of a network error. https://github.com/nextcloud/integration_openproject/actions/runs/5921730212/job/16054677003
```
<html>
<head><title>504 Gateway Time-out</title></head>
<body>
<center><h1>504 Gateway Time-out</h1></center>
<hr><center>nginx/1.18.0 (Ubuntu)</center>
</body>
</html>
```

Increase the version of the app to `2.4.1`