### PR TITLE
Fix php test failing in the CI

### DIFF
--- a/tests/lib/Controller/FilesControllerTest.php
+++ b/tests/lib/Controller/FilesControllerTest.php
@@ -660,8 +660,11 @@ class FilesControllerTest extends TestCase {
 				[$cachedMountFileInfoMock]
 			);
 
-		$filesController = $this->createFilesController($folderMock, null, $mountCacheMock);
-
+		$filesController = $this->getFilesControllerMock(
+			['getDavPermissions'], $folderMock, $mountCacheMock
+		);
+		$filesController->method('getDavPermissions')
+			->willReturnOnConsecutiveCalls('RGDNVCK', 'RGDNVCK');
 		$result = $filesController->getFilesInfo(["2","3"]);
 		assertSame(
 			[


### PR DESCRIPTION
php test `testGetFilesInfoSendStringIds` was failing in the CI with 

```console
There was 1 error:

1) OCA\OpenProject\Controller\FilesControllerTest::testGetFilesInfoSendStringIds
PHPUnit\Framework\MockObject\BadMethodCallException: Static method "getDavPermissions" cannot be invoked on mock object

/home/runner/work/integration_openproject/integration_openproject/server/apps/integration_openproject/lib/Controller/FilesController.php:3[39](https://github.com/nextcloud/integration_openproject/actions/runs/6071884336/job/16470815100#step:15:40)
/home/runner/work/integration_openproject/integration_openproject/server/apps/integration_openproject/lib/Controller/FilesController.php:247
/home/runner/work/integration_openproject/integration_openproject/server/apps/integration_openproject/lib/Controller/FilesController.php:162
/home/runner/work/integration_openproject/integration_openproject/server/apps/integration_openproject/tests/lib/Controller/FilesControllerTest.php:665
```
PR: https://github.com/nextcloud/integration_openproject/pull/471 made the changes to make use the server's function but this test wasn't updated with the changes made by this PR probably because the PR `471` and https://github.com/nextcloud/integration_openproject/pull/479 was merged around the same time and one or the other weren't rebased properly.
