### PR TITLE
[OP#49775] Drop support for Nextcloud 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,17 +15,8 @@ jobs:
     name: unit tests and linting
     strategy:
       matrix:
-        nextcloudVersion: [ stable24, stable25, stable26, stable27, master ]
-        phpVersion: [ 7.4, 8.0, 8.1 ]
-        exclude:
-          - nextcloudVersion: stable24
-            phpVersion: 8.1
-          - nextcloudVersion: stable26
-            phpVersion: 7.4
-          - nextcloudVersion: stable27
-            phpVersion: 7.4
-          - nextcloudVersion: master
-            phpVersion: 7.4
+        nextcloudVersion: [ stable25, stable26, stable27, master ]
+        phpVersion: [ 8.0, 8.1 ]
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
@@ -168,38 +159,10 @@ jobs:
     name: API tests
     strategy:
       matrix:
-        nextcloudVersion: [ stable24, stable25, stable26, stable27, master ]
-        phpVersionMajor: [ 7, 8 ]
-        phpVersionMinor: [ 4, 1 ]
+        nextcloudVersion: [ stable25, stable26, stable27, master ]
+        phpVersionMajor: [ 8 ]
+        phpVersionMinor: [ 1 ]
         database: [pgsql, mysql]
-        exclude:
-          - nextcloudVersion: stable24
-            phpVersionMajor: 8
-            phpVersionMinor: 1
-          - nextcloudVersion: stable26
-            phpVersionMajor: 7
-          - phpVersionMajor: 7
-            phpVersionMinor: 0
-          - phpVersionMajor: 7
-            phpVersionMinor: 1
-          - phpVersionMajor: 8
-            phpVersionMinor: 4
-          - nextcloudVersion: stable27
-            phpVersionMajor: 7
-          - phpVersionMajor: 7
-            phpVersionMinor: 0
-          - phpVersionMajor: 7
-            phpVersionMinor: 1
-          - phpVersionMajor: 8
-            phpVersionMinor: 4
-          - nextcloudVersion: master
-            phpVersionMajor: 7
-          - phpVersionMajor: 7
-            phpVersionMinor: 0
-          - phpVersionMajor: 7
-            phpVersionMinor: 1
-          - phpVersionMajor: 8
-            phpVersionMinor: 4
     runs-on: ubuntu-20.04
     container:
       image: ubuntu:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,14 @@ jobs:
     strategy:
       matrix:
         nextcloudVersion: [ stable25, stable26, stable27, master ]
-        phpVersion: [ 8.0, 8.1 ]
+        phpVersion: [ 7.4, 8.0, 8.1 ]
+        exclude:
+          - nextcloudVersion: stable26
+            phpVersion: 7.4
+          - nextcloudVersion: stable27
+            phpVersion: 7.4
+          - nextcloudVersion: master
+            phpVersion: 7.4
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
@@ -160,9 +167,34 @@ jobs:
     strategy:
       matrix:
         nextcloudVersion: [ stable25, stable26, stable27, master ]
-        phpVersionMajor: [ 8 ]
-        phpVersionMinor: [ 1 ]
+        phpVersionMajor: [ 7, 8 ]
+        phpVersionMinor: [ 4, 1 ]
         database: [pgsql, mysql]
+        exclude:
+          - nextcloudVersion: stable26
+            phpVersionMajor: 7
+          - phpVersionMajor: 7
+            phpVersionMinor: 0
+          - phpVersionMajor: 7
+            phpVersionMinor: 1
+          - phpVersionMajor: 8
+            phpVersionMinor: 4
+          - nextcloudVersion: stable27
+            phpVersionMajor: 7
+          - phpVersionMajor: 7
+            phpVersionMinor: 0
+          - phpVersionMajor: 7
+            phpVersionMinor: 1
+          - phpVersionMajor: 8
+            phpVersionMinor: 4
+          - nextcloudVersion: master
+            phpVersionMajor: 7
+          - phpVersionMajor: 7
+            phpVersionMinor: 0
+          - phpVersionMajor: 7
+            phpVersionMinor: 1
+          - phpVersionMajor: 8
+            phpVersionMinor: 4
     runs-on: ubuntu-20.04
     container:
       image: ubuntu:latest

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -39,7 +39,7 @@ For more information on how to set up and use the OpenProject application, pleas
 	<screenshot>https://github.com/nextcloud/integration_openproject/raw/master/img/screenshot1.png</screenshot>
 	<screenshot>https://github.com/nextcloud/integration_openproject/raw/master/img/screenshot2.png</screenshot>
 	<dependencies>
-		<nextcloud min-version="24" max-version="28"/>
+		<nextcloud min-version="25" max-version="28"/>
 	</dependencies>
 	<background-jobs>
 		<job>OCA\OpenProject\BackgroundJob\RemoveExpiredDirectUploadTokens</job>

--- a/tests/lib/Controller/FilesControllerTest.php
+++ b/tests/lib/Controller/FilesControllerTest.php
@@ -5,6 +5,7 @@ namespace OCA\OpenProject\Controller;
 use OCA\Files_Trashbin\Trash\ITrashManager;
 use OCP\Activity\IManager;
 use OCP\Files\Config\ICachedMountFileInfo;
+use OCP\Files\DavUtil;
 use OCP\Files\Node;
 use OCP\IConfig;
 use OCP\IDBConnection;
@@ -104,11 +105,10 @@ class FilesControllerTest extends TestCase {
 		$folderMock->method('getById')->willReturn($nodeMocks);
 
 		$mountCacheMock = $this->getSimpleMountCacheMock($internalPath);
-
-		$filesController = $this->createFilesController(
-			$folderMock, null, $mountCacheMock
+		$filesController = $this->getFilesControllerMock(
+			['getDavPermissions'], $folderMock, $mountCacheMock
 		);
-
+		$filesController->method('getDavPermissions')->willReturn('RGDNVCK');
 		$result = $filesController->getFileInfo(123);
 		assertSame(
 			[
@@ -156,10 +156,10 @@ class FilesControllerTest extends TestCase {
 		$mountCacheMock = $this->getSimpleMountCacheMock(
 			'files_trashbin/files/welcome.txt.d1648724302'
 		);
-
-		$filesController = $this->createFilesController(
-			$folderMock, $trashManagerMock, $mountCacheMock
+		$filesController = $this->getFilesControllerMock(
+			['getDavPermissions'], $folderMock, $mountCacheMock, true, null, $trashManagerMock
 		);
+		$filesController->method('getDavPermissions')->willReturn('RGDNVW');
 
 		$result = $filesController->getFileInfo(759);
 		assertSame($this->trashedWelcomeTxtResult, $result->getData());
@@ -245,10 +245,10 @@ class FilesControllerTest extends TestCase {
 				[null]
 			);
 
-		$filesController = $this->createFilesController(
-			$folderMock, null, $mountCacheMock
+		$filesController = $this->getFilesControllerMock(
+			['getDavPermissions'], $folderMock, $mountCacheMock
 		);
-
+		$filesController->method('getDavPermissions')->willReturn('RGDNVW');
 		$result = $filesController->getFileInfo(586);
 		assertSame($this->fileNameInTheContextOfRequesterResult, $result->getData());
 		assertSame(200, $result->getStatus());
@@ -272,10 +272,10 @@ class FilesControllerTest extends TestCase {
 			'files_trashbin/files/welcome.txt.d1648724302'
 		);
 
-		$filesController = $this->createFilesController(
-			$folderMock, $trashManagerMock, $mountCacheMock
+		$filesController = $this->getFilesControllerMock(
+			['getDavPermissions'], $folderMock, $mountCacheMock, true, null, $trashManagerMock
 		);
-
+		$filesController->method('getDavPermissions')->willReturn('RGDNVW');
 		$result = $filesController->getFilesInfo([759]);
 		assertSame(
 			[
@@ -334,11 +334,11 @@ class FilesControllerTest extends TestCase {
 				[$cachedMountFileInfoMock],
 			);
 
-		$filesController = $this->createFilesController(
-			$folderMock,
-			$trashManagerMock,
-			$mountCacheMock
+		$filesController = $this->getFilesControllerMock(
+			['getDavPermissions'], $folderMock, $mountCacheMock, true, null, $trashManagerMock
 		);
+		$filesController->method('getDavPermissions')
+			->willReturnOnConsecutiveCalls('RGDNVW', 'RGDNVW');
 
 		$result = $filesController->getFilesInfo([123, 759, 365, 956]);
 		assertSame(
@@ -363,9 +363,10 @@ class FilesControllerTest extends TestCase {
 			);
 
 		$mountCacheMock = $this->getSimpleMountCacheMock('files/logo.png');
-		$filesController = $this->createFilesController(
-			$folderMock, null, $mountCacheMock
+		$filesController = $this->getFilesControllerMock(
+			['getDavPermissions'], $folderMock, $mountCacheMock
 		);
+		$filesController->method('getDavPermissions')->willReturn('RGDNVW');
 
 		$result = $filesController->getFilesInfo([123]);
 		assertSame(
@@ -405,10 +406,11 @@ class FilesControllerTest extends TestCase {
 				[$cachedMountFileInfoMock], [], []
 			);
 
-		$filesController = $this->createFilesController(
-			$folderMock, null, $mountCacheMock
+		$filesController = $this->getFilesControllerMock(
+			['getDavPermissions'], $folderMock, $mountCacheMock
 		);
-
+		$filesController->method('getDavPermissions')
+			->willReturn('RGDNVW');
 		$result = $filesController->getFilesInfo([123,256,365]);
 		assertSame(
 			[
@@ -451,11 +453,11 @@ class FilesControllerTest extends TestCase {
 			->willReturn(
 				[$cachedMountFileInfoMock]
 			);
-
-		$filesController = $this->createFilesController(
-			$folderMock, null, $mountCacheMock
+		$filesController = $this->getFilesControllerMock(
+			['getDavPermissions'], $folderMock, $mountCacheMock
 		);
-
+		$filesController->method('getDavPermissions')
+			->willReturnOnConsecutiveCalls('RGDNVW', 'RGDNVW');
 		$result = $filesController->getFilesInfo([123,365]);
 		assertSame(
 			[
@@ -498,9 +500,11 @@ class FilesControllerTest extends TestCase {
 			->willReturn(
 				[$cachedMountFileInfoMock]
 			);
-		$filesController = $this->createFilesController(
-			$folderMock, null, $mountCacheMock
+		$filesController = $this->getFilesControllerMock(
+			['getDavPermissions'], $folderMock, $mountCacheMock
 		);
+		$filesController->method('getDavPermissions')
+			->willReturnOnConsecutiveCalls('RGDNVW', 'RGDNVW');
 
 		$result = $filesController->getFilesInfo([123,365]);
 		assertSame(
@@ -554,7 +558,11 @@ class FilesControllerTest extends TestCase {
 				[$cachedMountFileInfoMock]
 			);
 
-		$filesController = $this->createFilesController($folderMock, null, $mountCacheMock);
+		$filesController = $this->getFilesControllerMock(
+			['getDavPermissions'], $folderMock, $mountCacheMock
+		);
+		$filesController->method('getDavPermissions')
+			->willReturnOnConsecutiveCalls('RGDNVCK', 'RGDNVCK');
 
 		$result = $filesController->getFilesInfo([2,3]);
 		assertSame(
@@ -741,9 +749,11 @@ class FilesControllerTest extends TestCase {
 
 		$mountCacheMock = $this->getSimpleMountCacheMock($path);
 
-		$filesController = $this->createFilesController(
-			$folderMock, null, $mountCacheMock
+		$filesController = $this->getFilesControllerMock(
+			['getDavPermissions'], $folderMock, $mountCacheMock
 		);
+		$filesController->method('getDavPermissions')
+			->willReturn($davPermission);
 		$result = $filesController->getFileInfo(123);
 		assertSame(
 			[
@@ -880,7 +890,7 @@ class FilesControllerTest extends TestCase {
 		$trashManagerMock = null,
 		MockObject $mountCacheMock = null,
 		bool $isAppEnabled = true
-): FilesController {
+	): FilesController {
 		$storageMock = $this->getMockBuilder('\OCP\Files\IRootFolder')->getMock();
 		$storageMock->method('getUserFolder')->willReturn($folderMock);
 
@@ -917,13 +927,81 @@ class FilesControllerTest extends TestCase {
 			$this->createMock(ILogger::class),
 			$this->createMock(IL10N::class),
 			$this->createMock(IConfig::class),
-			$this->createMock(IUserManager::class)
+			$this->createMock(IUserManager::class),
+			$this->createMock(DavUtil::class)
 		);
 		if ($trashManagerMock === null) {
 			$trashManagerMock = $this->getMockBuilder('\OCA\Files_Trashbin\Trash\ITrashManager')->getMock();
 			$trashManagerMock->method('getTrashNodeById')->willReturn(null);
 		}
 		$controller->setTrashManager($trashManagerMock);
+		return $controller;
+	}
+
+	/**
+	 * @param array<string> $onlyMethods
+	 * @param MockObject $folderMock
+	 * @param MockObject|null $mountCacheMock mock for Files that exist but cannot be accessed by this user
+	 * @param bool $isAppEnabled
+	 * @param MockObject|null $davUtilsMock
+	 * @param MockObject|ITrashManager|null $trashManagerMock
+	 * @return FilesController|MockObject
+	 */
+	public function getFilesControllerMock(
+		array $onlyMethods,
+		MockObject $folderMock,
+		MockObject $mountCacheMock = null,
+		bool $isAppEnabled = true,
+		MockObject $davUtilsMock = null,
+		$trashManagerMock = null
+	): FilesController {
+		$storageMock = $this->getMockBuilder('\OCP\Files\IRootFolder')->getMock();
+		$storageMock->method('getUserFolder')->willReturn($folderMock);
+
+		$userMock = $this->getMockBuilder('\OCP\IUser')->getMock();
+		$userMock->method('getUID')->willReturn('testUser');
+
+		$userSessionMock = $this->getMockBuilder('\OCP\IUserSession')->getMock();
+		$userSessionMock->method('getUser')->willReturn($userMock);
+
+		if ($mountCacheMock === null) {
+			$mountCacheMock = $this->getMockBuilder('\OCP\Files\Config\IUserMountCache')->getMock();
+			$mountCacheMock->method('getMountsForFileId')->willReturn([]);
+		}
+		if ($davUtilsMock === null) {
+			$davUtilsMock = $this->getMockBuilder('\OCP\Files\DavUtil')->getMock();
+		}
+
+		$mountProviderCollectionMock = $this->getMockBuilder(
+		'OCP\Files\Config\IMountProviderCollection'
+		)->getMock();
+		$mountProviderCollectionMock->method('getMountCache')->willReturn($mountCacheMock);
+		$appManagerMock = $this->getMockBuilder('\OCP\App\IAppManager')->getMock();
+		$appManagerMock->method('isEnabledForUser')->willReturn($isAppEnabled);
+		$controller = $this->getMockBuilder(FilesController::class)
+		->setConstructorArgs(
+			[
+				'integration_openproject',
+				$this->createMock(IRequest::class),
+				$storageMock,
+				$userSessionMock,
+				$mountProviderCollectionMock,
+				$this->createMock(IManager::class),
+				$appManagerMock,
+				$this->createMock(IDBConnection::class),
+				$this->createMock(IValidator::class),
+				$this->createMock(ILogger::class),
+				$this->createMock(IL10N::class),
+				$this->createMock(IConfig::class),
+				$this->createMock(IUserManager::class),
+				$davUtilsMock
+			])
+		->onlyMethods($onlyMethods)
+		->getMock();
+		if ($trashManagerMock) {
+			$controller->setTrashManager($trashManagerMock);
+		}
+
 		return $controller;
 	}
 

--- a/tests/lib/Service/DirectDownloadServiceTest.php
+++ b/tests/lib/Service/DirectDownloadServiceTest.php
@@ -62,7 +62,6 @@ class DirectDownloadServiceTest extends TestCase {
 		/** @var IRootFolder $root */
 		$root = $c->get(IRootFolder::class);
 		$this->userFolder = $root->getUserFolder(self::USER_ID);
-		// @phpstan-ignore-next-line
 		$this->directController = new DirectController(
 				'dav',
 				$c->get(IRequest::class),

--- a/tests/lib/Service/DirectDownloadServiceTest.php
+++ b/tests/lib/Service/DirectDownloadServiceTest.php
@@ -9,7 +9,6 @@
 
 namespace OCA\OpenProject\Service;
 
-use OC_Util;
 use OCA\DAV\Controller\DirectController;
 use OCA\DAV\Db\DirectMapper;
 use OCA\OpenProject\AppInfo\Application;
@@ -63,11 +62,8 @@ class DirectDownloadServiceTest extends TestCase {
 		/** @var IRootFolder $root */
 		$root = $c->get(IRootFolder::class);
 		$this->userFolder = $root->getUserFolder(self::USER_ID);
-
-		// DirectController constructor changed from NC version 24, see https://github.com/nextcloud/server/pull/32482
-		if (version_compare(OC_Util::getVersionString(), '24') >= 0) {
-			// @phpstan-ignore-next-line
-			$this->directController = new DirectController(
+		// @phpstan-ignore-next-line
+		$this->directController = new DirectController(
 				'dav',
 				$c->get(IRequest::class),
 				$root,
@@ -78,19 +74,6 @@ class DirectDownloadServiceTest extends TestCase {
 				$c->get(IURLGenerator::class),
 				$c->get(IEventDispatcher::class)
 			);
-		} else {
-			// @phpstan-ignore-next-line
-			$this->directController = new DirectController(
-				'dav',
-				$c->get(IRequest::class),
-				$root,
-				self::USER_ID,
-				$c->get(DirectMapper::class),
-				$c->get(ISecureRandom::class),
-				$c->get(ITimeFactory::class),
-				$c->get(IURLGenerator::class)
-			);
-		}
 	}
 
 	public static function tearDownAfterClass(): void {

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -36,7 +36,6 @@ use OCP\IDBConnection;
 use OCP\IGroup;
 use OCP\IGroupManager;
 use OCP\IL10N;
-use OCP\ILogger;
 use OCP\IURLGenerator;
 use OC\Authentication\Token\IProvider;
 use OCP\Security\ISecureRandom;
@@ -279,7 +278,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 				$client,                                                       // @phpstan-ignore-line
 				$this->createMock(IRemoteHostValidator::class)                 // @phpstan-ignore-line
 			);
-		} elseif (version_compare(OC_Util::getVersionString(), '24') >= 0) {
+		} elseif (version_compare(OC_Util::getVersionString(), '25') >= 0) {
 			$clientConfigMock
 			->method('getSystemValueBool')
 			->with('allow_local_remote_servers', false)
@@ -288,19 +287,6 @@ class OpenProjectAPIServiceTest extends TestCase {
 			// @phpstan-ignore-next-line
 			$ocClient = new Client(
 				$clientConfigMock,                                             // @phpstan-ignore-line
-				$certificateManager,                                           // @phpstan-ignore-line
-				$client,                                                       // @phpstan-ignore-line
-				$this->createMock(\OC\Http\Client\LocalAddressChecker::class)  // @phpstan-ignore-line
-			);
-		} else {
-			$clientConfigMock
-			->method('getSystemValueBool')
-			->with('allow_local_remote_servers', false)
-			->willReturn(true);
-			// @phpstan-ignore-next-line
-			$ocClient = new Client(
-				$clientConfigMock,                                             // @phpstan-ignore-line
-				$this->createMock(ILogger::class),                             // @phpstan-ignore-line
 				$certificateManager,                                           // @phpstan-ignore-line
 				$client,                                                       // @phpstan-ignore-line
 				$this->createMock(\OC\Http\Client\LocalAddressChecker::class)  // @phpstan-ignore-line

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -227,7 +227,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 	) {
 		$certificateManager = $this->getMockBuilder('\OCP\ICertificateManager')->getMock();
 		$certificateManager->method('getAbsoluteBundlePath')->willReturn('/');
-
+		$ocClient = null;
 		$client = new GuzzleClient();
 		$clientConfigMock = $this->getMockBuilder(IConfig::class)->getMock();
 


### PR DESCRIPTION
As discussed we want to drop support for stable 24 as a part of patch release so backporting 
- https://github.com/nextcloud/integration_openproject/pull/469
- https://github.com/nextcloud/integration_openproject/pull/480

Fixes: https://community.openproject.org/projects/nextcloud-integration/work_packages/49775