### PR TITLE
Scheduled trigger for the release/2.4 branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
       - 'master'
   pull_request:
   schedule:
-    - cron: '0 22 * * *' # run at 10 PM UTC 
+    - cron: '0 22 * * *' # run at 10 PM UTC
 
 name: CI
 
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event_name == 'schedule' && 'release/2.4' || 'master' }}
 
       - name: Setup PHP ${{ matrix.phpVersion }}
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
### Description
Previously the scheduled cron did not trigger the `release/2.4` branch. This PR makes the release branch trigger for the scheduled time. The `workflow` can only be triggered from the default master branch. 

### Related WorkPackage
https://community.openproject.org/projects/nextcloud-integration/work_packages/50542/activity