### PR TITLE
[WP#52241]update doc for release preparation and also after release

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,15 +586,15 @@ npm run watch
 5. Do QA and fixes of bugs in the release branch
 6. Update `.github/workflows/nighlty-ci-release-branch.yml` to run nightly on release branch
 7. Merge the release branch into the `master` branch, to get all good changes also into the current development
-8. Add change log in `CHANGELOG.md` with version to be released
-9. If any unreleased changes in `CHANGELOG.md` then add to the newly added change log
+8. Add change log in `CHANGELOG.md` with the version to be released
+9. If any unreleased changes in `CHANGELOG.md`, Add them to the newly added change log
 
 ##### b. In case of a patch version
 
 1. On the release branch of the current minor version update the version in `appinfo/info.xml` (not needed for nightly builds)
 2. Merge the release branch into the `master` branch, to get all good changes also into the current development
-3. Add change log in `CHANGELOG.md` with version to be released
-4. If any unreleased changes in `CHANGELOG.md` then add to the newly added change log
+3. Add change log in `CHANGELOG.md` with the version to be released
+4. If any unreleased changes in `CHANGELOG.md`, Add them to the newly added change log
 
 #### 2. Publish Release
 1. Tag a commit on the `release/<version>` branch. The tag must have the format `v2.1.1` for releases and `v2.1.1-20220928-nightly` for nightly builds.

--- a/README.md
+++ b/README.md
@@ -586,11 +586,15 @@ npm run watch
 5. Do QA and fixes of bugs in the release branch
 6. Update `.github/workflows/nighlty-ci-release-branch.yml` to run nightly on release branch
 7. Merge the release branch into the `master` branch, to get all good changes also into the current development
+8. Add change log in `CHANGELOG.md` with version to be released
+9. If any unreleased changes in `CHANGELOG.md` then add to the newly added change log
 
 ##### b. In case of a patch version
 
 1. On the release branch of the current minor version update the version in `appinfo/info.xml` (not needed for nightly builds)
 2. Merge the release branch into the `master` branch, to get all good changes also into the current development
+3. Add change log in `CHANGELOG.md` with version to be released
+4. If any unreleased changes in `CHANGELOG.md` then add to the newly added change log
 
 #### 2. Publish Release
 1. Tag a commit on the `release/<version>` branch. The tag must have the format `v2.1.1` for releases and `v2.1.1-20220928-nightly` for nightly builds.
@@ -599,3 +603,7 @@ npm run watch
    e.g: `git tag v2.0.6-20220928-nightly -m "v2.0.6-20220928-nightly"`
 2. Push the tag to the `auto-release`  branch: `git push origin release/<version>:auto-release --tags -f`
 3. Approve the deployment in GitHub actions
+
+#### 3. After Release
+1. Generate all the change logs for the new version of app on GitHub
+   e.g. for newly created tag vX.X.X, follow `https://github.com/nextcloud/integration_openproject/releases/tag/vX.X.X`


### PR DESCRIPTION
### Description
Now that we have to show the change log in each release. We need to be sure that we add each change log during each release. So this PR adds documentation to add those change log during release. And also Adds documentation to generate change logs in github as well and not only in app store.

### Related WP
https://community.openproject.org/projects/nextcloud-integration/work_packages/52241/activity