### PR TITLE
[WP#49793]Update the troubleshooting link

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To set up or update the integration following data needs to be provided:
 > - To set up the integration without `project folders` we need to set data `setup_project_folder=false` and `setup_app_password=false`
 > - To set up the integration with `project folders` we need to set data `setup_project_folder=true` and `setup_app_password=true`, this will create a new user, group, and group folder named OpenProject if the system doesn't already have one or more of these present. Also, an application password will be provided for the user `OpenProject`
 > - Once the `project folder` has already been set up, the created `OpenProject` user and group cannot be disabled or removed.
-> - If there is any error related to `OpenProject` user, group, group folders when setting up the whole integration or if the admin user wants to remove those entities then this [troubleshooting guide](https://www.openproject.org/docs/system-admin-guide/integrations/nextcloud/) can be followed up on how to resolve it. 
+> - If there is any error related to `OpenProject` user, group, group folders when setting up the whole integration or if the admin user wants to remove those entities then this [troubleshooting guide](https://www.openproject.org/docs/system-admin-guide/integrations/nextcloud/#troubleshooting) can be followed up on how to resolve it. 
 
 
 1. **Set up the whole integration with a [POST] request**

--- a/integration_setup.sh
+++ b/integration_setup.sh
@@ -181,7 +181,7 @@ then
 		deleteOPStorageAndPrintErrorResponse "$nextcloud_information_response"
 		log_info "Above response is missing one or more of nextcloud_client_id, nextcloud_client_secret, or openproject_user_app_password"
 		log_info "If the error response is related to project folder setup name 'OpenProject' (group, user, folder) then follow below link to resolve the error"
-		log_info "Visit this link to resolve the error manually https://www.openproject.org/docs/system-admin-guide/integrations/nextcloud/"
+		log_info "Visit this link to resolve the error manually https://www.openproject.org/docs/system-admin-guide/integrations/nextcloud/#troubleshooting"
 		exit 1
 	fi
 else

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -520,7 +520,7 @@ export default {
 		},
 		errorHintForProjectFolderConfigAlreadyExists() {
 			const linkText = t('integration_openproject', 'troubleshooting guide')
-			const htmlLink = `<a class="link" href="https://www.openproject.org/docs/system-admin-guide/integrations/nextcloud/" target="_blank" title="${linkText}">${linkText}</a>`
+			const htmlLink = `<a class="link" href="https://www.openproject.org/docs/system-admin-guide/integrations/nextcloud/#troubleshooting" target="_blank" title="${linkText}">${linkText}</a>`
 			return t('integration_openproject', 'Setting up the OpenProject user, group and group folder was not possible. Please check this {htmlLink} on how to resolve this situation.', { htmlLink }, null, { escape: false, sanitize: false })
 		},
 		isIntegrationComplete() {


### PR DESCRIPTION
### Description
The driect link for troubleshooting was not updated after the project folder setup was implemented. This PR updates the link that navigates directly to the troubleshooting link when there is any issue or error while using the integration application.


### Related Workpackage
https://community.openproject.org/projects/nextcloud-integration/work_packages/49793/activity?query_id=3787