### PR TITLE
[#49327] Fix the workpackage id placement of link previews in text app

### DIFF
--- a/src/components/tab/WorkPackage.vue
+++ b/src/components/tab/WorkPackage.vue
@@ -268,6 +268,8 @@ export default {
 			font-size: 0.8rem;
 			height: 20px;
 			line-height: 20px;
+			display: flex;
+			align-self: center;
 		}
 
 		&__subject {


### PR DESCRIPTION
Previously on the text app  the work package id in link previews was at top instead of center this PR brings it to center

Related work package: https://community.openproject.org/work_packages/49327

## Before
![Screenshot from 2023-12-07 09-56-54](https://github.com/nextcloud/integration_openproject/assets/41103328/b57d2d64-f57f-4dd0-958a-71371c75afd7)


## After
![Screenshot from 2023-12-07 09-54-29](https://github.com/nextcloud/integration_openproject/assets/41103328/e01d1687-f9dd-46fb-b5c9-e103ffba5a15)
