### PR TITLE
disable psalm for nextcloud master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,10 +73,8 @@ jobs:
 
       - name: PHP code analysis
         run: |
-          if [[ ${{ matrix.nextcloudVersion }} == "master" ]]
+          if [[ ${{ matrix.nextcloudVersion }} != "master" ]]
           then
-            make psalm
-          else
             make phpstan
           fi
 


### PR DESCRIPTION
We have a pslam error in nextcloud master, on running locally the error is something like 
```console
PHP Fatal error:  Declaration of Doctrine\Common\Cache\Psr6\CacheItem::get() must be compatible with Psr\Cache\CacheItemInterface::get(): mixed in nextcloud/master/3rdparty/doctrine/cache/lib/Doctrine/Common/Cache/Psr6/CacheItem.php on line 51
```

The psalm for some reason is looking into the 3rdparty app and I couldn't find the way to suppress , I'll make a PR to 3rdparty to fix the errors if possible but till then maybe it's better to not run psalm in nextcloud master