### PR TITLE
[WP#40971]Link the multiple selected files in chunks

### DIFF
--- a/src/components/tab/SearchInput.vue
+++ b/src/components/tab/SearchInput.vue
@@ -36,7 +36,6 @@ import axios from '@nextcloud/axios'
 import { generateUrl } from '@nextcloud/router'
 import NcSelect from '@nextcloud/vue/dist/Components/NcSelect.js'
 import WorkPackage from './WorkPackage.vue'
-import { showError, showSuccess } from '@nextcloud/dialogs'
 import '@nextcloud/dialogs/styles/toast.scss'
 import { workpackageHelper } from '../../utils/workpackageHelper.js'
 import { STATE, WORKPACKAGES_SEARCH_ORIGIN } from '../../utils.js'
@@ -159,38 +158,19 @@ export default {
 				return
 			}
 			// since we can link multiple files now we send file information required in an array (whether it's only one value or multiple)
-			let fileInfoForBody = []
-			let successMessage
 			if (this.searchOrigin === WORKPACKAGES_SEARCH_ORIGIN.PROJECT_TAB) {
-				fileInfoForBody.push(this.fileInfo)
-				successMessage = t('integration_openproject', 'Link to work package created successfully!')
-			} else if (this.searchOrigin === WORKPACKAGES_SEARCH_ORIGIN.LINK_MULTIPLE_FILES_MODAL) {
-				fileInfoForBody = this.fileInfo
-				successMessage = t('integration_openproject', 'Links to work package created successfully for selected files!')
-			}
-
-			const config = {
-				headers: {
-					'Content-Type': 'application/json',
-				},
-			}
-
-			const body = {
-				values: {
-					workpackageId: selectedOption.id,
-					fileinfo: fileInfoForBody,
-				},
-			}
-			const url = generateUrl('/apps/integration_openproject/work-packages')
-			try {
-				await axios.post(url, body, config)
-				this.$emit('saved', selectedOption)
-				showSuccess(successMessage)
+				await workpackageHelper.linkFileToWorkPackageWithSingleRequest([this.fileInfo], selectedOption, t('integration_openproject', 'Link to work package created successfully!'), this)
 				this.resetState()
-			} catch (e) {
-				showError(
-					t('integration_openproject', 'Failed to link file to work package')
-				)
+			} else if (this.searchOrigin === WORKPACKAGES_SEARCH_ORIGIN.LINK_MULTIPLE_FILES_MODAL) {
+				if (this.fileInfo.length <= 20) {
+					await workpackageHelper.linkFileToWorkPackageWithSingleRequest(this.fileInfo, selectedOption, t('integration_openproject', 'Links to work package created successfully for selected files!'), this)
+					this.$emit('close', selectedOption)
+					this.resetState()
+				} else {
+					const chunkedFilesInformations = workpackageHelper.chunkMultipleSelectedFilesInformation(this.fileInfo)
+					await workpackageHelper.linkMultipleFilesToWorkPackageWithChunking(chunkedFilesInformations, selectedOption, false, this)
+					this.resetState()
+				}
 			}
 		},
 		async makeSearchRequest(search, fileId) {

--- a/src/components/tab/SearchInput.vue
+++ b/src/components/tab/SearchInput.vue
@@ -39,6 +39,7 @@ import WorkPackage from './WorkPackage.vue'
 import '@nextcloud/dialogs/styles/toast.scss'
 import { workpackageHelper } from '../../utils/workpackageHelper.js'
 import { STATE, WORKPACKAGES_SEARCH_ORIGIN } from '../../utils.js'
+import { translate as t } from '@nextcloud/l10n'
 
 const SEARCH_CHAR_LIMIT = 1
 const DEBOUNCE_THRESHOLD = 500
@@ -167,6 +168,7 @@ export default {
 					this.$emit('close', selectedOption)
 					this.resetState()
 				} else {
+					// the selected files will be linked in chunks
 					const chunkedFilesInformations = workpackageHelper.chunkMultipleSelectedFilesInformation(this.fileInfo)
 					await workpackageHelper.linkMultipleFilesToWorkPackageWithChunking(chunkedFilesInformations, selectedOption, false, this)
 					this.resetState()

--- a/src/components/tab/SearchInput.vue
+++ b/src/components/tab/SearchInput.vue
@@ -169,8 +169,7 @@ export default {
 					this.resetState()
 				} else {
 					// the selected files will be linked in chunks
-					const chunkedFilesInformations = workpackageHelper.chunkMultipleSelectedFilesInformation(this.fileInfo)
-					await workpackageHelper.linkMultipleFilesToWorkPackageWithChunking(chunkedFilesInformations, selectedOption, false, this)
+					await workpackageHelper.linkMultipleFilesToWorkPackageWithChunking(this.fileInfo, selectedOption, false, this)
 					this.resetState()
 				}
 			}

--- a/src/utils/workpackageHelper.js
+++ b/src/utils/workpackageHelper.js
@@ -98,7 +98,7 @@ export const workpackageHelper = {
 		}
 		return chunkedResult
 	},
-	getTotalNoOfFilesFromChunks(chunkedFilesInformations) {
+	getTotalNoOfFilesInAlreadyChunkedFilesInformation(chunkedFilesInformations) {
 		const totalFiles = []
 		for (let i = 0; i < chunkedFilesInformations.length; i++) {
 			totalFiles.push(...chunkedFilesInformations[i])
@@ -111,9 +111,9 @@ export const workpackageHelper = {
 	*/
 	async linkMultipleFilesToWorkPackageWithChunking(chunkedFilesInformations, selectedWorkpackage, isRemaining, component) {
 		const chunkingInformation = {
-			totalNoOfFilesSelected: this.getTotalNoOfFilesFromChunks(chunkedFilesInformations),
+			totalNoOfFilesSelected: this.getTotalNoOfFilesInAlreadyChunkedFilesInformation(chunkedFilesInformations),
 			totalFilesAlreadyLinked: 0,
-			totalFilesNotLinked: this.getTotalNoOfFilesFromChunks(chunkedFilesInformations),
+			totalFilesNotLinked: this.getTotalNoOfFilesInAlreadyChunkedFilesInformation(chunkedFilesInformations),
 			isChunkingError: false,
 			remainingFileInformations: [],
 			selectedWorkPackage: selectedWorkpackage,
@@ -135,13 +135,13 @@ export const workpackageHelper = {
 				if (chunkedFilesInformations.indexOf(fileInfoForBody) !== chunkedFilesInformations.length - 1) {
 					chunkingInformation.totalFilesAlreadyLinked = chunkingInformation.totalFilesAlreadyLinked + 20
 				} else {
-					// for the last chunked files information we only count the no of files which may not be 20
+					// for the last chunked files information we only count the no of files which are not be 20
 					chunkingInformation.totalFilesAlreadyLinked = chunkingInformation.totalFilesAlreadyLinked + fileInfoForBody.length
 				}
 				chunkingInformation.totalFilesNotLinked = chunkingInformation.totalNoOfFilesSelected - chunkingInformation.totalFilesAlreadyLinked
 			} catch (e) {
 				chunkingInformation.isChunkingError = true
-				// we compute the remaining files information when there is some error while chunking
+				// when error encounters while chunking we compute the information of files for relinking  again
 				for (let i = chunkedFilesInformations.indexOf(fileInfoForBody); i < chunkedFilesInformations.length; i++) {
 					chunkingInformation.remainingFileInformations.push(...chunkedFilesInformations[i])
 				}

--- a/src/utils/workpackageHelper.js
+++ b/src/utils/workpackageHelper.js
@@ -148,9 +148,9 @@ export const workpackageHelper = {
 				break
 			} finally {
 				if (isRemaining) {
-					component.getChunkedInformations(chunkingInformation)
+					component.setChunkedInformations(chunkingInformation)
 				} else {
-					component.$emit('get-chunked-informations', chunkingInformation)
+					component.$emit('set-chunked-informations', chunkingInformation)
 				}
 			}
 		}

--- a/src/views/LinkMultipleFilesModal.vue
+++ b/src/views/LinkMultipleFilesModal.vue
@@ -52,7 +52,7 @@
 						:linked-work-packages="alreadyLinkedWorkPackage"
 						:file-info="fileInfos"
 						:search-origin="searchOrigin"
-						@get-chunked-informations="getChunkedInformations"
+						@set-chunked-informations="setChunkedInformations"
 						@close="closeRequestModal" />
 					<EmptyContent
 						id="openproject-empty-content"
@@ -166,7 +166,7 @@ export default {
 				)
 			}
 		},
-		getChunkedInformations(data) {
+		setChunkedInformations(data) {
 			this.chunkingInformation = data
 		},
 		showModal() {

--- a/src/views/LinkMultipleFilesModal.vue
+++ b/src/views/LinkMultipleFilesModal.vue
@@ -2,21 +2,21 @@
 	<div class="multiple-link-modal-container">
 		<NcModal
 			v-if="show"
-			:can-close="canCloseModal"
+			:can-close="isError"
 			@close="closeRequestModal">
 			<div class="multiple-link-modal-content">
 				<LoadingIcon v-if="isLoading" class="loading-spinner" :size="60" />
 				<div v-else-if="chunkingInformation !== null" class="link-progress-information-wrapper">
-					<div v-if="getChunkStateInChunking" class="link-progress-information-failed">
+					<div v-if="getError" class="link-progress-information-failed">
 						<div class="link-progress-information-failed--details">
 							<div class="link-progress-information-failed--details--info">
-								<AlertCircleOutline fill-color="#e9322d" :size="70" />
+								<AlertCircleOutline fill-color="var(--color-error)" :size="70" />
 							</div>
 							<div class="link-progress-information-failed--details--info">
 								<p>{{ t('integration_openproject', `Files selected: ${getTotalNoOfFilesSelectedInChunking}`) }}</p>
 								<p>{{ t('integration_openproject', `Files successfully linked: ${getTotalNoOfFilesAlreadyLinkedInChunking}`) }}</p>
 								<p class="link-progress-information-failed--details--info--error">
-									{{ t('integration_openproject', `Files failed to linked: ${getTotalNoOfFilesNotLinkedInChunking}`) }}
+									{{ t('integration_openproject', `Files failed to be linked: ${getTotalNoOfFilesNotLinkedInChunking}`) }}
 								</p>
 							</div>
 							<div class="link-progress-information-failed--details--info">
@@ -142,11 +142,11 @@ export default {
 			}
 			return progressPercentage
 		},
-		getChunkStateInChunking() {
-			return this.chunkingInformation?.isChunkingError
+		getError() {
+			return this.chunkingInformation?.error
 		},
-		canCloseModal() {
-			return this.chunkingInformation?.isChunkingError !== false
+		isError() {
+			return this.chunkingInformation?.error !== false
 		},
 	},
 
@@ -155,11 +155,10 @@ export default {
 	},
 	methods: {
 		async relinkRemainingFilesToWorkPackage() {
-			this.chunkingInformation.isChunkingError = false
+			this.chunkingInformation.error = false
 			const remainingFilesToChunk = this.chunkingInformation.remainingFileInformations
 			const selectedWorkPackage = this.chunkingInformation.selectedWorkPackage
-			const chunkedFilesInformations = workpackageHelper.chunkMultipleSelectedFilesInformation(remainingFilesToChunk)
-			await workpackageHelper.linkMultipleFilesToWorkPackageWithChunking(chunkedFilesInformations, selectedWorkPackage, true, this)
+			await workpackageHelper.linkMultipleFilesToWorkPackageWithChunking(remainingFilesToChunk, selectedWorkPackage, true, this)
 			if (this.getTotalNoOfFilesAlreadyLinkedInChunking !== remainingFilesToChunk.length) {
 				showError(
 					t('integration_openproject', 'Failed to link selected files to work package')

--- a/src/views/LinkMultipleFilesModal.vue
+++ b/src/views/LinkMultipleFilesModal.vue
@@ -10,18 +10,18 @@
 					<div v-if="getChunkStateInChunking" class="link-progress-information-failed">
 						<div class="link-progress-information-failed--details">
 							<div class="link-progress-information-failed--details--info">
-								<AlertCircleOutline fill-color="#FF0000" :size="70" />
+								<AlertCircleOutline fill-color="#e9322d" :size="70" />
 							</div>
 							<div class="link-progress-information-failed--details--info">
-								<p>Files selected: {{ getTotalNoOfFilesSelectedInChunking }}</p>
-								<p>Files successfully linked: {{ getTotalNoOfFilesAlreadyLinkedInChunking }}</p>
-								<p :style="{ color: '#FF0000' }">
-									Files failed to linked: {{ getTotalNoOfFilesNotLinkedInChunking }}
+								<p>{{ t('integration_openproject', `Files selected: ${getTotalNoOfFilesSelectedInChunking}`) }}</p>
+								<p>{{ t('integration_openproject', `Files successfully linked: ${getTotalNoOfFilesAlreadyLinkedInChunking}`) }}</p>
+								<p class="link-progress-information-failed--details--info--error">
+									{{ t('integration_openproject', `Files failed to linked: ${getTotalNoOfFilesNotLinkedInChunking}`) }}
 								</p>
 							</div>
 							<div class="link-progress-information-failed--details--info">
 								<NcButton
-									data-test-id="reset-user-app-password"
+									data-test-id="relink-remaining-files"
 									@click="relinkRemainingFilesToWorkPackage">
 									<template #icon>
 										<AutoRenewIcon :size="20" />
@@ -35,8 +35,8 @@
 						<FileLinkIcon :size="50" />
 						<div class="success-progress-information">
 							<div class="success-progress-information--title">
-								<p>{{ getTotalNoOfFilesAlreadyLinkedInChunking }} of {{ getTotalNoOfFilesSelectedInChunking }} files linked</p>
-								<p>{{ getProgressValueOfMultipleFilesLinked }}%</p>
+								<p>{{ t('integration_openproject', `${getTotalNoOfFilesAlreadyLinkedInChunking} of ${getTotalNoOfFilesSelectedInChunking} files linked`) }}</p>
+								<p>{{ t('integration_openproject', `${getProgressValueOfMultipleFilesLinked}%`) }}</p>
 							</div>
 							<div class="success-progress-information--progress-bar">
 								<NcProgressBar :value="getProgressValueOfMultipleFilesLinked" size="medium" />
@@ -78,6 +78,7 @@ import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import AutoRenewIcon from 'vue-material-design-icons/Autorenew.vue'
 import FileLinkIcon from 'vue-material-design-icons/FileLink.vue'
 import NcProgressBar from '@nextcloud/vue/dist/Components/NcProgressBar.js'
+import { translate as t } from '@nextcloud/l10n'
 
 import {
 	checkOauthConnectionResult,
@@ -85,6 +86,7 @@ import {
 	WORKPACKAGES_SEARCH_ORIGIN,
 } from '../utils.js'
 import { showSuccess, showError } from '@nextcloud/dialogs'
+
 import { workpackageHelper } from '../utils/workpackageHelper.js'
 
 export default {
@@ -131,10 +133,12 @@ export default {
 			return this.chunkingInformation?.totalFilesNotLinked
 		},
 		getProgressValueOfMultipleFilesLinked() {
-			const progressPercentage = parseInt((this.chunkingInformation?.totalFilesAlreadyLinked / this.chunkingInformation?.totalNoOfFilesSelected) * 100)
+			const progressPercentage = parseInt((this.getTotalNoOfFilesAlreadyLinkedInChunking / this.getTotalNoOfFilesSelectedInChunking) * 100)
 			if (progressPercentage === 100) {
 				this.closeRequestModal()
-				showSuccess(t('integration_openproject', 'All selected files has been linked to WorkPackage Successfully!!'))
+				showSuccess(
+					t('integration_openproject', 'Links to work package created successfully for selected files!')
+				)
 			}
 			return progressPercentage
 		},
@@ -156,9 +160,9 @@ export default {
 			const selectedWorkPackage = this.chunkingInformation.selectedWorkPackage
 			const chunkedFilesInformations = workpackageHelper.chunkMultipleSelectedFilesInformation(remainingFilesToChunk)
 			await workpackageHelper.linkMultipleFilesToWorkPackageWithChunking(chunkedFilesInformations, selectedWorkPackage, true, this)
-			if (this.chunkingInformation?.totalFilesAlreadyLinked !== remainingFilesToChunk.length) {
+			if (this.getTotalNoOfFilesAlreadyLinkedInChunking !== remainingFilesToChunk.length) {
 				showError(
-					t('integration_openproject', 'Failed to link selected files to a work package')
+					t('integration_openproject', 'Failed to link selected files to work package')
 				)
 			}
 		},
@@ -214,7 +218,7 @@ export default {
 					this.state = STATE.FAILED_FETCHING_WORKPACKAGES
 				}
 			}
-		}
+		},
 	},
 }
 </script>
@@ -278,6 +282,9 @@ h2 {
 		text-align: center;
 		&--info {
 			padding: 13px;
+			&--error {
+				color: var(--color-error);
+			}
 		}
 	}
 }

--- a/tests/jest/components/tab/SearchInput.spec.js
+++ b/tests/jest/components/tab/SearchInput.spec.js
@@ -10,7 +10,6 @@ import workPackageSearchReqResponse from '../../fixtures/workPackageSearchReqRes
 import workPackageObjectsInSearchResults from '../../fixtures/workPackageObjectsInSearchResults.json'
 import { STATE, WORKPACKAGES_SEARCH_ORIGIN } from '../../../../src/utils.js'
 import * as initialState from '@nextcloud/initial-state'
-import { workpackageHelper } from '../../../../src/utils/workpackageHelper.js'
 
 jest.mock('@nextcloud/axios')
 jest.mock('@nextcloud/dialogs')
@@ -770,7 +769,7 @@ describe('SearchInput.vue', () => {
 									{ status: 200, data: [] })
 								)
 							await wrapper.setProps({
-								// here already linked package is empty when the file selected files is more than 1
+								// here already linked work package is empty when the selected files is more than 1
 								linkedWorkPackages: [],
 							})
 
@@ -823,9 +822,9 @@ describe('SearchInput.vue', () => {
 
 				describe('more than 20 with chunk', () => {
 					/*
-						For the test of linking multiple files more than 20
-						This test scenario create a file information of 55 which is used through the whole test for the link with chunking
-						It means the file will get hchunked as [20, 20, 25]
+						For the test of linking multiple files more than 20.
+						This test scenario creates a file information of 55 which is used through the whole test for the link with chunking.
+						It means the file will get chunked as [20, 20, 15].
 					 */
 					const multipleFilesForChunking = []
 					for (let i = 1; i <= 55; i++) {
@@ -834,19 +833,6 @@ describe('SearchInput.vue', () => {
 							name: `test${i}.txt`,
 						})
 					}
-
-					it('should chunk file information in 20', async () => {
-						wrapper = mountSearchInput()
-						const chunkedInformation = workpackageHelper.chunkMultipleSelectedFilesInformation(multipleFilesForChunking)
-						expect(chunkedInformation.length).toBe(3)
-						for (let i = 0; i < chunkedInformation.length; i++) {
-							if (i === chunkedInformation.length - 1) {
-								expect(chunkedInformation[i].length).toBe(15)
-							} else {
-								expect(chunkedInformation[i].length).toBe(20)
-							}
-						}
-					})
 
 					describe('select a work package for linking', () => {
 						let axiosGetSpy
@@ -887,7 +873,7 @@ describe('SearchInput.vue', () => {
 						})
 
 						it('should emit event "get-chunked-informations" for 3 times', async () => {
-							const postSpy = jest.spyOn(axios, 'post')
+							jest.spyOn(axios, 'post')
 								.mockImplementationOnce(() => Promise.resolve({
 									status: 200,
 								}))
@@ -897,11 +883,10 @@ describe('SearchInput.vue', () => {
 							for (let i = 0; i < 5; i++) {
 								await localVue.nextTick()
 							}
-							expect(postSpy).toHaveBeenCalledTimes(3)
 							expect(spyOnEmit).toHaveBeenCalledTimes(3)
 						})
 
-						it('should emit event "get-chunked-informations" with data', async () => {
+						it('should link all the files with chunks upon success', async () => {
 							let emittedData
 							jest.spyOn(axios, 'post')
 								.mockImplementationOnce(() => Promise.resolve({
@@ -916,6 +901,7 @@ describe('SearchInput.vue', () => {
 								await localVue.nextTick()
 							}
 							expect(spyOnEmit).toHaveBeenCalledTimes(3)
+							// here when the linking files with chunking is successful "totalFilesAlreadyLinked" and the total no of files selected must be equal
 							expect(emittedData.totalFilesAlreadyLinked).toBe(multipleFilesForChunking.length)
 						})
 
@@ -923,7 +909,7 @@ describe('SearchInput.vue', () => {
 							[
 								'should set chunk error true',
 								{
-									key: 'isChunkingError',
+									key: 'error',
 									value: true,
 								},
 							],
@@ -948,7 +934,7 @@ describe('SearchInput.vue', () => {
 							 	totalNoOfFilesSelected: number,
 							 	totalFilesAlreadyLinked: number,
 							 	totalFilesNotLinked: number,
-							 	isChunkingError: bool,
+							 	error: bool,
 							 	remainingFileInformations: Array,
 							 	selectedWorkPackage: Object
 							 }

--- a/tests/jest/components/tab/SearchInput.spec.js
+++ b/tests/jest/components/tab/SearchInput.spec.js
@@ -827,11 +827,11 @@ describe('SearchInput.vue', () => {
 						This test scenario create a file information of 55 which is used through the whole test for the link with chunking
 						It means the file will get hchunked as [20, 20, 25]
 					 */
-					let multipleFilesForChunking = []
-					for(let i = 1; i<=55; i++) {
+					const multipleFilesForChunking = []
+					for (let i = 1; i <= 55; i++) {
 						multipleFilesForChunking.push({
 							id: i,
-							name: `test${i}.txt`
+							name: `test${i}.txt`,
 						})
 					}
 
@@ -839,8 +839,8 @@ describe('SearchInput.vue', () => {
 						wrapper = mountSearchInput()
 						const chunkedInformation = workpackageHelper.chunkMultipleSelectedFilesInformation(multipleFilesForChunking)
 						expect(chunkedInformation.length).toBe(3)
-						for(let i = 0; i < chunkedInformation.length; i ++) {
-							if(i === chunkedInformation.length - 1) {
+						for (let i = 0; i < chunkedInformation.length; i++) {
+							if (i === chunkedInformation.length - 1) {
 								expect(chunkedInformation[i].length).toBe(15)
 							} else {
 								expect(chunkedInformation[i].length).toBe(20)
@@ -871,6 +871,7 @@ describe('SearchInput.vue', () => {
 						})
 						afterEach(() => {
 							axiosGetSpy.mockRestore()
+							axios.post.mockRestore()
 						})
 						it('should send request 3 times to link chunked file to workpackage', async () => {
 							const postSpy = jest.spyOn(axios, 'post')
@@ -879,7 +880,7 @@ describe('SearchInput.vue', () => {
 								}))
 							const ncSelectItem = wrapper.find(firstWorkPackageSelector)
 							await ncSelectItem.trigger('click')
-							for(let i = 0 ; i < 5; i++) {
+							for (let i = 0; i < 5; i++) {
 								await localVue.nextTick()
 							}
 							expect(postSpy).toHaveBeenCalledTimes(3)
@@ -890,10 +891,10 @@ describe('SearchInput.vue', () => {
 								.mockImplementationOnce(() => Promise.resolve({
 									status: 200,
 								}))
-							const spyOnEmit = jest.spyOn(wrapper.vm, '$emit');
+							const spyOnEmit = jest.spyOn(wrapper.vm, '$emit')
 							const ncSelectItem = wrapper.find(firstWorkPackageSelector)
 							await ncSelectItem.trigger('click')
-							for(let i = 0 ; i < 5; i++) {
+							for (let i = 0; i < 5; i++) {
 								await localVue.nextTick()
 							}
 							expect(postSpy).toHaveBeenCalledTimes(3)
@@ -901,17 +902,17 @@ describe('SearchInput.vue', () => {
 						})
 
 						it('should emit event "get-chunked-informations" with data', async () => {
-							let emittedData;
-							const postSpy = jest.spyOn(axios, 'post')
+							let emittedData
+							jest.spyOn(axios, 'post')
 								.mockImplementationOnce(() => Promise.resolve({
 									status: 200,
 								}))
 							const spyOnEmit = jest.spyOn(wrapper.vm, '$emit').mockImplementation((event, data) => {
-								emittedData = data;
-							});
+								emittedData = data
+							})
 							const ncSelectItem = wrapper.find(firstWorkPackageSelector)
 							await ncSelectItem.trigger('click')
-							for(let i = 0 ; i < 5; i++) {
+							for (let i = 0; i < 5; i++) {
 								await localVue.nextTick()
 							}
 							expect(spyOnEmit).toHaveBeenCalledTimes(3)
@@ -922,24 +923,24 @@ describe('SearchInput.vue', () => {
 							[
 								'should set chunk error true',
 								{
-									key: "isChunkingError",
+									key: 'isChunkingError',
 									value: true,
 								},
 							],
 							[
 								'should set alreadylinked files to 40',
 								{
-									key: "totalFilesAlreadyLinked",
+									key: 'totalFilesAlreadyLinked',
 									value: 40,
 								},
 							],
 							[
 								'should set files not linked to 2',
 								{
-									key: "totalFilesNotLinked",
+									key: 'totalFilesNotLinked',
 									value: 15,
 								},
-							]
+							],
 						])('%s when request fails', async (name, expectedData) => {
 							/*
 							Here the emmited chunking information data will be as
@@ -954,20 +955,22 @@ describe('SearchInput.vue', () => {
 							*/
 							let emittedData
 							// rejects the 3rd request
-							const postSpy = jest.spyOn(axios, 'post')
+							jest.spyOn(axios, 'post')
 								.mockImplementationOnce(() => Promise.resolve({
 									status: 200,
 								}))
 								.mockImplementationOnce(() => Promise.resolve({
 									status: 200,
 								}))
-								.mockImplementation(() => Promise.reject({}))
-							const spyOnEmit = jest.spyOn(wrapper.vm, '$emit').mockImplementation((event, data) => {
-								emittedData = data;
-							});
+								.mockImplementation(() => Promise.reject(
+									new Error('Throw eror')
+								))
+							jest.spyOn(wrapper.vm, '$emit').mockImplementation((event, data) => {
+								emittedData = data
+							})
 							const ncSelectItem = wrapper.find(firstWorkPackageSelector)
 							await ncSelectItem.trigger('click')
-							for(let i = 0 ; i < 5; i++) {
+							for (let i = 0; i < 5; i++) {
 								await localVue.nextTick()
 							}
 							const expectedKey = expectedData.key
@@ -975,22 +978,22 @@ describe('SearchInput.vue', () => {
 						})
 
 						it('should set length of remaining files to 15', async () => {
-							let emittedData;
+							let emittedData
 							// rejects the 3rd request
-							const postSpy = jest.spyOn(axios, 'post')
+							jest.spyOn(axios, 'post')
 								.mockImplementationOnce(() => Promise.resolve({
 									status: 200,
 								}))
 								.mockImplementationOnce(() => Promise.resolve({
 									status: 200,
 								}))
-								.mockImplementation(() => Promise.reject({}))
-							const spyOnEmit = jest.spyOn(wrapper.vm, '$emit').mockImplementation((event, data) => {
-								emittedData = data;
-							});
+								.mockImplementation(() => Promise.reject(new Error('Throw eror')))
+							jest.spyOn(wrapper.vm, '$emit').mockImplementation((event, data) => {
+								emittedData = data
+							})
 							const ncSelectItem = wrapper.find(firstWorkPackageSelector)
 							await ncSelectItem.trigger('click')
-							for(let i = 0 ; i < 5; i++) {
+							for (let i = 0; i < 5; i++) {
 								await localVue.nextTick()
 							}
 							expect(emittedData.remainingFileInformations.length).toBe(15)
@@ -999,14 +1002,14 @@ describe('SearchInput.vue', () => {
 						it('should retry once if a request to link fails', async () => {
 							const postSpy = jest.spyOn(axios, 'post')
 								.mockImplementationOnce(() => {
-									throw new Error('Throw error to retry once');
+									throw new Error('Throw error to retry once')
 								})
-								.mockImplementation(() => {
-									status: 200
-								});
+								.mockImplementation(() => Promise.resolve({
+									status: 200,
+								}))
 							const ncSelectItem = wrapper.find(firstWorkPackageSelector)
 							await ncSelectItem.trigger('click')
-							for(let i = 0 ; i < 5; i++) {
+							for (let i = 0; i < 5; i++) {
 								await localVue.nextTick()
 							}
 							// here 'makeRequestToLinkFilesToWorkPackage' is called 4 times since the chunk is [20,20,15] 3 times and 1 is added for retry since it fails for the first time
@@ -1015,10 +1018,10 @@ describe('SearchInput.vue', () => {
 
 						it('should not retry again if the retry it self fails', async () => {
 							const postSpy = jest.spyOn(axios, 'post')
-								.mockImplementation(() => Promise.reject())
+								.mockImplementation(() => Promise.reject(new Error('Throw eror')))
 							const ncSelectItem = wrapper.find(firstWorkPackageSelector)
 							await ncSelectItem.trigger('click')
-							for(let i = 0 ; i < 5; i++) {
+							for (let i = 0; i < 5; i++) {
 								await localVue.nextTick()
 							}
 							// here the post is called 2 times (1 extra for retry)

--- a/tests/jest/components/tab/SearchInput.spec.js
+++ b/tests/jest/components/tab/SearchInput.spec.js
@@ -10,6 +10,7 @@ import workPackageSearchReqResponse from '../../fixtures/workPackageSearchReqRes
 import workPackageObjectsInSearchResults from '../../fixtures/workPackageObjectsInSearchResults.json'
 import { STATE, WORKPACKAGES_SEARCH_ORIGIN } from '../../../../src/utils.js'
 import * as initialState from '@nextcloud/initial-state'
+import { workpackageHelper } from '../../../../src/utils/workpackageHelper.js'
 
 jest.mock('@nextcloud/axios')
 jest.mock('@nextcloud/dialogs')
@@ -701,120 +702,328 @@ describe('SearchInput.vue', () => {
 			})
 
 			describe('multiple files selected', () => {
-				describe('select a work package for linking', () => {
-					let axiosGetSpy
-					beforeEach(async () => {
-						axiosGetSpy = jest.spyOn(axios, 'get')
-							.mockImplementationOnce(() => Promise.resolve({
-								status: 200,
-								data: [],
-							}))
-						wrapper = mountSearchInput(multipleFileInfos)
-						await wrapper.setProps({
-							searchOrigin: WORKPACKAGES_SEARCH_ORIGIN.LINK_MULTIPLE_FILES_MODAL,
+				describe('less than 20', () => {
+					describe('select a work package for linking', () => {
+						let axiosGetSpy
+						beforeEach(async () => {
+							axiosGetSpy = jest.spyOn(axios, 'get')
+								.mockImplementationOnce(() => Promise.resolve({
+									status: 200,
+									data: [],
+								}))
+							wrapper = mountSearchInput(multipleFileInfos)
+							await wrapper.setProps({
+								searchOrigin: WORKPACKAGES_SEARCH_ORIGIN.LINK_MULTIPLE_FILES_MODAL,
+							})
+							const inputField = wrapper.find(inputSelector)
+							await inputField.setValue('orga')
+							await wrapper.setData({
+								searchResults: [{
+									fileId: 123,
+									id: 999,
+								}],
+							})
 						})
-						const inputField = wrapper.find(inputSelector)
-						await inputField.setValue('orga')
-						await wrapper.setData({
-							searchResults: [{
-								fileId: 123,
-								id: 999,
-							}],
+						afterEach(() => {
+							axiosGetSpy.mockRestore()
 						})
-					})
-					afterEach(() => {
-						axiosGetSpy.mockRestore()
-					})
-					it('should send a request to link file to workpackage', async () => {
-						const postSpy = jest.spyOn(axios, 'post')
-							.mockImplementationOnce(() => Promise.resolve({
-								status: 200,
-							}))
-						const ncSelectItem = wrapper.find(firstWorkPackageSelector)
-						await ncSelectItem.trigger('click')
-						const body = {
-							values: {
-								workpackageId: 999,
-								fileinfo: multipleFileInfos,
-							},
-						}
-						expect(postSpy).toBeCalledWith(
-							'http://localhost/apps/integration_openproject/work-packages',
-							body,
-							{ headers: { 'Content-Type': 'application/json' } }
-						)
-						postSpy.mockRestore()
-					})
-
-					it('should show an error when linking fails', async () => {
-						const err = new Error()
-						err.response = { status: 422 }
-						axios.post.mockRejectedValueOnce(err)
-						const showErrorSpy = jest.spyOn(dialogs, 'showError')
-						const ncSelectItem = wrapper.find(firstWorkPackageSelector)
-						await ncSelectItem.trigger('click')
-						await localVue.nextTick()
-						expect(showErrorSpy).toBeCalledTimes(1)
-						showErrorSpy.mockRestore()
-					})
-
-					it('should display work packages that are already linked', async () => {
-						const axiosSpy = jest.spyOn(axios, 'get')
-							.mockImplementationOnce(() => Promise.resolve({
-								status: 200,
-								data: workPackageSearchReqResponse,
-							}))
-							.mockImplementation(() => Promise.resolve(
-								{ status: 200, data: [] })
+						it('should send a request to link file to workpackage', async () => {
+							const postSpy = jest.spyOn(axios, 'post')
+								.mockImplementationOnce(() => Promise.resolve({
+									status: 200,
+								}))
+							const ncSelectItem = wrapper.find(firstWorkPackageSelector)
+							await ncSelectItem.trigger('click')
+							const body = {
+								values: {
+									workpackageId: 999,
+									fileinfo: multipleFileInfos,
+								},
+							}
+							expect(postSpy).toBeCalledWith(
+								'http://localhost/apps/integration_openproject/work-packages',
+								body,
+								{ headers: { 'Content-Type': 'application/json' } }
 							)
-						await wrapper.setProps({
-							// here already linked package is empty when the file selected files is more than 1
-							linkedWorkPackages: [],
+							postSpy.mockRestore()
 						})
 
-						const inputField = wrapper.find(inputSelector)
-						await inputField.setValue('anything longer than 3 char')
-						for (let i = 0; i < 8; i++) {
+						it('should show an error when linking fails', async () => {
+							const err = new Error()
+							err.response = { status: 422 }
+							axios.post.mockRejectedValueOnce(err)
+							const showErrorSpy = jest.spyOn(dialogs, 'showError')
+							const ncSelectItem = wrapper.find(firstWorkPackageSelector)
+							await ncSelectItem.trigger('click')
 							await localVue.nextTick()
+							expect(showErrorSpy).toBeCalledTimes(1)
+							showErrorSpy.mockRestore()
+						})
+
+						it('should display work packages that are already linked', async () => {
+							const axiosSpy = jest.spyOn(axios, 'get')
+								.mockImplementationOnce(() => Promise.resolve({
+									status: 200,
+									data: workPackageSearchReqResponse,
+								}))
+								.mockImplementation(() => Promise.resolve(
+									{ status: 200, data: [] })
+								)
+							await wrapper.setProps({
+								// here already linked package is empty when the file selected files is more than 1
+								linkedWorkPackages: [],
+							})
+
+							const inputField = wrapper.find(inputSelector)
+							await inputField.setValue('anything longer than 3 char')
+							for (let i = 0; i < 8; i++) {
+								await localVue.nextTick()
+							}
+							expect(wrapper.vm.searchResults).toMatchObject(
+								[
+									{
+										assignee: 'System',
+										id: 2,
+										picture: 'http://localhost/apps/integration_openproject/avatar?userId=1&userName=System',
+										project: 'Demo project',
+										statusCol: '',
+										statusTitle: 'In progress',
+										subject: 'Organize open source conference',
+										typeCol: '',
+										typeTitle: 'Phase',
+									},
+									{
+										assignee: 'System',
+										id: 13,
+										picture: 'http://localhost/apps/integration_openproject/avatar?userId=1&userName=System',
+										project: 'Demo project',
+										statusCol: '',
+										statusTitle: 'In progress',
+										subject: 'Write a software',
+										typeCol: '',
+										typeTitle: 'Phase',
+									},
+									{
+										assignee: 'System',
+										id: 5,
+										picture: 'http://localhost/apps/integration_openproject/avatar?userId=1&userName=System',
+										project: 'Demo project',
+										statusCol: '',
+										statusTitle: 'In progress',
+										subject: 'Create a website',
+										typeCol: '',
+										typeTitle: 'Phase',
+									},
+								],
+							)
+							axiosSpy.mockRestore()
+						})
+					})
+				})
+
+				describe('more than 20 with chunk', () => {
+					/*
+						For the test of linking multiple files more than 20
+						This test scenario create a file information of 55 which is used through the whole test for the link with chunking
+						It means the file will get hchunked as [20, 20, 25]
+					 */
+					let multipleFilesForChunking = []
+					for(let i = 1; i<=55; i++) {
+						multipleFilesForChunking.push({
+							id: i,
+							name: `test${i}.txt`
+						})
+					}
+
+					it('should chunk file information in 20', async () => {
+						wrapper = mountSearchInput()
+						const chunkedInformation = workpackageHelper.chunkMultipleSelectedFilesInformation(multipleFilesForChunking)
+						expect(chunkedInformation.length).toBe(3)
+						for(let i = 0; i < chunkedInformation.length; i ++) {
+							if(i === chunkedInformation.length - 1) {
+								expect(chunkedInformation[i].length).toBe(15)
+							} else {
+								expect(chunkedInformation[i].length).toBe(20)
+							}
 						}
-						expect(wrapper.vm.searchResults).toMatchObject(
+					})
+
+					describe('select a work package for linking', () => {
+						let axiosGetSpy
+						beforeEach(async () => {
+							axiosGetSpy = jest.spyOn(axios, 'get')
+								.mockImplementationOnce(() => Promise.resolve({
+									status: 200,
+									data: [],
+								}))
+							wrapper = mountSearchInput(multipleFilesForChunking)
+							await wrapper.setProps({
+								searchOrigin: WORKPACKAGES_SEARCH_ORIGIN.LINK_MULTIPLE_FILES_MODAL,
+							})
+							const inputField = wrapper.find(inputSelector)
+							await inputField.setValue('orga')
+							await wrapper.setData({
+								searchResults: [{
+									fileId: 123,
+									id: 999,
+								}],
+							})
+						})
+						afterEach(() => {
+							axiosGetSpy.mockRestore()
+						})
+						it('should send request 3 times to link chunked file to workpackage', async () => {
+							const postSpy = jest.spyOn(axios, 'post')
+								.mockImplementationOnce(() => Promise.resolve({
+									status: 200,
+								}))
+							const ncSelectItem = wrapper.find(firstWorkPackageSelector)
+							await ncSelectItem.trigger('click')
+							for(let i = 0 ; i < 5; i++) {
+								await localVue.nextTick()
+							}
+							expect(postSpy).toHaveBeenCalledTimes(3)
+						})
+
+						it('should emit event "get-chunked-informations" for 3 times', async () => {
+							const postSpy = jest.spyOn(axios, 'post')
+								.mockImplementationOnce(() => Promise.resolve({
+									status: 200,
+								}))
+							const spyOnEmit = jest.spyOn(wrapper.vm, '$emit');
+							const ncSelectItem = wrapper.find(firstWorkPackageSelector)
+							await ncSelectItem.trigger('click')
+							for(let i = 0 ; i < 5; i++) {
+								await localVue.nextTick()
+							}
+							expect(postSpy).toHaveBeenCalledTimes(3)
+							expect(spyOnEmit).toHaveBeenCalledTimes(3)
+						})
+
+						it('should emit event "get-chunked-informations" with data', async () => {
+							let emittedData;
+							const postSpy = jest.spyOn(axios, 'post')
+								.mockImplementationOnce(() => Promise.resolve({
+									status: 200,
+								}))
+							const spyOnEmit = jest.spyOn(wrapper.vm, '$emit').mockImplementation((event, data) => {
+								emittedData = data;
+							});
+							const ncSelectItem = wrapper.find(firstWorkPackageSelector)
+							await ncSelectItem.trigger('click')
+							for(let i = 0 ; i < 5; i++) {
+								await localVue.nextTick()
+							}
+							expect(spyOnEmit).toHaveBeenCalledTimes(3)
+							expect(emittedData.totalFilesAlreadyLinked).toBe(multipleFilesForChunking.length)
+						})
+
+						it.each([
 							[
+								'should set chunk error true',
 								{
-									assignee: 'System',
-									id: 2,
-									picture: 'http://localhost/apps/integration_openproject/avatar?userId=1&userName=System',
-									project: 'Demo project',
-									statusCol: '',
-									statusTitle: 'In progress',
-									subject: 'Organize open source conference',
-									typeCol: '',
-									typeTitle: 'Phase',
-								},
-								{
-									assignee: 'System',
-									id: 13,
-									picture: 'http://localhost/apps/integration_openproject/avatar?userId=1&userName=System',
-									project: 'Demo project',
-									statusCol: '',
-									statusTitle: 'In progress',
-									subject: 'Write a software',
-									typeCol: '',
-									typeTitle: 'Phase',
-								},
-								{
-									assignee: 'System',
-									id: 5,
-									picture: 'http://localhost/apps/integration_openproject/avatar?userId=1&userName=System',
-									project: 'Demo project',
-									statusCol: '',
-									statusTitle: 'In progress',
-									subject: 'Create a website',
-									typeCol: '',
-									typeTitle: 'Phase',
+									key: "isChunkingError",
+									value: true,
 								},
 							],
-						)
-						axiosSpy.mockRestore()
+							[
+								'should set alreadylinked files to 40',
+								{
+									key: "totalFilesAlreadyLinked",
+									value: 40,
+								},
+							],
+							[
+								'should set files not linked to 2',
+								{
+									key: "totalFilesNotLinked",
+									value: 15,
+								},
+							]
+						])('%s when request fails', async (name, expectedData) => {
+							/*
+							Here the emmited chunking information data will be as
+							emittedData = {
+							 	totalNoOfFilesSelected: number,
+							 	totalFilesAlreadyLinked: number,
+							 	totalFilesNotLinked: number,
+							 	isChunkingError: bool,
+							 	remainingFileInformations: Array,
+							 	selectedWorkPackage: Object
+							 }
+							*/
+							let emittedData
+							// rejects the 3rd request
+							const postSpy = jest.spyOn(axios, 'post')
+								.mockImplementationOnce(() => Promise.resolve({
+									status: 200,
+								}))
+								.mockImplementationOnce(() => Promise.resolve({
+									status: 200,
+								}))
+								.mockImplementation(() => Promise.reject({}))
+							const spyOnEmit = jest.spyOn(wrapper.vm, '$emit').mockImplementation((event, data) => {
+								emittedData = data;
+							});
+							const ncSelectItem = wrapper.find(firstWorkPackageSelector)
+							await ncSelectItem.trigger('click')
+							for(let i = 0 ; i < 5; i++) {
+								await localVue.nextTick()
+							}
+							const expectedKey = expectedData.key
+							expect(emittedData[expectedKey]).toBe(expectedData.value)
+						})
+
+						it('should set length of remaining files to 15', async () => {
+							let emittedData;
+							// rejects the 3rd request
+							const postSpy = jest.spyOn(axios, 'post')
+								.mockImplementationOnce(() => Promise.resolve({
+									status: 200,
+								}))
+								.mockImplementationOnce(() => Promise.resolve({
+									status: 200,
+								}))
+								.mockImplementation(() => Promise.reject({}))
+							const spyOnEmit = jest.spyOn(wrapper.vm, '$emit').mockImplementation((event, data) => {
+								emittedData = data;
+							});
+							const ncSelectItem = wrapper.find(firstWorkPackageSelector)
+							await ncSelectItem.trigger('click')
+							for(let i = 0 ; i < 5; i++) {
+								await localVue.nextTick()
+							}
+							expect(emittedData.remainingFileInformations.length).toBe(15)
+						})
+
+						it('should retry once if a request to link fails', async () => {
+							const postSpy = jest.spyOn(axios, 'post')
+								.mockImplementationOnce(() => {
+									throw new Error('Throw error to retry once');
+								})
+								.mockImplementation(() => {
+									status: 200
+								});
+							const ncSelectItem = wrapper.find(firstWorkPackageSelector)
+							await ncSelectItem.trigger('click')
+							for(let i = 0 ; i < 5; i++) {
+								await localVue.nextTick()
+							}
+							// here 'makeRequestToLinkFilesToWorkPackage' is called 4 times since the chunk is [20,20,15] 3 times and 1 is added for retry since it fails for the first time
+							expect(postSpy).toHaveBeenCalledTimes(4)
+						})
+
+						it('should not retry again if the retry it self fails', async () => {
+							const postSpy = jest.spyOn(axios, 'post')
+								.mockImplementation(() => Promise.reject())
+							const ncSelectItem = wrapper.find(firstWorkPackageSelector)
+							await ncSelectItem.trigger('click')
+							for(let i = 0 ; i < 5; i++) {
+								await localVue.nextTick()
+							}
+							// here the post is called 2 times (1 extra for retry)
+							expect(postSpy).toHaveBeenCalledTimes(2)
+						})
 					})
 				})
 			})

--- a/tests/jest/views/LinkMultipleFilesModal.spec.js
+++ b/tests/jest/views/LinkMultipleFilesModal.spec.js
@@ -482,7 +482,7 @@ describe('LinkMultipleFilesModal.vue', () => {
 				})
 
 				it('should show error dialog on failure', async () => {
-					const postSpy = jest.spyOn(axios, 'post')
+					jest.spyOn(axios, 'post')
 						.mockImplementation(() => Promise.reject(new Error('Throw eror')))
 					dialogs.showError
 						.mockImplementationOnce()

--- a/tests/jest/views/LinkMultipleFilesModal.spec.js
+++ b/tests/jest/views/LinkMultipleFilesModal.spec.js
@@ -423,7 +423,7 @@ describe('LinkMultipleFilesModal.vue', () => {
 				totalNoOfFilesSelected: 100,
 				totalFilesAlreadyLinked: 65,
 				totalFilesNotLinked: 35,
-				isChunkingError: true,
+				error: true,
 				remainingFileInformations,
 				selectedWorkPackage: { fileId: 123, id: 999 },
 			}
@@ -466,7 +466,7 @@ describe('LinkMultipleFilesModal.vue', () => {
 					await wrapper.setData({
 						chunkingInformation: {
 							totalNoOfFilesSelected: 100,
-							isChunkingError: true,
+							error: true,
 							totalFilesAlreadyLinked: 65,
 							totalFilesNotLinked: 35,
 							remainingFileInformations,
@@ -483,14 +483,14 @@ describe('LinkMultipleFilesModal.vue', () => {
 
 				it('should show error dialog on failure', async () => {
 					jest.spyOn(axios, 'post')
-						.mockImplementation(() => Promise.reject(new Error('Throw eror')))
+						.mockImplementation(() => Promise.reject(new Error('Throw error')))
 					dialogs.showError
 						.mockImplementationOnce()
 					const wrapper = mountWrapper()
 					await wrapper.setData({
 						chunkingInformation: {
 							totalNoOfFilesSelected: 100,
-							isChunkingError: true,
+							error: true,
 							totalFilesAlreadyLinked: 65,
 							totalFilesNotLinked: 35,
 							remainingFileInformations,
@@ -513,14 +513,18 @@ describe('LinkMultipleFilesModal.vue', () => {
 				expect(wrapper.find(ncModalStubSelector).exists()).toBeFalsy()
 			})
 
-			it('should make chunkng information empty', async () => {
-				await wrapper.vm.closeRequestModal()
-				expect(wrapper.vm.chunkingInformation).toBe(null)
-			})
-
-			it('should make chunkng information empty when not empty', async () => {
+			it.each([
+				[
+					'should clean chunkng information',
+					null,
+				],
+				[
+					'should clean chunkng information when not empty',
+					{},
+				],
+			])('%s', async (name, chunkingInformation) => {
 				await wrapper.setData({
-					chunkingInformation: {},
+					chunkingInformation,
 				})
 				await wrapper.vm.closeRequestModal()
 				expect(wrapper.vm.chunkingInformation).toBe(null)

--- a/tests/jest/views/LinkMultipleFilesModal.spec.js
+++ b/tests/jest/views/LinkMultipleFilesModal.spec.js
@@ -405,10 +405,23 @@ describe('LinkMultipleFilesModal.vue', () => {
 			})
 		})
 
-		describe('onSave', () => {
+		describe('close', () => {
 			it('should closed the modal', async () => {
-				await wrapper.vm.onSaved()
+				await wrapper.vm.closeRequestModal()
 				expect(wrapper.find(ncModalStubSelector).exists()).toBeFalsy()
+			})
+
+			it('should make chunkng information empty', async () => {
+				await wrapper.vm.closeRequestModal()
+				expect(wrapper.vm.chunkingInformation).toBe(null)
+			})
+
+			it('should make chunkng information empty when not empty', async () => {
+				await wrapper.setData({
+					chunkingInformation: {},
+				})
+				await wrapper.vm.closeRequestModal()
+				expect(wrapper.vm.chunkingInformation).toBe(null)
 			})
 
 			it('should empty "alreadyLinkedWorkPackage", "fileInfos" and close modal', async () => {
@@ -428,7 +441,7 @@ describe('LinkMultipleFilesModal.vue', () => {
 						picture: '/server/index.php/apps/integration_openproject/avatar?userId=1&userName=System',
 					}],
 				})
-				await wrapper.vm.onSaved()
+				await wrapper.vm.closeRequestModal()
 				expect(wrapper.find(ncModalStubSelector).exists()).toBeFalsy()
 			})
 		})


### PR DESCRIPTION
### Description
The `OpenProject` server only supports the multiple selected up to only `20` files at once to link to a workpackage. So this PR makes changes in the request to make it support to link the multiple selected files more than `20` in chunks to link to a single workpackage.

### Part of:
https://community.openproject.org/projects/nextcloud-integration/work_packages/40971/activity