### PR TITLE
[OP#49859] Allow openproject host through CSP

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -28,7 +28,6 @@ use OCP\IURLGenerator;
 use OCP\IUserSession;
 use OCP\Util;
 use OCP\Collaboration\Reference\RenderReferenceEvent;
-
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
 use OCP\AppFramework\Bootstrap\IBootContext;
@@ -39,6 +38,8 @@ use OCP\Group\Events\BeforeGroupDeletedEvent;
 use OCP\User\Events\UserChangedEvent;
 use OCA\OpenProject\Dashboard\OpenProjectWidget;
 use OCA\OpenProject\Search\OpenProjectSearchProvider;
+use OCP\Security\CSP\AddContentSecurityPolicyEvent;
+use OCA\OpenProject\Listener\AddContentSecurityPolicyListener;
 
 /**
  * Class Application
@@ -81,6 +82,7 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(
 			BeforeNodeRenamedEvent::class, BeforeNodeInsideOpenProjectGroupfilderChangedListener::class
 		);
+		$context->registerEventListener(AddContentSecurityPolicyEvent::class, AddContentSecurityPolicyListener::class);
 
 		if (version_compare($this->config->getSystemValueString('version', '0.0.0'), '26.0.0', '>=')) {
 			// @phpstan-ignore-next-line - make phpstan not complain in nextcloud version other than 26

--- a/lib/Listener/AddContentSecurityPolicyListener.php
+++ b/lib/Listener/AddContentSecurityPolicyListener.php
@@ -30,6 +30,9 @@ use OCP\EventDispatcher\IEventListener;
 use OCP\IConfig;
 use OCP\Security\CSP\AddContentSecurityPolicyEvent;
 
+/**
+ * @template-implements IEventListener<Event>
+ */
 class AddContentSecurityPolicyListener implements IEventListener {
 	/**
 	 * @var IConfig

--- a/lib/Listener/AddContentSecurityPolicyListener.php
+++ b/lib/Listener/AddContentSecurityPolicyListener.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * @copyright Copyright (c) 2023, Swikriti Tripathi <swikriti@jankaritech.com>
+ *
+ * @author Swikriti Tripathi <swikriti@jankaritech.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\OpenProject\Listener;
+
+use OCA\OpenProject\AppInfo\Application;
+use OCP\AppFramework\Http\ContentSecurityPolicy;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\IConfig;
+use OCP\Security\CSP\AddContentSecurityPolicyEvent;
+
+class AddContentSecurityPolicyListener implements IEventListener {
+	/**
+	 * @var IConfig
+	 */
+	protected $config;
+
+	public function __construct(IConfig $config) {
+		$this->config = $config;
+	}
+
+	public function handle(Event $event): void {
+		if (!($event instanceof AddContentSecurityPolicyEvent)) {
+			return;
+		}
+		$csp = new ContentSecurityPolicy();
+		$baseUrl = $this->config->getAppValue(Application::APP_ID, 'openproject_instance_url', '');
+		$csp->addAllowedFrameDomain($baseUrl);
+		$event->addPolicy($csp);
+	}
+}


### PR DESCRIPTION
While implementing the creating workpackage through the nextcloud we will use the `iframe` from open project so allow open project host through content security policy

Related Workpackage[OP#49944] : https://community.openproject.org/work_packages/49944