### PR TITLE
Revert to latest image of nextcloud in CI

### DIFF
--- a/.github/workflows/shared_workflow.yml
+++ b/.github/workflows/shared_workflow.yml
@@ -209,7 +209,7 @@ jobs:
 
     services:
       nextcloud:
-        image: ghcr.io/juliushaertl/nextcloud-dev-php${{ format('{0}{1}', matrix.phpVersionMajor,matrix.phpVersionMinor) }}:${{ matrix.phpVersionMajor == 7 && 'latest@sha256:2ab4bf7241fb6997d4819b5a32345b8cdb66ea27511c7b5698b77a592e09153f' || 'latest@sha256:7e9bb4cf6d232001b93add1b2a14628b000af1480ad11d6d7b3f93c14a9249b8' }}
+        image: ghcr.io/juliushaertl/nextcloud-dev-php${{ format('{0}{1}', matrix.phpVersionMajor,matrix.phpVersionMinor) }}:latest
         env:
           SQL: ${{ matrix.database }}
           SERVER_BRANCH: ${{ matrix.nextcloudVersion }}


### PR DESCRIPTION
### Description
According to the discussion made in the image of nextcloud repo. The php blackfire was enabled in the latest image for nextcloud instance which caused the never ending loop. But now it is reverted to disabled. So we can use the latest image like previously.

### Discussion
https://github.com/juliushaertl/nextcloud-docker-dev/discussions/254#discussioncomment-7720537