### PR TITLE
[WP#51373]Make the min password length dynamic instead of hardcoded one

### DIFF
--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -203,7 +203,7 @@ class ConfigController extends Controller {
 		if (key_exists('setup_project_folder', $values) && $values['setup_project_folder'] === true) {
 			$isSystemReady = $this->openprojectAPIService->isSystemReadyForProjectFolderSetUp();
 			if ($isSystemReady) {
-				$password = $this->secureRandom->generate(10, ISecureRandom::CHAR_HUMAN_READABLE);
+				$password = $this->secureRandom->generate($this->openprojectAPIService->getPasswordLength(), ISecureRandom::CHAR_ALPHANUMERIC.ISecureRandom::CHAR_SYMBOLS);
 				$user = $this->userManager->createUser(Application::OPEN_PROJECT_ENTITIES_NAME, $password);
 				$group = $this->groupManager->createGroup(Application::OPEN_PROJECT_ENTITIES_NAME);
 				$group->addUser($user);

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -1103,12 +1103,20 @@ class OpenProjectAPIService {
 	}
 
 	/**
+	 * @return int
+	 */
+	public function getPasswordLength(): int {
+		$passLengthSet = (int) $this->config->getAppValue('password_policy', 'minLength', '');
+		return $passLengthSet === 0 ? 72 : max(72, $passLengthSet);
+	}
+
+	/**
 	 * @return string
 	 */
 	public function generateAppPasswordTokenForUser(): string {
 		$user = $this->userManager->get(Application::OPEN_PROJECT_ENTITIES_NAME);
 		$userID = $user->getUID();
-		$token = $this->random->generate(72, ISecureRandom::CHAR_UPPER.ISecureRandom::CHAR_LOWER.ISecureRandom::CHAR_DIGITS.ISecureRandom::CHAR_SYMBOLS);
+		$token = $this->random->generate(self::getPasswordLength(), ISecureRandom::CHAR_ALPHANUMERIC.ISecureRandom::CHAR_SYMBOLS);
 		$generatedToken = $this->tokenProvider->generateToken(
 			$token,
 			$userID,

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -1106,7 +1106,7 @@ class OpenProjectAPIService {
 	 * @return int
 	 */
 	public function getPasswordLength(): int {
-		$passLengthSet = (int) $this->config->getAppValue('password_policy', 'minLength', '');
+		$passLengthSet = (int) $this->config->getAppValue('password_policy', 'minLength', '0');
 		return $passLengthSet === 0 ? 72 : max(72, $passLengthSet);
 	}
 

--- a/tests/lib/Controller/ConfigControllerTest.php
+++ b/tests/lib/Controller/ConfigControllerTest.php
@@ -1287,7 +1287,7 @@ class ConfigControllerTest extends TestCase {
 				['integration_openproject', 'oPOAuthTokenRevokeStatus', ''],
 				['integration_openproject', 'openproject_client_id'],
 				['integration_openproject', 'openproject_client_secret'],
-				['integration_openproject', 'openproject_instance_url']
+				['integration_openproject', 'openproject_instance_url'],
 			)
 			->willReturnOnConsecutiveCalls(
 				'http://localhost:3000',
@@ -1301,8 +1301,11 @@ class ConfigControllerTest extends TestCase {
 		$secureRandomMock = $this->getMockBuilder(ISecureRandom::class)->getMock();
 		$secureRandomMock
 			->method('generate')
-			->with(10, ISecureRandom::CHAR_HUMAN_READABLE)
+			->with(15, ISecureRandom::CHAR_ALPHANUMERIC.ISecureRandom::CHAR_SYMBOLS)
 			->willReturn('thisisapassword123');
+		$service
+			->method('getPasswordLength')
+			->willReturn(15);
 		$userMock = $this->createMock(IUser::class);
 		$userManagerMock = $this->getMockBuilder(IUserManager::class)->getMock();
 		$userManagerMock

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -2440,4 +2440,44 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$this->expectException(OpenprojectErrorException::class);
 		$service->deleteFileLink(12345, 'testUser');
 	}
+
+
+	/**
+	 * @return array<int, array<int, int|string>>
+	 */
+	public function passwordLengthProvider(): array {
+		return [
+			['10', 72],
+			['100', 100]
+		];
+	}
+
+	/**
+	 * @dataProvider passwordLengthProvider
+	 * @return void
+	 */
+	public function testGetPasswordLength(string $passwordLength, int $expectedPasswordLength): void {
+		$configMock = $this->getMockBuilder(IConfig::class)->getMock();
+		$configMock
+			->method('getAppValue')
+			->with(
+				'password_policy', 'minLength', ''
+			)
+			->willReturn(
+				$passwordLength
+			);
+		$service = $this->getServiceMock(
+			[],
+			null,
+			null,
+			null,
+			null,
+			null,
+			null,
+			null,
+			$configMock
+		);
+		$result = $service->getPasswordLength();
+		$this->assertEquals($expectedPasswordLength, $result);
+	}
 }

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -2461,7 +2461,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$configMock
 			->method('getAppValue')
 			->with(
-				'password_policy', 'minLength', ''
+				'password_policy', 'minLength'
 			)
 			->willReturn(
 				$passwordLength


### PR DESCRIPTION
### Description
Previously when creating user the min length was hardcoded to `10` and would fail to create user when min length of it was greater which can be changed through `password_policy` app. With this PR, the length of the min password is made more dynamic according to `password_policy` app.

### Related Work Package
Fixes Bug: https://community.openproject.org/projects/nextcloud-integration/work_packages/51373