### PR TITLE
[#50431] Project folders setup: add special characters to generated passwords

### DIFF
--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -1108,7 +1108,7 @@ class OpenProjectAPIService {
 	public function generateAppPasswordTokenForUser(): string {
 		$user = $this->userManager->get(Application::OPEN_PROJECT_ENTITIES_NAME);
 		$userID = $user->getUID();
-		$token = $this->random->generate(72, ISecureRandom::CHAR_UPPER.ISecureRandom::CHAR_LOWER.ISecureRandom::CHAR_DIGITS);
+		$token = $this->random->generate(72, ISecureRandom::CHAR_UPPER.ISecureRandom::CHAR_LOWER.ISecureRandom::CHAR_DIGITS.ISecureRandom::CHAR_SYMBOLS);
 		$generatedToken = $this->tokenProvider->generateToken(
 			$token,
 			$userID,


### PR DESCRIPTION
Fixes: https://community.openproject.org/work_packages/50431
As the password that we generated for project folders didn't contain the special characters in case the nextcloud instance has a password policy setup enforcing special characters, an error is shown while setting up the project folders. This PR adds special characters in the password to prevent that from happening