### PR TITLE
[OP#49754] fix File(s)info endpoint does not return fileID for group folders

### DIFF
--- a/lib/Controller/FilesController.php
+++ b/lib/Controller/FilesController.php
@@ -141,7 +141,7 @@ class FilesController extends OCSController {
 	 * 		-u USER:PASSWD http://my.nc.org/ocs/v1.php/apps/integration_openproject/filesinfo
 	 * 		-X POST -d '{"fileIds":[FILE_ID_1,FILE_ID_2,...]}'
 	 *
-	 * @param array<int>|null $fileIds
+	 * @param array<mixed>|null $fileIds
 	 * @NoAdminRequired
 	 *
 	 */
@@ -208,7 +208,9 @@ class FilesController extends OCSController {
 					break;
 				}
 			}
-			if ($internalPath === null) {
+			// Note: in case of groupfolders the internal path is `__groupfolders/<group-folder-id>` so
+			// getInternalPath() functions returns empty string and the internal path fallbacks to the context of requester
+			if (!$internalPath) {
 				$this->logger->error(
 					'could not get the file name in the context of the owner,' .
 					' falling back to the context of requester'

--- a/lib/Controller/FilesController.php
+++ b/lib/Controller/FilesController.php
@@ -151,7 +151,7 @@ class FilesController extends OCSController {
 		}
 		$result = [];
 		foreach ($fileIds as $fileId) {
-			$result[$fileId] = $this->compileFileInfo($fileId);
+			$result[$fileId] = $this->compileFileInfo((int)$fileId);
 		}
 		return new DataResponse($result);
 	}

--- a/tests/acceptance/features/api/getFileinfoByFileIDAPI.feature
+++ b/tests/acceptance/features/api/getFileinfoByFileIDAPI.feature
@@ -1224,3 +1224,43 @@ Feature: retrieve file information of a single file, using the file ID
       | read+create+share+delete  | SRGDCK                    | RGDNVCK               |
       | read+create+update+delete | SGDNVCK                   | RGDNVCK               |
       | read+create+update+share  | SRGNVCK                   | RGDNVCK               |
+
+
+  Scenario: get information of a group folder
+    Given user "Carol" has been created
+    And group "grp1" has been created
+    And user "Carol" has been added to the group "grp1"
+    And group folder "groupFolder" has been created
+    And  group "grp1" has been added to group folder "groupFolder"
+    When user "Carol" gets the information of the folder "/groupFolder"
+    Then the HTTP status code should be "200"
+    And the ocs data of the response should match
+      """"
+      {
+      "type": "object",
+      "required": [
+      "status",
+      "statuscode",
+      "size",
+      "name",
+      "owner_id",
+      "owner_name",
+      "modifier_id",
+      "modifier_name",
+      "dav_permissions",
+      "path"
+      ],
+      "properties": {
+      "status": {"type": "string", "pattern": "^OK$"},
+      "statuscode" : {"type" : "number", "enum": [200]},
+      "size" : {"type" : "integer", "enum": [0] },
+      "name": {"type": "string", "pattern": "^groupFolder$"},
+      "owner_id": {"type": "string", "pattern": "^Carol$"},
+      "owner_name": {"type": "string", "pattern": "^Carol$"},
+      "modifier_id": {"type": "null"},
+      "modifier_name": {"type": "null"},
+      "dav_permissions": {"type": "string", "pattern":"^RMGDNVCK$"},
+      "path": {"type": "string", "pattern":"^files/groupFolder$"}
+      }
+      }
+      """

--- a/tests/acceptance/features/api/getFilesinfoByFileIDsAPI.feature
+++ b/tests/acceptance/features/api/getFilesinfoByFileIDsAPI.feature
@@ -1,7 +1,11 @@
 Feature: retrieve information of multiple files using the file IDs
 
-  Scenario: get information of four files, one own, one received as share, one trashed, one not accessible
+  Scenario: get information of four files, group folders, one own, one received as share, one trashed, one not accessible
     Given user "Carol" has been created
+    And group "grp1" has been created
+    And user "Carol" has been added to the group "grp1"
+    And group folder "groupFolder" has been created
+    And  group "grp1" has been added to group folder "groupFolder"
     And user "Brian" has been created with display-name "Brian Adams"
     And user "Carol" has uploaded file with content "some data" to "file.txt"
     And user "Brian" has uploaded file with content "some data" to "fromBrian.txt"
@@ -13,7 +17,7 @@ Feature: retrieve information of multiple files using the file IDs
     And user "Carol" has emptied the trash-bin
     And user "Carol" has deleted file "trashed.txt"
     And user "Carol" has renamed file "/fromBrian.txt" to "/renamedByCarol.txt"
-    When user "Carol" gets the information of all files created in this scenario
+    When user "Carol" gets the information of all files and group folder "groupFolder" created in this scenario
     Then the HTTP status code should be "200"
     And the ocs data of the response should match
     """"
@@ -24,7 +28,8 @@ Feature: retrieve information of multiple files using the file IDs
         "%ids[1]%",
         "%ids[2]%",
         "%ids[3]%",
-        "%ids[4]%"
+        "%ids[4]%",
+        "%ids[5]%"
       ],
       "properties": {
           "%ids[0]%": {
@@ -193,7 +198,44 @@ Feature: retrieve information of multiple files using the file IDs
               "status": {"type": "string", "pattern": "^Not Found$"},
               "statuscode" : {"type" : "number", "enum": [404]}
             }
+          },
+          "%ids[5]%": {
+            "type": "object",
+            "required": [
+              "status",
+              "statuscode",
+              "id",
+              "size",
+              "name",
+              "mtime",
+              "ctime",
+              "mimetype",
+              "owner_id",
+              "owner_name",
+              "modifier_id",
+              "modifier_name",
+              "trashed",
+              "dav_permissions",
+              "path"
+            ],
+            "properties": {
+              "status": {"type": "string", "pattern": "^OK$"},
+              "statuscode" : {"type" : "number", "enum": [200]},
+              "id" : {"type" : "integer", "minimum": 1, "maximum": 99999},
+              "size" : {"type" : "integer", "enum": [0] },
+              "mtime" : {"type" : "integer"},
+              "ctime" : {"type" : "integer", "enum": [0]},
+              "name": {"type": "string", "pattern": "^groupFolder$"},
+              "mimetype": {"type": "string", "pattern": "^application\/x-op-directory$"},
+              "owner_id": {"type": "string", "pattern": "^Carol$"},
+              "owner_name": {"type": "string", "pattern": "^Carol$"},
+              "modifier_id": {"type": "null"},
+              "modifier_name": {"type": "null"},
+              "trashed": {"type": "boolean", "enum": [false]},
+              "dav_permissions": {"type": "string", "pattern":"^RMGDNVCK"},
+              "path": {"type": "string", "pattern":"^files/groupFolder$"}
+            }
           }
-        }
+      }
     }
    """

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -22,6 +22,8 @@ class FeatureContext implements Context {
 	 */
 	/** @var array<mixed> */
 	private array $createdUsers = [];
+	/** @var array<mixed> */
+	private array $createdgroups = [];
 	private string $regularUserPassword = '';
 	private string $adminUsername = '';
 	private string $adminPassword = '';
@@ -128,6 +130,20 @@ class FeatureContext implements Context {
 			"DELETE",
 			"welcome.txt"
 		);
+	}
+
+	/**
+	 * @Given  group :group has been created
+	 */
+	public function groupHasBeenCreated(string $group):void {
+		$this->response = $this->sendOCSRequest(
+			'/cloud/groups',
+			'POST',
+			$this->getAdminUsername(),
+			['groupid' => $group]
+		);
+		$this->theHttpStatusCodeShouldBe(200);
+		$this->createdgroups['groupid'] = $group;
 	}
 
 	/**
@@ -411,9 +427,10 @@ class FeatureContext implements Context {
 	}
 
 	/**
-	 * @When user :user gets the information of all files created in this scenario
+	 * @When user :user gets the information of all files and group folder :groupFolder created in this scenario
 	 */
-	public function userGetsTheInformationOfAllCreatedFiles(string $user): void {
+	public function userGetsTheInformationOfAllCreatedFiles(string $user, string $groupFolder): void {
+		$this->createdFiles[] = $this->getIdOfElement($user, $groupFolder);
 		$body = json_encode(["fileIds" => $this->createdFiles]);
 		Assert::assertNotFalse(
 			$body,
@@ -1095,6 +1112,9 @@ class FeatureContext implements Context {
 	public function after():void {
 		foreach ($this->createdUsers as $userData) {
 			$this->theAdministratorDeletesTheUser($userData['userid']);
+		}
+		foreach ($this->createdgroups as $groups) {
+			$this->theAdministratorDeletesTheGroup($groups);
 		}
 		$this->createdAppPasswords = [];
 	}

--- a/tests/lib/Controller/FilesControllerTest.php
+++ b/tests/lib/Controller/FilesControllerTest.php
@@ -611,6 +611,92 @@ class FilesControllerTest extends TestCase {
 		assertSame(400, $result->getStatus());
 	}
 
+	public function testGetFilesInfoSendStringIds(): void {
+		$folderMock = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$folderMock->method('getById')
+			->withConsecutive([2], [3])
+			->willReturnOnConsecutiveCalls(
+				[
+					$this->getNodeMock(
+						'httpd/unix-directory',
+						2,
+						'dir',
+						'/testUser/files/myFolder/a-sub-folder'
+					)
+				],
+				[
+					$this->getNodeMock(
+						'httpd/unix-directory',
+						3,
+						'dir',
+						'/testUser/files/testFolder'
+					)
+				]
+			);
+
+		$cachedMountFileInfoMock = $this->getMockBuilder(
+			'\OCP\Files\Config\ICachedMountFileInfo'
+		)->getMock();
+		$cachedMountFileInfoMock->method('getInternalPath')
+			->willReturnOnConsecutiveCalls(
+				'files/myFolder/a-sub-folder',
+				''
+			);
+		$ownerMock = $this->getMockBuilder('\OCP\IUser')->getMock();
+		$ownerMock->method('getUID')->willReturn('3df8ff78-49cb-4d60-8d8b-171b29591fd3');
+		$cachedMountFileInfoMock->method('getUser')
+			->willReturn($ownerMock);
+		$mountCacheMock = $this->getMockBuilder('\OCP\Files\Config\IUserMountCache')->getMock();
+		$mountCacheMock->method('getMountsForFileId')
+			->willReturn(
+				[$cachedMountFileInfoMock]
+			);
+
+		$filesController = $this->createFilesController($folderMock, null, $mountCacheMock);
+
+		$result = $filesController->getFilesInfo(["2","3"]);
+		assertSame(
+			[
+				2 => [
+					'status' => 'OK',
+					'statuscode' => 200,
+					'id' => 2,
+					'name' => 'a-sub-folder',
+					'mtime' => 1640008813,
+					'ctime' => 1639906930,
+					'mimetype' => 'application/x-op-directory',
+					'size' => 200245,
+					'owner_name' => 'Test User',
+					'owner_id' => '3df8ff78-49cb-4d60-8d8b-171b29591fd3',
+					'trashed' => false,
+					'modifier_name' => null,
+					'modifier_id' => null,
+					'dav_permissions' => 'RGDNVCK',
+					'path' => 'files/myFolder/a-sub-folder'
+				],
+				3 => [
+					'status' => 'OK',
+					'statuscode' => 200,
+					'id' => 3,
+					'name' => 'name-in-the-context-of-requester',
+					'mtime' => 1640008813,
+					'ctime' => 1639906930,
+					'mimetype' => 'application/x-op-directory',
+					'size' => 200245,
+					'owner_name' => 'Test User',
+					'owner_id' => '3df8ff78-49cb-4d60-8d8b-171b29591fd3',
+					'trashed' => false,
+					'modifier_name' => null,
+					'modifier_id' => null,
+					'dav_permissions' => 'RGDNVCK',
+					'path' => 'files/testFolder'
+				]
+			],
+			$result->getData()
+		);
+		assertSame(200, $result->getStatus());
+	}
+
 	/**
 	 * @return array<mixed>
 	 */


### PR DESCRIPTION
[OP#49754] - https://community.openproject.org/work_packages/49754

For groupfolders if the fileId's are sent as string then the request returned `404` and also for group folders the internal path is `__groupfolders/<group-folder-id>` so `getInternalPath()` function returns empty string which resulted into the filename being empty so this PR fixes that as well.