### PR TITLE
[WP#49787]Remove the function for emptying search input

### DIFF
--- a/src/components/tab/SearchInput.vue
+++ b/src/components/tab/SearchInput.vue
@@ -159,7 +159,6 @@ export default {
 					t('integration_openproject', 'Work package linked successfully!')
 				)
 				this.resetState()
-				this.emptySearchInput()
 			} catch (e) {
 				showError(
 					t('integration_openproject', 'Failed to link file to work package')


### PR DESCRIPTION
### Description
The PR merged https://github.com/nextcloud/integration_openproject/pull/466 removes the non used function `emptySearchInput()`. This function was missed to clean up in the function for linking work package which introduced bug.
The test may have passed because it was success and failure at the same time and this function was called after the api request was successfull.

### Related WP
 https://community.openproject.org/projects/nextcloud-integration/work_packages/49787/activity?query_id=3787