### PR TITLE
[OP#49871] fix White (or light) colored work package type not visible with light theme on work package picker (Talk)

### DIFF
--- a/src/components/tab/SearchInput.vue
+++ b/src/components/tab/SearchInput.vue
@@ -15,7 +15,8 @@
 			@option:selected="linkWorkPackageToFile">
 			<template #option="option">
 				<WorkPackage :key="option.id"
-					:workpackage="option" />
+					:workpackage="option"
+					:is-smart-picker="isSmartPicker" />
 			</template>
 			<template #no-options>
 				{{ noOptionsText }}

--- a/src/components/tab/WorkPackage.vue
+++ b/src/components/tab/WorkPackage.vue
@@ -52,6 +52,14 @@ export default {
 			type: Object,
 			required: true,
 		},
+		isSmartPicker: {
+			type: Boolean,
+			default: false,
+		},
+		isLinkPreviews: {
+			type: Boolean,
+			default: false,
+		},
 	},
 	data: () => ({
 		wpTypeTextStroke: 'unset',
@@ -126,6 +134,12 @@ export default {
 		},
 		getWPBackgroundElement() {
 			let el = document.getElementById('workpackage-' + this.workpackage.id)
+			console.log(this.workpackage.id)
+			console.log(typeof el)
+			console.log(el)
+			if (this.isSmartPicker) {
+				el = document.getElementById('work-package-smart-picker')
+			}
 			if (el === null) {
 				el = document.getElementById('tab-open-project')
 			}

--- a/src/components/tab/WorkPackage.vue
+++ b/src/components/tab/WorkPackage.vue
@@ -134,11 +134,10 @@ export default {
 		},
 		getWPBackgroundElement() {
 			let el = document.getElementById('workpackage-' + this.workpackage.id)
-			console.log(this.workpackage.id)
-			console.log(typeof el)
-			console.log(el)
 			if (this.isSmartPicker) {
 				el = document.getElementById('work-package-smart-picker')
+			} else if (this.isLinkPreviews) {
+				el = document.getElementById('workpackage-link-previews')
 			}
 			if (el === null) {
 				el = document.getElementById('tab-open-project')

--- a/src/views/WorkPackagePickerElement.vue
+++ b/src/views/WorkPackagePickerElement.vue
@@ -20,7 +20,7 @@
   -->
 
 <template>
-	<div id="work-package-smart-picker" class="work-package-picker" >
+	<div id="work-package-smart-picker" class="work-package-picker">
 		<h2 class="work-package-picker__header">
 			{{ t('integration_openproject', 'OpenProject work package picker') }}
 		</h2>

--- a/src/views/WorkPackagePickerElement.vue
+++ b/src/views/WorkPackagePickerElement.vue
@@ -20,7 +20,7 @@
   -->
 
 <template>
-	<div class="work-package-picker">
+	<div id="work-package-smart-picker" class="work-package-picker" >
 		<h2 class="work-package-picker__header">
 			{{ t('integration_openproject', 'OpenProject work package picker') }}
 		</h2>

--- a/src/views/WorkPackageReferenceWidget.vue
+++ b/src/views/WorkPackageReferenceWidget.vue
@@ -20,7 +20,7 @@
   -->
 
 <template>
-	<div class="work-package-reference">
+	<div id="workpackage-link-previews" class="work-package-reference">
 		<div v-if="isError">
 			<h3 class="error-title">
 				<CloseIcon :size="20" class="icon" />
@@ -31,9 +31,11 @@
 				{{ t('integration_openproject', 'OpenProject settings') }}
 			</a>
 		</div>
-		<WorkPackage :id="'workpackage-'+ richObject.id"
+		<WorkPackage v-if="workpackage"
+			:id="'workpackage-'+ richObject.id"
 			class="work-package-reference__link-preview"
-			:workpackage="workpackage" />
+			:workpackage="workpackage"
+			:is-link-previews="true" />
 	</div>
 </template>
 

--- a/tests/jest/components/tab/__snapshots__/SearchInput.spec.js.snap
+++ b/tests/jest/components/tab/__snapshots__/SearchInput.spec.js.snap
@@ -20,6 +20,8 @@ exports[`SearchInput.vue state messages no-token: should display the correct sta
 
 exports[`SearchInput.vue work packages select search list should display correct options list of search results 1`] = `
 Object {
+  "isLinkPreviews": false,
+  "isSmartPicker": false,
   "workpackage": Object {
     "assignee": "test",
     "fileId": 1234,
@@ -40,6 +42,8 @@ exports[`SearchInput.vue work packages select search list should not be displaye
 
 exports[`SearchInput.vue work packages select search list should only use the options from the latest search response 1`] = `
 Object {
+  "isLinkPreviews": false,
+  "isSmartPicker": false,
   "workpackage": Object {
     "assignee": "some assignee",
     "fileId": 111,


### PR DESCRIPTION
Fixes [OP#49871] : https://community.openproject.org/projects/nextcloud-integration/work_packages/49871

## Before

![2023-09-01_11-43](https://github.com/nextcloud/integration_openproject/assets/41103328/b3338744-0599-47f5-b9d6-2b435c225a03)

## After
![Screenshot from 2023-09-07 14-12-39](https://github.com/nextcloud/integration_openproject/assets/41103328/79061c50-f79e-4201-9508-455bff8773e8)
