### PR TITLE
[OP#50542]Schedule nightly CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ on:
     branches:
       - 'master'
   pull_request:
+  schedule:
+    - cron: '0 22 * * *' # run at 10 PM UTC 
 
 name: CI
 


### PR DESCRIPTION
Since our CI doesn't run unless there's some new push or new PR sometimes we might not know about certain regressions due to the releases of the next cloud servers until it's too late. So, maybe we can run the nightly which will be more reliable in catching such errors.

I have put the time to be `10` PM UTC which should be 4 am in Nepal but it can be changed to 12am 
For time format and more info https://crontab.guru/

### Related WP
https://community.openproject.org/projects/nextcloud-integration/work_packages/50542