### PR TITLE
[WP#49786]Remove border and check for consistency in `WorkPackages`

### DIFF
--- a/src/components/tab/WorkPackage.vue
+++ b/src/components/tab/WorkPackage.vue
@@ -225,7 +225,6 @@ export default {
 .workpackage {
 	width: 100%;
 	padding: 15px 6px 0 10px;
-	border-bottom: 1px solid rgb(237 237 237);
 
 	.row {
 		display: flex;


### PR DESCRIPTION
### Description
The earlier multi select did not had a border line when navigating with keyboard. But the new `NcSelect` has it own border when navigating with keyboard which made the inconsistency in the UI.



### Before With Border

With Keyboard-navigation:

![keyboard-action-lightmode](https://github.com/nextcloud/integration_openproject/assets/46086950/d9ef53c7-220e-44a3-a6fa-ba39a057266f)


![border-fix](https://github.com/nextcloud/integration_openproject/assets/46086950/08dfc13a-e576-430e-b040-6f5c4f85d7cc)


### After without border (But with Default NcSelect Border)


![keyboard-light-mode](https://github.com/nextcloud/integration_openproject/assets/46086950/685d144e-fc7c-43d3-8ddc-62f73ae5c42f)


![keyboard-darkmode](https://github.com/nextcloud/integration_openproject/assets/46086950/8f5a9f7f-2093-4451-b5ec-fe9c6fd4ad07)



### Related WorkPaakage
https://community.openproject.org/projects/nextcloud-integration/work_packages/49786/activity?query_id=3787