### PR TITLE
[WP#49755]Focus search input for workpackage when displayed

### DIFF
--- a/src/components/tab/SearchInput.vue
+++ b/src/components/tab/SearchInput.vue
@@ -2,6 +2,7 @@
 	<div id="searchBar">
 		<NcSelect ref="workPackageSelect"
 			class="searchInput"
+			input-id="searchInput"
 			:placeholder="placeholder"
 			:options="filterSearchResultsByFileId"
 			:user-select="true"
@@ -107,17 +108,10 @@ export default {
 		fileInfo(oldFile, newFile) {
 			if (oldFile.id !== newFile.id) {
 				this.resetState()
-				this.emptySearchInput()
 			}
 		},
 	},
 	methods: {
-		emptySearchInput() {
-			// FIXME: https://github.com/shentao/vue-multiselect/issues/633
-			if (this.$refs.workPackageSelect?.$refs?.VueMultiselect?.search) {
-				this.$refs.workPackageSelect.$refs.VueMultiselect.search = ''
-			}
-		},
 		resetState() {
 			this.searchResults = []
 			this.state = STATE.OK

--- a/src/views/WorkPackagePickerElement.vue
+++ b/src/views/WorkPackagePickerElement.vue
@@ -24,7 +24,8 @@
 		<h2 class="work-package-picker__header">
 			{{ t('integration_openproject', 'OpenProject work package picker') }}
 		</h2>
-		<SearchInput :is-smart-picker="true"
+		<SearchInput ref="linkPicker"
+			:is-smart-picker="true"
 			:file-info="fileInfo"
 			:linked-work-packages="linkedWorkPackages"
 			@submit="onSubmit" />
@@ -67,7 +68,11 @@ export default {
 		state: STATE.OK,
 		isAdminConfigOk: loadState('integration_openproject', 'admin-config-status'),
 	}),
-
+	mounted() {
+		if (this.$refs.linkPicker?.$refs?.workPackageSelect) {
+			document.getElementById(`${this.$refs.linkPicker?.$refs?.workPackageSelect?.inputId}`).focus()
+		}
+	},
 	methods: {
 		onSubmit(data) {
 			this.$emit('submit', data)


### PR DESCRIPTION
### Description
Search input from `smartpicker` was not focused when it was displayed instead the closed button was displayed. This PR makes sure that the search input is focused when user opens the search for the workpackages from any where i.e from `smart-picker`, `tab` or `multiple-files-link-modal`.

### Relates Issue:
https://community.openproject.org/work_packages/49755/activity