### PR TITLE
[OP#50542]Forward port schedule nightly builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ on:
     branches:
       - 'master'
   pull_request:
+  schedule:
+    - cron: '0 22 * * *' # run at 10 PM UTC 
 
 name: CI
 


### PR DESCRIPTION
### Description
The nightly run was merged on released bracnch `2.4`. https://github.com/nextcloud/integration_openproject/pull/510. But it did not got triggered. So forward porting it to master if it is triggered in master and can be adjusted accordingly to released branch.

### Part of :
https://community.openproject.org/projects/nextcloud-integration/work_packages/50542/activity
