### PR TITLE
[WP#50326]Added trailing slash for folder for files info endpoint

### DIFF
--- a/lib/Controller/FilesController.php
+++ b/lib/Controller/FilesController.php
@@ -212,16 +212,18 @@ class FilesController extends OCSController {
 				$modifierId = null;
 				$modifierName = null;
 			}
-			if ($file->getMimeType() === FileInfo::MIMETYPE_FOLDER) {
-				$mimeType = 'application/x-op-directory';
-			} else {
-				$mimeType = $file->getMimeType();
-			}
 			$fullpath = $file->getpath();
 			// full path is in format `<user-name>/files/a/b/`
 			// since we don't want to send it with username, only get the `files/a/b` and send it
 			$path = explode('/', $fullpath, 3);
 			$davPermission = $this->getDavPermissions($file);
+			if ($file->getMimeType() === FileInfo::MIMETYPE_FOLDER) {
+				$mimeType = 'application/x-op-directory';
+				$path = $path[2] . '/';
+			} else {
+				$mimeType = $file->getMimeType();
+				$path = $path[2];
+			}
 			return [
 				'status' => 'OK',
 				'statuscode' => 200,
@@ -237,7 +239,7 @@ class FilesController extends OCSController {
 				'modifier_name' => $modifierName,
 				'modifier_id' => $modifierId,
 				'dav_permissions' => $davPermission,
-				'path' => $path[2]
+				'path' => $path
 			];
 		}
 

--- a/tests/acceptance/features/api/getFileinfoByFileIDAPI.feature
+++ b/tests/acceptance/features/api/getFileinfoByFileIDAPI.feature
@@ -699,7 +699,7 @@ Feature: retrieve file information of a single file, using the file ID
       "required": [
       "status",
       "statuscode",
-      "size",
+      "size"
       "name",
       "mtime",
       "ctime",
@@ -900,7 +900,7 @@ Feature: retrieve file information of a single file, using the file ID
       "modifier_name": {"type": "null"},
       "trashed": {"type": "boolean", "enum": [false]},
       "dav_permissions": {"type": "string", "pattern":"^RGDNVCK$"},
-      "path": {"type": "string", "pattern":"^files\/folder$"}
+      "path": {"type": "string", "pattern":"^files\/folder/$"}
       }
       }
       """
@@ -1173,7 +1173,7 @@ Feature: retrieve file information of a single file, using the file ID
       "modifier_id": {"type": "null"},
       "modifier_name": {"type": "null"},
       "dav_permissions": {"type": "string", "pattern":"^<requester-dav-permissions>$"},
-      "path": {"type": "string", "pattern":"^files\/folder$"}
+      "path": {"type": "string", "pattern":"^files\/folder/$"}
       }
       }
       """
@@ -1205,7 +1205,7 @@ Feature: retrieve file information of a single file, using the file ID
       "modifier_id": {"type": "null"},
       "modifier_name": {"type": "null"},
       "dav_permissions": {"type": "string", "pattern":"^<owner-dav-permissions>$"},
-      "path": {"type": "string", "pattern":"^files\/folder$"}
+      "path": {"type": "string", "pattern":"^files\/folder/$"}
       }
       }
       """
@@ -1260,7 +1260,7 @@ Feature: retrieve file information of a single file, using the file ID
       "modifier_id": {"type": "null"},
       "modifier_name": {"type": "null"},
       "dav_permissions": {"type": "string", "pattern":"^RMGDNVCK$"},
-      "path": {"type": "string", "pattern":"^files/groupFolder$"}
+      "path": {"type": "string", "pattern":"^files/groupFolder/$"}
       }
       }
       """

--- a/tests/acceptance/features/api/getFileinfoByFileIDAPI.feature
+++ b/tests/acceptance/features/api/getFileinfoByFileIDAPI.feature
@@ -699,7 +699,7 @@ Feature: retrieve file information of a single file, using the file ID
       "required": [
       "status",
       "statuscode",
-      "size"
+      "size",
       "name",
       "mtime",
       "ctime",
@@ -900,7 +900,7 @@ Feature: retrieve file information of a single file, using the file ID
       "modifier_name": {"type": "null"},
       "trashed": {"type": "boolean", "enum": [false]},
       "dav_permissions": {"type": "string", "pattern":"^RGDNVCK$"},
-      "path": {"type": "string", "pattern":"^files\/folder/$"}
+      "path": {"type": "string", "pattern":"^files\/folder\/$"}
       }
       }
       """
@@ -1173,7 +1173,7 @@ Feature: retrieve file information of a single file, using the file ID
       "modifier_id": {"type": "null"},
       "modifier_name": {"type": "null"},
       "dav_permissions": {"type": "string", "pattern":"^<requester-dav-permissions>$"},
-      "path": {"type": "string", "pattern":"^files\/folder/$"}
+      "path": {"type": "string", "pattern":"^files\/folder\/$"}
       }
       }
       """
@@ -1205,7 +1205,7 @@ Feature: retrieve file information of a single file, using the file ID
       "modifier_id": {"type": "null"},
       "modifier_name": {"type": "null"},
       "dav_permissions": {"type": "string", "pattern":"^<owner-dav-permissions>$"},
-      "path": {"type": "string", "pattern":"^files\/folder/$"}
+      "path": {"type": "string", "pattern":"^files\/folder\/$"}
       }
       }
       """
@@ -1260,7 +1260,7 @@ Feature: retrieve file information of a single file, using the file ID
       "modifier_id": {"type": "null"},
       "modifier_name": {"type": "null"},
       "dav_permissions": {"type": "string", "pattern":"^RMGDNVCK$"},
-      "path": {"type": "string", "pattern":"^files/groupFolder/$"}
+      "path": {"type": "string", "pattern":"^files\/groupFolder\/$"}
       }
       }
       """

--- a/tests/acceptance/features/api/getFilesinfoByFileIDsAPI.feature
+++ b/tests/acceptance/features/api/getFilesinfoByFileIDsAPI.feature
@@ -233,7 +233,7 @@ Feature: retrieve information of multiple files using the file IDs
               "modifier_name": {"type": "null"},
               "trashed": {"type": "boolean", "enum": [false]},
               "dav_permissions": {"type": "string", "pattern":"^RMGDNVCK"},
-              "path": {"type": "string", "pattern":"^files/groupFolder$"}
+              "path": {"type": "string", "pattern":"^files/groupFolder/$"}
             }
           }
       }

--- a/tests/acceptance/features/api/getFilesinfoByFileIDsAPI.feature
+++ b/tests/acceptance/features/api/getFilesinfoByFileIDsAPI.feature
@@ -233,7 +233,7 @@ Feature: retrieve information of multiple files using the file IDs
               "modifier_name": {"type": "null"},
               "trashed": {"type": "boolean", "enum": [false]},
               "dav_permissions": {"type": "string", "pattern":"^RMGDNVCK"},
-              "path": {"type": "string", "pattern":"^files/groupFolder/$"}
+              "path": {"type": "string", "pattern":"^files/groupFolder\/$"}
             }
           }
       }

--- a/tests/lib/Controller/FilesControllerTest.php
+++ b/tests/lib/Controller/FilesControllerTest.php
@@ -37,49 +37,54 @@ class FilesControllerTest extends TestCase {
 			// getById returns only one result
 			[
 				[
-					$this->getNodeMock('image/png')
+					$this->getNodeMock('image/png', 123, 'file', '/testUser/files/logo.png', 'files/logo.png')
 				],
 				'files/logo.png',
 				'logo.png',
-				'image/png'
+				'image/png',
+				'files/logo.png'
 			],
 			// getById returns multiple results e.g. if the file was received through multiple path
 			[
 				[
-					$this->getNodeMock('image/png'),
-					$this->getNodeMock('image/png')
+					$this->getNodeMock('image/png', 123, 'file', '/testUser/files/receivedAsFolderShare/logo.png', 'files/receivedAsFolderShare/logo.png'),
+					$this->getNodeMock('image/png', 123, 'file', '/testUser/files/receivedAsFolderShare/logo.png', 'files/receivedAsFolderShare/logo.png')
 
 				],
 				'files/receivedAsFolderShare/logo.png',
 				'logo.png',
 				'image/png',
+				'files/receivedAsFolderShare/logo.png'
 			],
 			// getById returns a folder
 			[
 				[
-					$this->getNodeMock('httpd/unix-directory')
+					$this->getNodeMock('httpd/unix-directory', 123, 'dir', '/testUser/files/myFolder', 'files/myFolder')
 				],
 				'files/myFolder',
 				'myFolder',
-				'application/x-op-directory'
+				'application/x-op-directory',
+				'files/myFolder/'
 			],
 			// getById returns a sub folder
 			[
 				[
-					$this->getNodeMock('httpd/unix-directory')
+					$this->getNodeMock('httpd/unix-directory', 123, 'dir', '/testUser/files/myFolder/a-sub-folder', 'files/myFolder/a-sub-folder')
 				],
 				'files/myFolder/a-sub-folder',
 				'a-sub-folder',
-				'application/x-op-directory'
+				'application/x-op-directory',
+				'files/myFolder/a-sub-folder/'
 			],
 			// getById returns the root folder
 			[
 				[
-					$this->getNodeMock('httpd/unix-directory')
+					$this->getNodeMock('httpd/unix-directory', 123, 'dir', '/testUser/files', 'files')
 				],
 				'files',
 				'files',
-				'application/x-op-directory'
+				'application/x-op-directory',
+				'files/'
 			],
 		];
 	}
@@ -90,13 +95,15 @@ class FilesControllerTest extends TestCase {
 	 * @param string $internalPath
 	 * @param string $expectedName
 	 * @param string $expectedMimeType
+	 * @param string $expectedPath
 	 * @return void
 	 */
 	public function testGetFileInfo(
 		$nodeMocks,
 		$internalPath,
 		$expectedName,
-		$expectedMimeType
+		$expectedMimeType,
+		$expectedPath
 	) {
 		$folderMock = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
 		$folderMock->method('getById')->willReturn($nodeMocks);
@@ -123,7 +130,7 @@ class FilesControllerTest extends TestCase {
 				'modifier_name' => null,
 				'modifier_id' => null,
 				'dav_permissions' => 'RGDNVCK',
-				'path' => 'files/test'
+				'path' => $expectedPath
 			],
 			$result->getData()
 		);
@@ -579,7 +586,7 @@ class FilesControllerTest extends TestCase {
 					'modifier_name' => null,
 					'modifier_id' => null,
 					'dav_permissions' => 'RGDNVCK',
-					'path' => 'files/myFolder/a-sub-folder'
+					'path' => 'files/myFolder/a-sub-folder/'
 				],
 				3 => [
 					'status' => 'OK',
@@ -596,7 +603,7 @@ class FilesControllerTest extends TestCase {
 					'modifier_name' => null,
 					'modifier_id' => null,
 					'dav_permissions' => 'RGDNVCK',
-					'path' => 'files'
+					'path' => 'files/'
 				]
 			],
 			$result->getData()
@@ -680,7 +687,7 @@ class FilesControllerTest extends TestCase {
 					'modifier_name' => null,
 					'modifier_id' => null,
 					'dav_permissions' => 'RGDNVCK',
-					'path' => 'files/myFolder/a-sub-folder'
+					'path' => 'files/myFolder/a-sub-folder/'
 				],
 				3 => [
 					'status' => 'OK',
@@ -697,7 +704,7 @@ class FilesControllerTest extends TestCase {
 					'modifier_name' => null,
 					'modifier_id' => null,
 					'dav_permissions' => 'RGDNVCK',
-					'path' => 'files/testFolder'
+					'path' => 'files/testFolder/'
 				]
 			],
 			$result->getData()
@@ -728,7 +735,7 @@ class FilesControllerTest extends TestCase {
 				'SRMGDNVCK',
 				'application/x-op-directory',
 				'Folder',
-				'files/Folder'
+				'files/Folder/'
 			],
 			// only read permision set for file
 			[
@@ -748,7 +755,7 @@ class FilesControllerTest extends TestCase {
 				'G',
 				'application/x-op-directory',
 				'Folder',
-				'files/Folder'
+				'files/Folder/'
 			],
 			// create+update permision set for folder
 			[
@@ -758,7 +765,7 @@ class FilesControllerTest extends TestCase {
 				'NVCK',
 				'application/x-op-directory',
 				'Folder',
-				'files/Folder'
+				'files/Folder/'
 			],
 			// share+read permision set for file
 			[
@@ -778,7 +785,7 @@ class FilesControllerTest extends TestCase {
 				'RG',
 				'application/x-op-directory',
 				'Folder',
-				'files/Folder'
+				'files/Folder/'
 			],
 			// shared+shareable+update permision set for file
 			[
@@ -798,7 +805,7 @@ class FilesControllerTest extends TestCase {
 				'SRNV',
 				'application/x-op-directory',
 				'Folder',
-				'files/Folder'
+				'files/Folder/'
 			],
 			// shared+shareable+update+create permision set for folder
 			[
@@ -808,7 +815,7 @@ class FilesControllerTest extends TestCase {
 				'SRNVCK',
 				'application/x-op-directory',
 				'Folder',
-				'files/Folder'
+				'files/Folder/'
 			],
 		];
 	}


### PR DESCRIPTION
### Description
This PR adds the trailing slash for the folder path in the response for the file(s)info endopint.

### Relared WP
https://community.openproject.org/projects/nextcloud-integration/work_packages/50326/activity