### PR TITLE
[OP#51321][forwardport]fix: Virus infected File is not removed by background job when integration app is enabled

### DIFF
--- a/lib/Listener/BeforeNodeInsideOpenProjectGroupfilderChangedListener.php
+++ b/lib/Listener/BeforeNodeInsideOpenProjectGroupfilderChangedListener.php
@@ -51,11 +51,13 @@ class BeforeNodeInsideOpenProjectGroupfilderChangedListener implements IEventLis
 		} else {
 			return;
 		}
+		$currentUser = $this->userSession->getUser();
 		// we do not listen event where user is not logged or there is no user session (e.g. public link )
-		if (OC_User::isIncognitoMode()) {
+		// or if it's some background job in which case user will be null
+		if (OC_User::isIncognitoMode() || $currentUser === null) {
 			return;
 		}
-		$currentUserId = $this->userSession->getUser()->getUID();
+		$currentUserId = $currentUser->getUID();
 		if (
 			$this->openprojectAPIService->isProjectFoldersSetupComplete() &&
 			preg_match('/.*\/files\/' .  Application::OPEN_PROJECT_ENTITIES_NAME . '$/', $parentNode->getPath()) === 1 &&


### PR DESCRIPTION
Fordwardport: https://github.com/nextcloud/integration_openproject/pull/527
## Description
We have a hook to protect the deletion of the folders inside the `OpenProject` groupfolder and to do so we intercept each deletion request to check if the node is inside  of `OpenProject` groupfolder. We expect the user to have a user session but in case of background jobs doing some cleanup jobs there's no user session. In the case where the files antivirus is trying to scan the files and remove any virus infected file our app didn't allow the deletion of such files.

In this PR we check if the user is `null` and the user is returned `null` we assume that it's a background job and return without performing further operation

Related Issues:
- https://community.openproject.org/work_packages/51321
- https://github.com/nextcloud/files_antivirus/issues/297