### PR TITLE
[OP#49775] Use the server's getDavPermissions function

### DIFF
--- a/lib/Controller/FilesController.php
+++ b/lib/Controller/FilesController.php
@@ -18,6 +18,7 @@ use OCA\Activity\UserSettings;
 use OCA\Files_Trashbin\Trash\ITrashManager;
 use OCP\Activity\IManager;
 use OCP\App\IAppManager;
+use OCP\AppFramework\QueryException;
 use OCP\Files\Config\ICachedMountFileInfo;
 use OCP\Files\Config\IMountProviderCollection;
 use OCP\Files\FileInfo;
@@ -35,6 +36,7 @@ use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\RichObjectStrings\IValidator;
 use Throwable;
+use OCP\Files\DavUtil;
 
 class FilesController extends OCSController {
 
@@ -90,6 +92,10 @@ class FilesController extends OCSController {
 	 * @var ITrashManager
 	 */
 	private $trashManager = null;
+	/**
+	 * @var DavUtil
+	 */
+	private $davUtils;
 
 	public function __construct(string $appName,
 								IRequest $request,
@@ -103,7 +109,8 @@ class FilesController extends OCSController {
 								ILogger $logger,
 								IL10N $l,
 								IConfig $config,
-								IUserManager $userManager
+								IUserManager $userManager,
+								DavUtil $davUtils
 	) {
 		parent::__construct($appName, $request);
 		$this->user = $userSession->getUser();
@@ -117,6 +124,7 @@ class FilesController extends OCSController {
 		$this->config = $config;
 		$this->userManager = $userManager;
 		$this->appManager = $appManager;
+		$this->davUtils = $davUtils;
 	}
 
 	/**
@@ -158,10 +166,12 @@ class FilesController extends OCSController {
 
 	/**
 	 * Function to make the trash-manager testable
-	 * @param ITrashManager $trashManager
+	 *
+	 * @param ITrashManager|null $trashManager
 	 * @return void
+	 * @throws QueryException
 	 */
-	public function setTrashManager($trashManager = null) {
+	public function setTrashManager(ITrashManager $trashManager = null): void {
 		if ($trashManager !== null) {
 			$this->trashManager = $trashManager;
 		} elseif ($this->trashManager === null) {
@@ -323,37 +333,9 @@ class FilesController extends OCSController {
 		return null;
 	}
 
-	// copy of https://github.com/nextcloud/server/blob/cd44ee2053f105f60c668906ed8460605cb1da81/lib/public/Files/DavUtil.php#L58
-	// as this is only availabe from V25 and we need it in versions below that
-	private function getDavPermissions(FileInfo $info): string {
-		$p = '';
-		if ($info->isShared()) {
-			$p .= 'S';
-		}
-		if ($info->isShareable()) {
-			$p .= 'R';
-		}
-		if ($info->isMounted()) {
-			$p .= 'M';
-		}
-		if ($info->isReadable()) {
-			$p .= 'G';
-		}
-		if ($info->isDeletable()) {
-			$p .= 'D';
-		}
-		if ($info->isUpdateable()) {
-			$p .= 'NV'; // Renameable, Moveable
-		}
-		if ($info->getType() === FileInfo::TYPE_FILE) {
-			if ($info->isUpdateable()) {
-				$p .= 'W';
-			}
-		} else {
-			if ($info->isCreatable()) {
-				$p .= 'CK';
-			}
-		}
-		return $p;
+	// `davUtils->getDavPermissions` method is static so it cannot be mocked to
+	// creating similar function here for testing purposes
+	public function getDavPermissions(FileInfo $info): string {
+		return $this->davUtils->getDavPermissions($info);
 	}
 }

--- a/tests/lib/Controller/FilesControllerTest.php
+++ b/tests/lib/Controller/FilesControllerTest.php
@@ -5,6 +5,7 @@ namespace OCA\OpenProject\Controller;
 use OCA\Files_Trashbin\Trash\ITrashManager;
 use OCP\Activity\IManager;
 use OCP\Files\Config\ICachedMountFileInfo;
+use OCP\Files\DavUtil;
 use OCP\Files\Node;
 use OCP\IConfig;
 use OCP\IDBConnection;
@@ -104,11 +105,10 @@ class FilesControllerTest extends TestCase {
 		$folderMock->method('getById')->willReturn($nodeMocks);
 
 		$mountCacheMock = $this->getSimpleMountCacheMock($internalPath);
-
-		$filesController = $this->createFilesController(
-			$folderMock, null, $mountCacheMock
+		$filesController = $this->getFilesControllerMock(
+			['getDavPermissions'], $folderMock, $mountCacheMock
 		);
-
+		$filesController->method('getDavPermissions')->willReturn('RGDNVCK');
 		$result = $filesController->getFileInfo(123);
 		assertSame(
 			[
@@ -156,10 +156,10 @@ class FilesControllerTest extends TestCase {
 		$mountCacheMock = $this->getSimpleMountCacheMock(
 			'files_trashbin/files/welcome.txt.d1648724302'
 		);
-
-		$filesController = $this->createFilesController(
-			$folderMock, $trashManagerMock, $mountCacheMock
+		$filesController = $this->getFilesControllerMock(
+			['getDavPermissions'], $folderMock, $mountCacheMock, true, null, $trashManagerMock
 		);
+		$filesController->method('getDavPermissions')->willReturn('RGDNVW');
 
 		$result = $filesController->getFileInfo(759);
 		assertSame($this->trashedWelcomeTxtResult, $result->getData());
@@ -245,10 +245,10 @@ class FilesControllerTest extends TestCase {
 				[null]
 			);
 
-		$filesController = $this->createFilesController(
-			$folderMock, null, $mountCacheMock
+		$filesController = $this->getFilesControllerMock(
+			['getDavPermissions'], $folderMock, $mountCacheMock
 		);
-
+		$filesController->method('getDavPermissions')->willReturn('RGDNVW');
 		$result = $filesController->getFileInfo(586);
 		assertSame($this->fileNameInTheContextOfRequesterResult, $result->getData());
 		assertSame(200, $result->getStatus());
@@ -272,10 +272,10 @@ class FilesControllerTest extends TestCase {
 			'files_trashbin/files/welcome.txt.d1648724302'
 		);
 
-		$filesController = $this->createFilesController(
-			$folderMock, $trashManagerMock, $mountCacheMock
+		$filesController = $this->getFilesControllerMock(
+			['getDavPermissions'], $folderMock, $mountCacheMock, true, null, $trashManagerMock
 		);
-
+		$filesController->method('getDavPermissions')->willReturn('RGDNVW');
 		$result = $filesController->getFilesInfo([759]);
 		assertSame(
 			[
@@ -334,11 +334,11 @@ class FilesControllerTest extends TestCase {
 				[$cachedMountFileInfoMock],
 			);
 
-		$filesController = $this->createFilesController(
-			$folderMock,
-			$trashManagerMock,
-			$mountCacheMock
+		$filesController = $this->getFilesControllerMock(
+			['getDavPermissions'], $folderMock, $mountCacheMock, true, null, $trashManagerMock
 		);
+		$filesController->method('getDavPermissions')
+			->willReturnOnConsecutiveCalls('RGDNVW', 'RGDNVW');
 
 		$result = $filesController->getFilesInfo([123, 759, 365, 956]);
 		assertSame(
@@ -363,9 +363,10 @@ class FilesControllerTest extends TestCase {
 			);
 
 		$mountCacheMock = $this->getSimpleMountCacheMock('files/logo.png');
-		$filesController = $this->createFilesController(
-			$folderMock, null, $mountCacheMock
+		$filesController = $this->getFilesControllerMock(
+			['getDavPermissions'], $folderMock, $mountCacheMock
 		);
+		$filesController->method('getDavPermissions')->willReturn('RGDNVW');
 
 		$result = $filesController->getFilesInfo([123]);
 		assertSame(
@@ -405,10 +406,11 @@ class FilesControllerTest extends TestCase {
 				[$cachedMountFileInfoMock], [], []
 			);
 
-		$filesController = $this->createFilesController(
-			$folderMock, null, $mountCacheMock
+		$filesController = $this->getFilesControllerMock(
+			['getDavPermissions'], $folderMock, $mountCacheMock
 		);
-
+		$filesController->method('getDavPermissions')
+			->willReturn('RGDNVW');
 		$result = $filesController->getFilesInfo([123,256,365]);
 		assertSame(
 			[
@@ -451,11 +453,11 @@ class FilesControllerTest extends TestCase {
 			->willReturn(
 				[$cachedMountFileInfoMock]
 			);
-
-		$filesController = $this->createFilesController(
-			$folderMock, null, $mountCacheMock
+		$filesController = $this->getFilesControllerMock(
+			['getDavPermissions'], $folderMock, $mountCacheMock
 		);
-
+		$filesController->method('getDavPermissions')
+			->willReturnOnConsecutiveCalls('RGDNVW', 'RGDNVW');
 		$result = $filesController->getFilesInfo([123,365]);
 		assertSame(
 			[
@@ -498,9 +500,11 @@ class FilesControllerTest extends TestCase {
 			->willReturn(
 				[$cachedMountFileInfoMock]
 			);
-		$filesController = $this->createFilesController(
-			$folderMock, null, $mountCacheMock
+		$filesController = $this->getFilesControllerMock(
+			['getDavPermissions'], $folderMock, $mountCacheMock
 		);
+		$filesController->method('getDavPermissions')
+			->willReturnOnConsecutiveCalls('RGDNVW', 'RGDNVW');
 
 		$result = $filesController->getFilesInfo([123,365]);
 		assertSame(
@@ -554,7 +558,11 @@ class FilesControllerTest extends TestCase {
 				[$cachedMountFileInfoMock]
 			);
 
-		$filesController = $this->createFilesController($folderMock, null, $mountCacheMock);
+		$filesController = $this->getFilesControllerMock(
+			['getDavPermissions'], $folderMock, $mountCacheMock
+		);
+		$filesController->method('getDavPermissions')
+			->willReturnOnConsecutiveCalls('RGDNVCK', 'RGDNVCK');
 
 		$result = $filesController->getFilesInfo([2,3]);
 		assertSame(
@@ -652,7 +660,11 @@ class FilesControllerTest extends TestCase {
 				[$cachedMountFileInfoMock]
 			);
 
-		$filesController = $this->createFilesController($folderMock, null, $mountCacheMock);
+		$filesController = $this->getFilesControllerMock(
+			['getDavPermissions'], $folderMock, $mountCacheMock
+		);
+		$filesController->method('getDavPermissions')
+			->willReturnOnConsecutiveCalls('RGDNVCK', 'RGDNVCK');
 
 		$result = $filesController->getFilesInfo(["2","3"]);
 		assertSame(
@@ -827,9 +839,11 @@ class FilesControllerTest extends TestCase {
 
 		$mountCacheMock = $this->getSimpleMountCacheMock($path);
 
-		$filesController = $this->createFilesController(
-			$folderMock, null, $mountCacheMock
+		$filesController = $this->getFilesControllerMock(
+			['getDavPermissions'], $folderMock, $mountCacheMock
 		);
+		$filesController->method('getDavPermissions')
+			->willReturn($davPermission);
 		$result = $filesController->getFileInfo(123);
 		assertSame(
 			[
@@ -966,7 +980,7 @@ class FilesControllerTest extends TestCase {
 		$trashManagerMock = null,
 		MockObject $mountCacheMock = null,
 		bool $isAppEnabled = true
-): FilesController {
+	): FilesController {
 		$storageMock = $this->getMockBuilder('\OCP\Files\IRootFolder')->getMock();
 		$storageMock->method('getUserFolder')->willReturn($folderMock);
 
@@ -1003,13 +1017,81 @@ class FilesControllerTest extends TestCase {
 			$this->createMock(ILogger::class),
 			$this->createMock(IL10N::class),
 			$this->createMock(IConfig::class),
-			$this->createMock(IUserManager::class)
+			$this->createMock(IUserManager::class),
+			$this->createMock(DavUtil::class)
 		);
 		if ($trashManagerMock === null) {
 			$trashManagerMock = $this->getMockBuilder('\OCA\Files_Trashbin\Trash\ITrashManager')->getMock();
 			$trashManagerMock->method('getTrashNodeById')->willReturn(null);
 		}
 		$controller->setTrashManager($trashManagerMock);
+		return $controller;
+	}
+
+	/**
+	 * @param array<string> $onlyMethods
+	 * @param MockObject $folderMock
+	 * @param MockObject|null $mountCacheMock mock for Files that exist but cannot be accessed by this user
+	 * @param bool $isAppEnabled
+	 * @param MockObject|null $davUtilsMock
+	 * @param MockObject|ITrashManager|null $trashManagerMock
+	 * @return FilesController|MockObject
+	 */
+	public function getFilesControllerMock(
+		array $onlyMethods,
+		MockObject $folderMock,
+		MockObject $mountCacheMock = null,
+		bool $isAppEnabled = true,
+		MockObject $davUtilsMock = null,
+		$trashManagerMock = null
+	): FilesController {
+		$storageMock = $this->getMockBuilder('\OCP\Files\IRootFolder')->getMock();
+		$storageMock->method('getUserFolder')->willReturn($folderMock);
+
+		$userMock = $this->getMockBuilder('\OCP\IUser')->getMock();
+		$userMock->method('getUID')->willReturn('testUser');
+
+		$userSessionMock = $this->getMockBuilder('\OCP\IUserSession')->getMock();
+		$userSessionMock->method('getUser')->willReturn($userMock);
+
+		if ($mountCacheMock === null) {
+			$mountCacheMock = $this->getMockBuilder('\OCP\Files\Config\IUserMountCache')->getMock();
+			$mountCacheMock->method('getMountsForFileId')->willReturn([]);
+		}
+		if ($davUtilsMock === null) {
+			$davUtilsMock = $this->getMockBuilder('\OCP\Files\DavUtil')->getMock();
+		}
+
+		$mountProviderCollectionMock = $this->getMockBuilder(
+		'OCP\Files\Config\IMountProviderCollection'
+		)->getMock();
+		$mountProviderCollectionMock->method('getMountCache')->willReturn($mountCacheMock);
+		$appManagerMock = $this->getMockBuilder('\OCP\App\IAppManager')->getMock();
+		$appManagerMock->method('isEnabledForUser')->willReturn($isAppEnabled);
+		$controller = $this->getMockBuilder(FilesController::class)
+		->setConstructorArgs(
+			[
+				'integration_openproject',
+				$this->createMock(IRequest::class),
+				$storageMock,
+				$userSessionMock,
+				$mountProviderCollectionMock,
+				$this->createMock(IManager::class),
+				$appManagerMock,
+				$this->createMock(IDBConnection::class),
+				$this->createMock(IValidator::class),
+				$this->createMock(ILogger::class),
+				$this->createMock(IL10N::class),
+				$this->createMock(IConfig::class),
+				$this->createMock(IUserManager::class),
+				$davUtilsMock
+			])
+		->onlyMethods($onlyMethods)
+		->getMock();
+		if ($trashManagerMock) {
+			$controller->setTrashManager($trashManagerMock);
+		}
+
 		return $controller;
 	}
 


### PR DESCRIPTION
Related work package [OP#49775] https://community.openproject.org/projects/nextcloud-integration/work_packages/49775

Since we dropped the support for nextcloud-24 we can use the server's `getDavPermissions` and can remove the copy of it from our app