### PR TITLE
[#50658] Connect to OpenProject Button in Smart Picker

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -44,6 +44,7 @@ return [
 		['name' => 'openProjectAPI#getOpenProjectWorkPackageForm', 'url' => '/projects/{projectId}/work-packages/form','verb' => 'POST'],
 		['name' => 'openProjectAPI#getAvailableAssigneesOfAProject', 'url' => '/projects/{projectId}/available-assignees','verb' => 'GET'],
 		['name' => 'openProjectAPI#createWorkPackage', 'url' => '/create/work-packages','verb' => 'POST'],
+		['name' => 'openProjectAPI#getOpenProjectConfiguration', 'url' => '/configuration', 'verb' => 'GET'],
 	],
 	'ocs' => [
 		['name' => 'files#getFileInfo', 'url' => '/fileinfo/{fileId}', 'verb' => 'GET'],

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -416,6 +416,8 @@ class ConfigController extends Controller {
 					'dir' => $oauthJourneyStartingPageDecoded->file->dir,
 					'scrollto' => $oauthJourneyStartingPageDecoded->file->name
 				]);
+			} elseif ($oauthJourneyStartingPageDecoded->page === 'spreed') {
+				$newUrl = $oauthJourneyStartingPageDecoded->callUrl;
 			} else {
 				$this->logger->error(
 					'could not determine where the OAuth journey ' .

--- a/lib/Controller/OpenProjectAPIController.php
+++ b/lib/Controller/OpenProjectAPIController.php
@@ -508,6 +508,29 @@ class OpenProjectAPIController extends Controller {
 	}
 
 	/**
+	 * get OpenProject configuration
+	 *
+	 * @NoAdminRequired
+	 *
+	 * @return DataResponse
+	 */
+	public function getOpenProjectConfiguration(): DataResponse {
+		if ($this->accessToken === '') {
+			return new DataResponse('', Http::STATUS_UNAUTHORIZED);
+		} elseif (!OpenProjectAPIService::validateURL($this->openprojectUrl)) {
+			return new DataResponse('', Http::STATUS_BAD_REQUEST);
+		}
+		try {
+			$result = $this->openprojectAPIService->getOpenProjectConfiguration($this->userId);
+		} catch (OpenprojectErrorException $e) {
+			return new DataResponse($e->getMessage(), $e->getCode());
+		} catch (\Exception $e) {
+			return new DataResponse($e->getMessage(), Http::STATUS_INTERNAL_SERVER_ERROR);
+		}
+		return new DataResponse($result);
+	}
+
+	/**
 	 * check if there is a OpenProject behind a certain URL
 	 *
 	 * @NoAdminRequired

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -1361,4 +1361,29 @@ class OpenProjectAPIService {
 		}
 		return $result;
 	}
+
+	/**
+	 * @param string $userId
+	 *
+	 * @return array<mixed>
+	 * @throws OpenprojectErrorException
+	 * @throws OpenprojectResponseException
+	 */
+	public function getOpenProjectConfiguration(string $userId): array {
+		$result = $this->request(
+			$userId, '/configuration'
+		);
+
+		if (isset($result['error'])) {
+			throw new OpenprojectErrorException($result['error'], $result['statusCode']);
+		}
+
+		if (
+			!isset($result['_type']) ||
+			$result['_type'] !== 'Configuration'
+		) {
+			throw new OpenprojectResponseException('Malformed response');
+		}
+		return $result;
+	}
 }

--- a/src/components/OAuthConnectButton.vue
+++ b/src/components/OAuthConnectButton.vue
@@ -67,6 +67,9 @@ export default {
 			if (window.location.pathname.includes('apps/files') && Object.keys(this.fileInfo).length === 0) {
 				return { page: 'files' }
 			}
+			if (window.location.pathname.includes('call')) {
+				return { page: 'spreed', callUrl: window.location.href }
+			}
 			return { page: 'settings' }
 		},
 		async onOAuthClick() {

--- a/src/components/tab/EmptyContent.vue
+++ b/src/components/tab/EmptyContent.vue
@@ -4,14 +4,15 @@
 			<div class="empty-content--icon">
 				<CheckIcon v-if="isStateOk && dashboard" :size="60" />
 				<LinkPlusIcon v-else-if="!!isAdminConfigOk && isStateOk && !dashboard && !isSmartPicker" :size="60" />
-				<OpenProjectIcon v-else-if="!!isSmartPicker" class="empty-content--icon--openproject" />
+				<OpenProjectIcon v-else-if="!!isSmartPicker && isStateOk" class="empty-content--icon--openproject" />
 				<LinkOffIcon v-else :size="60" />
 			</div>
-			<div v-if="!!isAdminConfigOk && !isSmartPicker" class="empty-content--message">
-				<div class="empty-content--message--title">
+			<div v-if="!!isAdminConfigOk" class="empty-content--message">
+				<div v-if="!!isStateOk && isSmartPicker" class="empty-content--message--title" />
+				<div v-else class="empty-content--message--title">
 					{{ emptyContentTitleMessage }}
 				</div>
-				<div v-if="!!emptyContentSubTitleMessage" class="empty-content--message--sub-title">
+				<div v-if="!!emptyContentSubTitleMessage && !isSmartPicker" class="empty-content--message--sub-title">
 					{{ emptyContentSubTitleMessage }}
 				</div>
 			</div>

--- a/src/components/tab/SearchInput.vue
+++ b/src/components/tab/SearchInput.vue
@@ -11,6 +11,7 @@
 			:loading="isStateLoading"
 			:filterable="false"
 			:clear-search-on-blur="() => false"
+			:disabled="isDisabled"
 			@search="asyncFind"
 			@option:selected="linkWorkPackageToFile">
 			<template #option="option">
@@ -99,6 +100,10 @@ export default {
 			type: String,
 			required: false,
 			default: null,
+		},
+		isDisabled: {
+			type: Boolean,
+			default: false,
 		},
 	},
 	data: () => ({


### PR DESCRIPTION
https://community.openproject.org/work_packages/50658

![Screenshot from 2023-12-04 14-29-17](https://github.com/nextcloud/integration_openproject/assets/41103328/e95fd6a4-d7e2-4ff2-a460-50eb7385a427)


> Note: that the redirection does take back to the talk chat but it doesn't open the smart picker itself, as there was no easy of opening the smart picker programmatically, we decided that it's okay that the redirection doesn't open the smart picker. The user would have to open the smart picker to know if the OAuth connection was successful. Similar, is the reason for the lack of success/failure message, as we'll have to mount the smart picker component to display success/failure message for the connection, there was no easy way to mount it during the OAuth redirection so we decided that we'll leave it as it is in this PR