### PR TITLE
Checkout code for not scheduled

### DIFF
--- a/.github/workflows/shared_workflow.yml
+++ b/.github/workflows/shared_workflow.yml
@@ -29,7 +29,7 @@ jobs:
           ref: ${{ inputs.branch }}
 
       - name: Checkout
-        if: github.event_name == 'pull_request'
+        if: github.event_name != 'schedule'
         uses: actions/checkout@v3
 
       - name: Setup PHP ${{ matrix.phpVersion }}
@@ -257,7 +257,7 @@ jobs:
           ref: ${{ inputs.branch }}
 
       - name: Checkout
-        if: github.event_name == 'pull_request'
+        if: github.event_name != 'schedule'
         uses: actions/checkout@v3
         with:
           path: integration_openproject


### PR DESCRIPTION
### Description
The previous PR only checkout for `pull_request` event which did not run when for merge event.So this PR fixes it.