### PR TITLE
Make CI run with stable28

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
       - 'master'
   pull_request:
   schedule:
-    - cron: '0 22 * * *' # run at 10 PM UTC 
+    - cron: '0 22 * * *' # run at 10 PM UTC
 
 name: CI
 
@@ -17,14 +17,14 @@ jobs:
     name: unit tests and linting
     strategy:
       matrix:
-        nextcloudVersion: [ stable25, stable26, stable27, master ]
+        nextcloudVersion: [ stable25, stable26, stable27, stable28 ]
         phpVersion: [ 7.4, 8.0, 8.1 ]
         exclude:
           - nextcloudVersion: stable26
             phpVersion: 7.4
           - nextcloudVersion: stable27
             phpVersion: 7.4
-          - nextcloudVersion: master
+          - nextcloudVersion: stable28
             phpVersion: 7.4
     runs-on: ubuntu-20.04
     steps:
@@ -75,7 +75,7 @@ jobs:
 
       - name: PHP code analysis
         run: |
-          if [[ ${{ matrix.nextcloudVersion }} != "master" ]]
+          if [[ ${{ matrix.nextcloudVersion }} != "stable28" ]]
           then
             make phpstan
           fi
@@ -105,7 +105,7 @@ jobs:
           make jsunit
 
       - name: JS Code Coverage Summary Report
-        if: ${{ github.event_name == 'pull_request' && matrix.nextcloudVersion == 'master' && matrix.phpVersion == '8.1' }}
+        if: ${{ github.event_name == 'pull_request' && matrix.nextcloudVersion == 'stable28' && matrix.phpVersion == '8.1' }}
         uses: romeovs/lcov-reporter-action@v0.3.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -114,14 +114,14 @@ jobs:
           title: "JS Code Coverage"
 
       - name: Setup .NET Core # this is required to execute Convert PHP cobertura coverage to lcov step
-        if: ${{ github.event_name == 'pull_request' && matrix.nextcloudVersion == 'master' && matrix.phpVersion == '8.1' }}
+        if: ${{ github.event_name == 'pull_request' && matrix.nextcloudVersion == 'stable28' && matrix.phpVersion == '8.1' }}
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 6.0.101
           dotnet-quality: 'ga'
 
       - name: Convert PHP cobertura coverage to lcov
-        if: ${{ github.event_name == 'pull_request' && matrix.nextcloudVersion == 'master' && matrix.phpVersion == '8.1' }}
+        if: ${{ github.event_name == 'pull_request' && matrix.nextcloudVersion == 'stable28' && matrix.phpVersion == '8.1' }}
         uses: danielpalme/ReportGenerator-GitHub-Action@5.1.23
         with:
           reports: './server/apps/integration_openproject/coverage/php/cobertura.xml' # REQUIRED # The coverage reports that should be parsed (separated by semicolon). Globbing is supported.
@@ -140,7 +140,7 @@ jobs:
           toolpath: 'reportgeneratortool' # Default directory for installing the dotnet tool.
 
       - name: PHP Code Coverage Summary Report
-        if: ${{ github.event_name == 'pull_request' && matrix.nextcloudVersion == 'master' && matrix.phpVersion == '8.1' }}
+        if: ${{ github.event_name == 'pull_request' && matrix.nextcloudVersion == 'stable28' && matrix.phpVersion == '8.1' }}
         uses: romeovs/lcov-reporter-action@v0.3.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -149,14 +149,14 @@ jobs:
           title: "PHP Code Coverage"
 
       - name: JS coverage check
-        if: ${{ github.event_name == 'pull_request' && matrix.nextcloudVersion == 'master' && matrix.phpVersion == '8.1' }}
+        if: ${{ github.event_name == 'pull_request' && matrix.nextcloudVersion == 'stable28' && matrix.phpVersion == '8.1' }}
         uses: VeryGoodOpenSource/very_good_coverage@v2
         with:
           min_coverage: '59'
           path: './server/apps/integration_openproject/coverage/jest/lcov.info'
 
       - name: PHP coverage check
-        if: ${{ github.event_name == 'pull_request' && matrix.nextcloudVersion == 'master' && matrix.phpVersion == '8.1' }}
+        if: ${{ github.event_name == 'pull_request' && matrix.nextcloudVersion == 'stable28' && matrix.phpVersion == '8.1' }}
         uses: VeryGoodOpenSource/very_good_coverage@v2
         with:
           min_coverage: '56'
@@ -166,7 +166,7 @@ jobs:
     name: API tests
     strategy:
       matrix:
-        nextcloudVersion: [ stable25, stable26, stable27, master ]
+        nextcloudVersion: [ stable25, stable26, stable27, stable28 ]
         phpVersionMajor: [ 7, 8 ]
         phpVersionMinor: [ 4, 1 ]
         database: [pgsql, mysql]
@@ -187,7 +187,7 @@ jobs:
             phpVersionMinor: 1
           - phpVersionMajor: 8
             phpVersionMinor: 4
-          - nextcloudVersion: master
+          - nextcloudVersion: stable28
             phpVersionMajor: 7
           - phpVersionMajor: 7
             phpVersionMinor: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
           sudo apt install make openssl -y
           echo "###### installing nextcloud"
           mkdir ~/html
-          git clone https://github.com/nextcloud/server.git --recursive --depth 1 -b master ~/html/nextcloud
+          git clone https://github.com/nextcloud/server.git --recursive --depth 1 -b stable28 ~/html/nextcloud
           sed -i $'s|if (substr($fullPath, 0, strlen($root) + 1) === $root . \'/\')|if (is_string($root) and substr($fullPath, 0, strlen($root) + 1) === $root . \'/\')|g' ~/html/nextcloud/lib/autoloader.php
           cp -r $GITHUB_WORKSPACE ~/html/nextcloud/apps/${APP_ID}
           php ~/html/nextcloud/occ maintenance:install --database "sqlite" --admin-user "admin" --admin-pass "password"


### PR DESCRIPTION
Nextcloud checked out a stable-28 branch https://github.com/nextcloud/server/tree/stable28 so now the master is version-29 , since apps like `groupfolders` aren't yet compatible with nextcloud version-29 we are getting CI failures like

```console
Run git clone --depth 1 https://github.com/nextcloud/groupfolders.git -b master server/apps/groupfolders
Cloning into 'server/apps/groupfolders'...
App "Group folders" cannot be installed because it is not compatible with this version of the server.
Error: Process completed with exit code 1.
```

This will unblock the CI.

## Related Workpackage
OP#51218 - https://community.openproject.org/projects/nextcloud-integration/work_packages/51218

Backport of changes from https://github.com/nextcloud/integration_openproject/pull/521