### PR TITLE
[WP#50137]Remove check for class exists for `groupfolders`

### DIFF
--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -1090,7 +1090,6 @@ class OpenProjectAPIService {
 	public function isGroupfoldersAppEnabled(): bool {
 		$user = $this->userManager->get(Application::OPEN_PROJECT_ENTITIES_NAME);
 		return (
-			class_exists('\OCA\GroupFolders\Folder\FolderManager') &&
 			$this->appManager->isEnabledForUser(
 			'groupfolders',
 			$user


### PR DESCRIPTION
### Description
The check for class `class_exists('\OCA\GroupFolders\Folder\FolderManager')` in function `isGroupfoldersAppEnabled` seems to be useless since it is `true` when app is enabled/installed and `false` when app is disabled/removed. So Error may arise when making an extra check by it since all the thing can be checked by `isEnabledForUser` this function check enabled/installed or disable for the `groupfolder` app

### Related WP
https://community.openproject.org/projects/nextcloud-integration/work_packages/50137/activity?query_id=4615