### PR TITLE
[OP#50617] Use dependecy Injection to get classes from other apps

### DIFF
--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -30,7 +30,6 @@ use OCP\Http\Client\IResponse;
 use OCP\ICache;
 use OCP\ICacheFactory;
 use OCP\IGroupManager;
-use OCP\IDBConnection;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\IUserManager;
@@ -44,7 +43,6 @@ use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\ServerException;
 use GuzzleHttp\Exception\ConnectException;
 use OCP\AppFramework\Http;
-use OCP\Files\IMimeTypeLoader;
 use OC\Authentication\Events\AppPasswordCreatedEvent;
 use OC\Authentication\Token\IProvider;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -115,15 +113,6 @@ class OpenProjectAPIService {
 	private ISubAdmin $subAdminManager;
 
 	/**
-	 * @var IDBConnection
-	 */
-	private $dbConnection;
-
-	/**
-	 * @var IMimeTypeLoader
-	 */
-	private $mimeTypeLoader;
-	/**
 	 * Service to make requests to OpenProject v3 (JSON) API
 	 */
 
@@ -144,12 +133,10 @@ class OpenProjectAPIService {
 								IUserManager $userManager,
 								IGroupManager $groupManager,
 								IAppManager $appManager,
-								IDBConnection $dbConnection,
 								IProvider $tokenProvider,
 								ISecureRandom $random,
 								IEventDispatcher $eventDispatcher,
-								ISubAdmin $subAdminManager,
-								IMimeTypeLoader $mimeTypeLoader
+								ISubAdmin $subAdminManager
 	) {
 		$this->appName = $appName;
 		$this->avatarManager = $avatarManager;
@@ -163,9 +150,7 @@ class OpenProjectAPIService {
 		$this->userManager = $userManager;
 		$this->groupManager = $groupManager;
 		$this->appManager = $appManager;
-		$this->dbConnection = $dbConnection;
 		$this->subAdminManager = $subAdminManager;
-		$this->mimeTypeLoader = $mimeTypeLoader;
 		$this->tokenProvider = $tokenProvider;
 		$this->random = $random;
 		$this->eventDispatcher = $eventDispatcher;

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -45,12 +45,11 @@ use GuzzleHttp\Exception\ServerException;
 use GuzzleHttp\Exception\ConnectException;
 use OCP\AppFramework\Http;
 use OCP\Files\IMimeTypeLoader;
-use OC_Util;
 use OC\Authentication\Events\AppPasswordCreatedEvent;
 use OC\Authentication\Token\IProvider;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Security\ISecureRandom;
-
+use OCP\Server;
 use OCA\OpenProject\AppInfo\Application;
 use Safe\Exceptions\JsonException;
 
@@ -1031,13 +1030,8 @@ class OpenProjectAPIService {
 	 * @throws NoUserException
 	 */
 	public function createGroupfolder(): void {
-		if (version_compare(OC_Util::getVersionString(), '27') >= 0) {
-			// @phpstan-ignore-next-line - make phpstan not complain if groupfolders app does not exist
-			$groupfoldersFolderManager = new FolderManager($this->dbConnection, $this->groupManager, $this->mimeTypeLoader, $this->logger);
-		} else {
-			// @phpstan-ignore-next-line - make phpstan not complain if groupfolders app does not exist
-			$groupfoldersFolderManager = new FolderManager($this->dbConnection);
-		}
+		// @phpstan-ignore-next-line - make phpstan not complain if groupfolders app does not exist
+		$groupfoldersFolderManager = Server::get(FolderManager::class);
 		// @phpstan-ignore-next-line - make phpstan not complain if groupfolders app does not exist
 		$folderId = $groupfoldersFolderManager->createFolder(
 			Application::OPEN_PROJECT_ENTITIES_NAME
@@ -1064,13 +1058,8 @@ class OpenProjectAPIService {
 
 	// @phpstan-ignore-next-line - make phpstan not complain if groupfolders app does not exist
 	public function getGroupFolderManager(): FolderManager {
-		if (version_compare(OC_Util::getVersionString(), '27') >= 0) {
-			// @phpstan-ignore-next-line - make phpstan not complain if groupfolders app does not exist
-			$groupfoldersFolderManager = new FolderManager($this->dbConnection, $this->groupManager, $this->mimeTypeLoader, $this->logger);
-		} else {
-			// @phpstan-ignore-next-line - make phpstan not complain if groupfolders app does not exist
-			$groupfoldersFolderManager = new FolderManager($this->dbConnection);
-		}
+		// @phpstan-ignore-next-line - make phpstan not complain if groupfolders app does not exist
+		$groupfoldersFolderManager = Server::get(FolderManager::class);
 		return $groupfoldersFolderManager;
 	}
 

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -22,7 +22,6 @@ use OCA\OpenProject\AppInfo\Application;
 use OCA\OpenProject\Exception\OpenprojectErrorException;
 use OCA\OpenProject\Exception\OpenprojectResponseException;
 use OCP\App\IAppManager;
-use OCP\Files\IMimeTypeLoader;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
@@ -32,7 +31,6 @@ use OCP\IAvatarManager;
 use OCP\ICache;
 use OCP\ICacheFactory;
 use OCP\IConfig;
-use OCP\IDBConnection;
 use OCP\IGroup;
 use OCP\IGroupManager;
 use OCP\IL10N;
@@ -462,12 +460,10 @@ class OpenProjectAPIServiceTest extends TestCase {
 			$this->createMock(IUserManager::class),
 			$this->createMock(IGroupManager::class),
 			$this->createMock(IAppManager::class),
-			$this->createMock(IDBConnection::class),
 			$this->createMock(IProvider::class),
 			$this->createMock(ISecureRandom::class),
 			$this->createMock(IEventDispatcher::class),
-			$this->createMock(ISubAdmin::class),
-			$this->createMock(IMimeTypeLoader::class)
+			$this->createMock(ISubAdmin::class)
 		);
 	}
 
@@ -539,12 +535,10 @@ class OpenProjectAPIServiceTest extends TestCase {
 					$userManagerMock,
 					$groupManagerMock,
 					$appManagerMock,
-					$this->createMock(IDBConnection::class),
 					$tokenProviderMock,
 					$iSecureRandomMock,
 					$this->createMock(IEventDispatcher::class),
 					$subAdminManagerMock,
-					$this->createMock(IMimeTypeLoader::class)
 				])
 			->onlyMethods($onlyMethods)
 			->getMock();
@@ -1663,12 +1657,10 @@ class OpenProjectAPIServiceTest extends TestCase {
 			$this->createMock(IUserManager::class),
 			$this->createMock(IGroupManager::class),
 			$this->createMock(IAppManager::class),
-			$this->createMock(IDBConnection::class),
 			$this->createMock(IProvider::class),
 			$this->createMock(ISecureRandom::class),
 			$this->createMock(IEventDispatcher::class),
-			$this->createMock(ISubAdmin::class),
-			$this->createMock(IMimeTypeLoader::class)
+			$this->createMock(ISubAdmin::class)
 		);
 
 		$response = $service->request('', '', []);


### PR DESCRIPTION
We have some functions that require the classes of other nextcloud apps like groupfolders and as we are supporting 3 major versions of the nextcloud server, the parameters to the class constructors may change according to the server's version. Currently, we are determining the version of the nextcloud and providing parameters based on that but in this PR we use dependency injection like in PR https://github.com/nextcloud/integration_openproject/pull/502

Related work package: https://community.openproject.org/projects/nextcloud-integration/work_packages/50617