### PR TITLE
fix: Use DI for getting 3rdparty app classes

### DIFF
--- a/lib/Controller/FilesController.php
+++ b/lib/Controller/FilesController.php
@@ -23,9 +23,7 @@ use OCP\Files\Config\ICachedMountFileInfo;
 use OCP\Files\Config\IMountProviderCollection;
 use OCP\Files\FileInfo;
 use OCP\Files\IRootFolder;
-use OCP\IConfig;
 use OCP\IDBConnection;
-use OCP\IL10N;
 use OCP\ILogger;
 use OCP\IRequest;
 use OCP\AppFramework\OCSController;
@@ -34,7 +32,7 @@ use OCP\AppFramework\Http\DataResponse;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IUserSession;
-use OCP\RichObjectStrings\IValidator;
+use OCP\Server;
 use Throwable;
 use OCP\Files\DavUtil;
 
@@ -61,24 +59,9 @@ class FilesController extends OCSController {
 	protected $connection;
 
 	/**
-	 * @var IValidator
-	 */
-	private $richObjectValidator;
-
-	/**
 	 * @var ILogger
 	 */
 	private $logger;
-
-	/**
-	 * @var IL10N
-	 */
-	private $l;
-
-	/**
-	 * @var IConfig
-	 */
-	private $config;
 
 	/**
 	 * @var IUserManager
@@ -105,10 +88,7 @@ class FilesController extends OCSController {
 								IManager $activityManager,
 								IAppManager $appManager,
 								IDBConnection $connection,
-								IValidator $richObjectValidator,
 								ILogger $logger,
-								IL10N $l,
-								IConfig $config,
 								IUserManager $userManager,
 								DavUtil $davUtils
 	) {
@@ -118,10 +98,7 @@ class FilesController extends OCSController {
 		$this->mountCollection = $mountCollection;
 		$this->activityManager = $activityManager;
 		$this->connection = $connection;
-		$this->richObjectValidator = $richObjectValidator;
 		$this->logger = $logger;
-		$this->l = $l;
-		$this->config = $config;
 		$this->userManager = $userManager;
 		$this->appManager = $appManager;
 		$this->davUtils = $davUtils;
@@ -281,20 +258,15 @@ class FilesController extends OCSController {
 			class_exists('\OCA\Activity\GroupHelperDisabled') &&
 			class_exists('\OCA\Activity\UserSettings')
 		) {
-			$activityData = new Data($this->activityManager, $this->connection);
+			$activityData = Server::get(Data::class);
 		} else {
 			return null;
 		}
 
 		// @phpstan-ignore-next-line - make phpstan not complain if activity app does not exist
-		$groupHelper = new GroupHelperDisabled(
-			$this->l,
-			$this->activityManager,
-			$this->richObjectValidator,
-			$this->logger
-		);
+		$groupHelper = Server::get(GroupHelperDisabled::class);
 		// @phpstan-ignore-next-line - make phpstan not complain if activity app does not exist
-		$userSettings = new UserSettings($this->activityManager, $this->config);
+		$userSettings = Server::get(UserSettings::class);
 		if (!method_exists($activityData, 'get') ||
 			!method_exists($activityData, 'getById')
 		) {

--- a/tests/lib/Controller/FilesControllerTest.php
+++ b/tests/lib/Controller/FilesControllerTest.php
@@ -7,13 +7,10 @@ use OCP\Activity\IManager;
 use OCP\Files\Config\ICachedMountFileInfo;
 use OCP\Files\DavUtil;
 use OCP\Files\Node;
-use OCP\IConfig;
 use OCP\IDBConnection;
-use OCP\IL10N;
 use OCP\ILogger;
 use OCP\IRequest;
 use OCP\IUserManager;
-use OCP\RichObjectStrings\IValidator;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use function PHPUnit\Framework\assertSame;
@@ -1012,10 +1009,7 @@ class FilesControllerTest extends TestCase {
 			$this->createMock(IManager::class),
 			$appManagerMock,
 			$this->createMock(IDBConnection::class),
-			$this->createMock(IValidator::class),
 			$this->createMock(ILogger::class),
-			$this->createMock(IL10N::class),
-			$this->createMock(IConfig::class),
 			$this->createMock(IUserManager::class),
 			$this->createMock(DavUtil::class)
 		);
@@ -1078,10 +1072,7 @@ class FilesControllerTest extends TestCase {
 				$this->createMock(IManager::class),
 				$appManagerMock,
 				$this->createMock(IDBConnection::class),
-				$this->createMock(IValidator::class),
 				$this->createMock(ILogger::class),
-				$this->createMock(IL10N::class),
-				$this->createMock(IConfig::class),
 				$this->createMock(IUserManager::class),
 				$davUtilsMock
 			])


### PR DESCRIPTION
Fix incompatible constructor arguments for the activity classes by using the dependency injection container get method to automatically construct it.

Relevant upstream change https://github.com/nextcloud/activity/pull/1309 but the adjustment here makes it less error prone for further changes.

# Related WorkPackage:
This PR fixes: https://community.openproject.org/projects/nextcloud-integration/work_packages/50507/activity