### PR TITLE
Downgrade the image of nextcloud service

### DIFF
--- a/.github/workflows/shared_workflow.yml
+++ b/.github/workflows/shared_workflow.yml
@@ -209,7 +209,7 @@ jobs:
 
     services:
       nextcloud:
-        image: ghcr.io/juliushaertl/nextcloud-dev-php${{ format('{0}{1}', matrix.phpVersionMajor,matrix.phpVersionMinor) }}:latest
+        image: ghcr.io/juliushaertl/nextcloud-dev-php${{ format('{0}{1}', matrix.phpVersionMajor,matrix.phpVersionMinor) }}:20231202-1
         env:
           SQL: ${{ matrix.database }}
           SERVER_BRANCH: ${{ matrix.nextcloudVersion }}


### PR DESCRIPTION
### Description
Something changed with the new latest image yesterday again. They have released a tag for every image with date name so that we do not need to apply condition for image in CI. For now the CI is green. We can debug the change in latest in other PR.
