### PR TITLE
[OP#49928] Enable CI in nextcloud master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,14 @@ jobs:
     name: unit tests and linting
     strategy:
       matrix:
-        nextcloudVersion: [ stable25, stable26, stable27 ]
+        nextcloudVersion: [ stable25, stable26, stable27, master ]
         phpVersion: [ 7.4, 8.0, 8.1 ]
         exclude:
           - nextcloudVersion: stable26
             phpVersion: 7.4
           - nextcloudVersion: stable27
+            phpVersion: 7.4
+          - nextcloudVersion: master
             phpVersion: 7.4
     runs-on: ubuntu-20.04
     steps:
@@ -103,7 +105,7 @@ jobs:
           make jsunit
 
       - name: JS Code Coverage Summary Report
-        if: ${{ github.event_name == 'pull_request' && matrix.nextcloudVersion == 'stable27' && matrix.phpVersion == '8.1' }}
+        if: ${{ github.event_name == 'pull_request' && matrix.nextcloudVersion == 'master' && matrix.phpVersion == '8.1' }}
         uses: romeovs/lcov-reporter-action@v0.3.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -112,14 +114,14 @@ jobs:
           title: "JS Code Coverage"
 
       - name: Setup .NET Core # this is required to execute Convert PHP cobertura coverage to lcov step
-        if: ${{ github.event_name == 'pull_request' && matrix.nextcloudVersion == 'stable27' && matrix.phpVersion == '8.1' }}
+        if: ${{ github.event_name == 'pull_request' && matrix.nextcloudVersion == 'master' && matrix.phpVersion == '8.1' }}
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 6.0.101
           dotnet-quality: 'ga'
 
       - name: Convert PHP cobertura coverage to lcov
-        if: ${{ github.event_name == 'pull_request' && matrix.nextcloudVersion == 'stable27' && matrix.phpVersion == '8.1' }}
+        if: ${{ github.event_name == 'pull_request' && matrix.nextcloudVersion == 'master' && matrix.phpVersion == '8.1' }}
         uses: danielpalme/ReportGenerator-GitHub-Action@5.1.23
         with:
           reports: './server/apps/integration_openproject/coverage/php/cobertura.xml' # REQUIRED # The coverage reports that should be parsed (separated by semicolon). Globbing is supported.
@@ -138,7 +140,7 @@ jobs:
           toolpath: 'reportgeneratortool' # Default directory for installing the dotnet tool.
 
       - name: PHP Code Coverage Summary Report
-        if: ${{ github.event_name == 'pull_request' && matrix.nextcloudVersion == 'stable27' && matrix.phpVersion == '8.1' }}
+        if: ${{ github.event_name == 'pull_request' && matrix.nextcloudVersion == 'master' && matrix.phpVersion == '8.1' }}
         uses: romeovs/lcov-reporter-action@v0.3.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -147,14 +149,14 @@ jobs:
           title: "PHP Code Coverage"
 
       - name: JS coverage check
-        if: ${{ github.event_name == 'pull_request' && matrix.nextcloudVersion == 'stable27' && matrix.phpVersion == '8.1' }}
+        if: ${{ github.event_name == 'pull_request' && matrix.nextcloudVersion == 'master' && matrix.phpVersion == '8.1' }}
         uses: VeryGoodOpenSource/very_good_coverage@v2
         with:
           min_coverage: '59'
           path: './server/apps/integration_openproject/coverage/jest/lcov.info'
 
       - name: PHP coverage check
-        if: ${{ github.event_name == 'pull_request' && matrix.nextcloudVersion == 'stable27' && matrix.phpVersion == '8.1' }}
+        if: ${{ github.event_name == 'pull_request' && matrix.nextcloudVersion == 'master' && matrix.phpVersion == '8.1' }}
         uses: VeryGoodOpenSource/very_good_coverage@v2
         with:
           min_coverage: '56'
@@ -164,7 +166,7 @@ jobs:
     name: API tests
     strategy:
       matrix:
-        nextcloudVersion: [ stable25, stable26, stable27 ]
+        nextcloudVersion: [ stable25, stable26, stable27, master ]
         phpVersionMajor: [ 7, 8 ]
         phpVersionMinor: [ 4, 1 ]
         database: [pgsql, mysql]
@@ -185,14 +187,14 @@ jobs:
             phpVersionMinor: 1
           - phpVersionMajor: 8
             phpVersionMinor: 4
-          # - nextcloudVersion: master
-          #   phpVersionMajor: 7
-          # - phpVersionMajor: 7
-          #   phpVersionMinor: 0
-          # - phpVersionMajor: 7
-          #   phpVersionMinor: 1
-          # - phpVersionMajor: 8
-          #   phpVersionMinor: 4
+          - nextcloudVersion: master
+            phpVersionMajor: 7
+          - phpVersionMajor: 7
+            phpVersionMinor: 0
+          - phpVersionMajor: 7
+            phpVersionMinor: 1
+          - phpVersionMajor: 8
+            phpVersionMinor: 4
     runs-on: ubuntu-20.04
     container:
       image: ubuntu:latest


### PR DESCRIPTION
Previously the CI was failing in master of the next cloud due to some issue with the group folders app and the CI was disabled for nextcloud master in https://github.com/nextcloud/integration_openproject/pull/490 but the issue with groupsfolder has been fixed so enable the CI for master again. 

Related workpackage[OP#49928] : https://community.openproject.org/projects/nextcloud-integration/work_packages/49928