### PR TITLE
[WP#52658]Fix undefined array title in error log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 - Replaced vue loading icon with default Nextcloud loading icon [#561](https://github.com/nextcloud/integration_openproject/pull/561)
 - Fixes: Signing terms and services for special user "OpenProject" when `terms_of_service` app is enabled [#552](https://github.com/nextcloud/integration_openproject/pull/552)
-- Fix error log when fetching non-existent work package
+- Fix error log when fetching non-existent work package [#573](https://github.com/nextcloud/integration_openproject/pull/573)
 
 ## 2.6.0 - 2024-01-17
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 - Replaced vue loading icon with default Nextcloud loading icon [#561](https://github.com/nextcloud/integration_openproject/pull/561)
 - Fixes: Signing terms and services for special user "OpenProject" when `terms_of_service` app is enabled [#552](https://github.com/nextcloud/integration_openproject/pull/552)
+- Fix error log when fetching non-existent work package
 
 ## 2.6.0 - 2024-01-17
 ### Changed

--- a/lib/Reference/WorkPackageReferenceProvider.php
+++ b/lib/Reference/WorkPackageReferenceProvider.php
@@ -32,7 +32,6 @@ use OCP\Collaboration\Reference\IReference;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
-use phpDocumentor\Reflection\Types\This;
 
 class WorkPackageReferenceProvider extends ADiscoverableReferenceProvider {
 	private const RICH_OBJECT_TYPE = Application::APP_ID . '_work_package';

--- a/lib/Reference/WorkPackageReferenceProvider.php
+++ b/lib/Reference/WorkPackageReferenceProvider.php
@@ -128,21 +128,21 @@ class WorkPackageReferenceProvider extends ADiscoverableReferenceProvider {
 			$wpId = $this->getWorkPackageIdFromUrl($referenceText);
 			if ($wpId !== null) {
 				$wpInfo = $this->openProjectAPIService->getWorkPackageInfo($this->userId, $wpId);
-
-				$reference = new Reference($referenceText);
-				// this is used if your custom reference widget cannot be loaded (in mobile/desktop clients for example)
-				$reference->setTitle($wpInfo['title']);
-				$reference->setDescription($wpInfo['description']);
-				$reference->setImageUrl($wpInfo['imageUrl']);
-				// this is the data you will get in your custom reference widget
-				$reference->setRichObject(
-					self::RICH_OBJECT_TYPE,
-					$wpInfo['entry']
-				);
-				return $reference;
+                if($wpInfo !== null) {
+                    $reference = new Reference($referenceText);
+                    // this is used if your custom reference widget cannot be loaded (in mobile/desktop clients for example)
+                    $reference->setTitle($wpInfo['title']);
+                    $reference->setDescription($wpInfo['description']);
+                    $reference->setImageUrl($wpInfo['imageUrl']);
+                    // this is the data you will get in your custom reference widget
+                    $reference->setRichObject(
+                        self::RICH_OBJECT_TYPE,
+                        $wpInfo['entry']
+                    );
+                    return $reference;
+                }
 			}
 		}
-
 		return null;
 	}
 

--- a/lib/Reference/WorkPackageReferenceProvider.php
+++ b/lib/Reference/WorkPackageReferenceProvider.php
@@ -32,6 +32,7 @@ use OCP\Collaboration\Reference\IReference;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
+use phpDocumentor\Reflection\Types\This;
 
 class WorkPackageReferenceProvider extends ADiscoverableReferenceProvider {
 	private const RICH_OBJECT_TYPE = Application::APP_ID . '_work_package';
@@ -103,7 +104,6 @@ class WorkPackageReferenceProvider extends ADiscoverableReferenceProvider {
 	}
 
 	/**
-	 * @inheritDoc
 	 */
 	public function matchReference(string $referenceText): bool {
 		if ($this->userId !== null) {
@@ -120,11 +120,14 @@ class WorkPackageReferenceProvider extends ADiscoverableReferenceProvider {
 		return $this->getWorkPackageIdFromUrl($referenceText) !== null;
 	}
 
+	public function getIsAdminConfigOk(): bool {
+		return OpenProjectAPIService::isAdminConfigOk($this->config);
+	}
+
 	/**
-	 * @inheritDoc
 	 */
 	public function resolveReference(string $referenceText): ?IReference {
-		if ($this->matchReference($referenceText) && OpenProjectAPIService::isAdminConfigOk($this->config)) {
+		if ($this->matchReference($referenceText) && $this->getIsAdminConfigOk() ) {
 			$wpId = $this->getWorkPackageIdFromUrl($referenceText);
 			if ($wpId !== null) {
 				$wpInfo = $this->openProjectAPIService->getWorkPackageInfo($this->userId, $wpId);

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -827,6 +827,9 @@ class OpenProjectAPIService {
 		return $result;
 	}
 	/**
+	 *
+	 * @NoCSRFRequired
+	 *
 	 * @param int $workpackageId
 	 * @param string $userId
 	 * @return array<mixed>

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -1280,19 +1280,23 @@ class OpenProjectAPIService {
 	 * @param string $userId
 	 * @param int $wpId
 	 *
-	 * @return array<mixed>
+	 * @return array<mixed>|null
 	 */
-	public function getWorkPackageInfo(string $userId, int $wpId): array {
-		$result[] = null;
+	public function getWorkPackageInfo(string $userId, int $wpId): ?array {
 		$accessToken = $this->config->getUserValue($userId, Application::APP_ID, 'token');
 		if ($accessToken) {
 			$searchResult = $this->searchWorkPackage($userId, null, null, false, $wpId);
+			if (isset($searchResult['error'])) {
+				return null;
+			}
+			$result = [];
 			$result['title'] = $this->getSubline($searchResult[0]);
 			$result['description'] = $this->getMainText($searchResult[0]);
 			$result['imageUrl'] = $this->getOpenProjectUserAvatarUrl($searchResult[0]);
 			$result['entry'] = $searchResult[0];
+			return $result;
 		}
-		return $result;
+		return null;
 	}
 
 	/**

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -827,9 +827,6 @@ class OpenProjectAPIService {
 		return $result;
 	}
 	/**
-	 *
-	 * @NoCSRFRequired
-	 *
 	 * @param int $workpackageId
 	 * @param string $userId
 	 * @return array<mixed>

--- a/tests/lib/Reference/WorkPackageReferenceProviderTest.php
+++ b/tests/lib/Reference/WorkPackageReferenceProviderTest.php
@@ -79,4 +79,52 @@ class WorkPackageReferenceProviderTest extends TestCase {
 
 		$this->assertSame(1111, $result);
 	}
+
+	/**
+	 * @return void
+	 */
+	public function testResolveReferenceWithExistentWorkPackage() {
+		$configMock = $this->getMockBuilder(IConfig::class)->getMock();
+		$configMock->method('getAppValue')->with(Application::APP_ID, 'openproject_instance_url')
+			->willReturn("https://openproject.org");
+		$service = $this->getMockBuilder(OpenProjectAPIService::class)->disableOriginalConstructor()->getMock();
+		$service->method('getWorkPackageInfo')->willReturn(['title' => 'title', 'description' => 'description', 'imageUrl' => 'some image url', 'entry' => []]);
+		$refrenceProviderMock = $this->getMockBuilder(WorkPackageReferenceProvider::class)->setConstructorArgs([
+			$configMock,
+			$this->createMock(IL10N::class),
+			$this->createMock(IURLGenerator::class),
+			$this->createMock(ReferenceManager::class),
+			$service,
+			'testUser'
+		])->onlyMethods(['getIsAdminConfigOk', 'matchReference'])->getMock();
+		$referenceText = 'https://openproject.org/projects/123/work_packages/1111';
+		$refrenceProviderMock->method('matchReference')->with($referenceText)->willReturn(true);
+		$refrenceProviderMock->method('getIsAdminConfigOk')->willReturn(true);
+		$result = $refrenceProviderMock->resolveReference("https://openproject.org/projects/123/work_packages/1111");
+		$this->assertNotNull($result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testResolveReferenceWithNonExistentWorkPackage() {
+		$configMock = $this->getMockBuilder(IConfig::class)->getMock();
+		$configMock->method('getAppValue')->with(Application::APP_ID, 'openproject_instance_url')
+			->willReturn("https://openproject.org");
+		$service = $this->getMockBuilder(OpenProjectAPIService::class)->disableOriginalConstructor()->getMock();
+		$service->method('getWorkPackageInfo')->willReturn(null);
+		$refrenceProviderMock = $this->getMockBuilder(WorkPackageReferenceProvider::class)->setConstructorArgs([
+			$configMock,
+			$this->createMock(IL10N::class),
+			$this->createMock(IURLGenerator::class),
+			$this->createMock(ReferenceManager::class),
+			$service,
+			'testUser'
+		])->onlyMethods(['getIsAdminConfigOk', 'matchReference'])->getMock();
+		$referenceText = 'https://openproject.org/projects/123/work_packages/1111';
+		$refrenceProviderMock->method('matchReference')->with($referenceText)->willReturn(true);
+		$refrenceProviderMock->method('getIsAdminConfigOk')->willReturn(true);
+		$result = $refrenceProviderMock->resolveReference("https://openproject.org/projects/123/work_packages/1111");
+		$this->assertNull($result);
+	}
 }

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -494,6 +494,31 @@ class OpenProjectAPIServiceTest extends TestCase {
 	];
 
 	/**
+	 * @var array<mixed>
+	 */
+	private $wpInformationResponse = [
+		"_type" => "WorkPackage",
+		"id" => 123,
+		"identifier" => "dev-custom-fields",
+		"subject" => "New login screen",
+		"_links" => [
+			"type" => [
+				"title" => "User story"
+			],
+			"status" => [
+				"title" => "In specification"
+			],
+			"project" => [
+				"title" => "Scrum project"
+			],
+			"assignee" => [
+				"href" => "/api/v3/users/3",
+				"title" => "OpenProject Admin"
+			]
+		]
+	];
+
+	/**
 	 * @return void
 	 * @before
 	 */
@@ -716,6 +741,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 	 * @param IConfig|null $configMock
 	 * @param IProvider|null $tokenProviderMock
 	 * @param IDBConnection|null $db
+	 * @param IURLGenerator|null $iURLGenerator
 	 * @return OpenProjectAPIService|MockObject
 	 */
 	private function getServiceMock(
@@ -729,7 +755,8 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$iSecureRandomMock = null,
 		$configMock = null,
 		$tokenProviderMock = null,
-		$db = null
+		$db = null,
+		$iURLGenerator = null
 	): OpenProjectAPIService {
 		$onlyMethods[] = 'getBaseUrl';
 		if ($rootMock === null) {
@@ -762,6 +789,9 @@ class OpenProjectAPIServiceTest extends TestCase {
 		if ($db === null) {
 			$db = $this->createMock(IDBConnection::class);
 		}
+		if ($iURLGenerator === null) {
+			$iURLGenerator = $this->createMock(IURLGenerator::class);
+		}
 		$mock = $this->getMockBuilder(OpenProjectAPIService::class)
 			->setConstructorArgs(
 				[
@@ -772,7 +802,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 					$configMock,
 					$this->createMock(IClientService::class),
 					$rootMock,
-					$this->createMock(IURLGenerator::class),
+					$iURLGenerator,
 					$cacheFactoryMock,
 					$userManagerMock,
 					$groupManagerMock,
@@ -781,7 +811,8 @@ class OpenProjectAPIServiceTest extends TestCase {
 					$iSecureRandomMock,
 					$this->createMock(IEventDispatcher::class),
 					$subAdminManagerMock,
-					$db
+					$db,
+					$iURLGenerator
 				])
 			->onlyMethods($onlyMethods)
 			->getMock();
@@ -3476,7 +3507,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$this->assertSame($expectedResult, $result);
 	}
 
-	public function testGetSubline() {
+	public function testGetSubline(): void {
 		$configMock = $this->getMockBuilder(IConfig::class)->getMock();
 		$configMock->method('getUserValue')->with('testUser', Application::APP_ID, 'token')
 			->willReturn("access-token");
@@ -3493,32 +3524,11 @@ class OpenProjectAPIServiceTest extends TestCase {
 			null,
 			$configMock
 		);
-		$wpInformationResponse = [
-			"_type" => "WorkPackage",
-			"id" => 123,
-			"identifier" => "dev-custom-fields",
-			"subject" => "New login screen",
-			"_links" => [
-				"type" => [
-					"title" => "User story"
-				],
-				"status" => [
-					"title" => "In specification"
-				],
-				"project" => [
-					"title" => "Scrum project"
-				],
-				"assignee" => [
-					"href" => "/api/v3/users/3",
-					"title" => "OpenProject Admin"
-				]
-			]
-		];
-		$resultTitle = $service->getSubline($wpInformationResponse);
+		$resultTitle = $service->getSubline($this->wpInformationResponse);
 		$this->assertSame("#123 [In specification] Scrum project", $resultTitle);
 	}
 
-	public function testGetMainText() {
+	public function testGetMainText() : void {
 		$configMock = $this->getMockBuilder(IConfig::class)->getMock();
 		$configMock->method('getUserValue')->with('testUser', Application::APP_ID, 'token')
 			->willReturn("access-token");
@@ -3535,28 +3545,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 			null,
 			$configMock
 		);
-		$wpInformationResponse = [
-			"_type" => "WorkPackage",
-			"id" => 123,
-			"identifier" => "dev-custom-fields",
-			"subject" => "New login screen",
-			"_links" => [
-				"type" => [
-					"title" => "User story"
-				],
-				"status" => [
-					"title" => "In specification"
-				],
-				"project" => [
-					"title" => "Scrum project"
-				],
-				"assignee" => [
-					"href" => "/api/v3/users/3",
-					"title" => "OpenProject Admin"
-				]
-			]
-		];
-		$resultMainText = $service->getMainText($wpInformationResponse);
+		$resultMainText = $service->getMainText($this->wpInformationResponse);
 		$this->assertSame("USER STORY: New login screen", $resultMainText);
 	}
 
@@ -3566,6 +3555,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 			->willReturn("access-token");
 		$userManagerMock = $this->getMockBuilder(IUserManager::class)
 			->getMock();
+		$iULGeneratorMock = $this->getMockBuilder(IURLGenerator::class)->getMock();
 		$service = $this->getServiceMock(
 			['searchWorkPackage'],
 			null,
@@ -3575,34 +3565,24 @@ class OpenProjectAPIServiceTest extends TestCase {
 			null,
 			null,
 			null,
-			$configMock
+			$configMock,
+			null,
+			null,
+			$iULGeneratorMock
 		);
-		$wpInformationResponse = [
-			[
-				"_type" => "WorkPackage",
-				"id" => 123,
-				"identifier" => "dev-custom-fields",
-				"subject" => "New login screen",
-				"_links" => [
-					"type" => [
-						"title" => "User story"
-					],
-					"status" => [
-						"title" => "In specification"
-					],
-					"project" => [
-						"title" => "Scrum project"
-					],
-					"assignee" => [
-						"href" => "/api/v3/users/3",
-						"title" => "OpenProject Admin"
-					]
-				]
-			],
+		$imageURL = 'http://nextcloud/server/index.php/apps/integration_openproject/avatar?userId=3&userName=OpenProject Admin';
+		$iULGeneratorMock->method('getAbsoluteURL')->willReturn($imageURL);
+		$testUser = 'testUser';
+		$workPackageId = 123;
+		$service->method('searchWorkPackage')->with($testUser, null, null, false, $workPackageId)->willReturn([$this->wpInformationResponse]);
+		$resultGetWorkPackageInfo = $service->getWorkPackageInfo($testUser, $workPackageId);
+		$expectedGetWorkPackageInfo = [
+			"title" => '#123 [In specification] Scrum project',
+			"description" => 'USER STORY: New login screen',
+			"imageUrl" => $imageURL,
+			"entry" => $this->wpInformationResponse,
 		];
-		$service->method('searchWorkPackage')->with('testUser', null, null, false, 123)->willReturn($wpInformationResponse);
-		$resultGetWorkPackageInfo = $service->getWorkPackageInfo('testUser', '123');
-		$this->assertNotEmpty($resultGetWorkPackageInfo);
+		self::assertSame($expectedGetWorkPackageInfo, $resultGetWorkPackageInfo);
 	}
 
 	public function testGetWorkPackageInfoForNonExistentWorkPackage(): void {
@@ -3624,7 +3604,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 		);
 		$wpInformationResponse = ["error" => []];
 		$service->method('searchWorkPackage')->with('testUser', null, null, false, 123)->willReturn($wpInformationResponse);
-		$resultGetWorkPackageInfo = $service->getWorkPackageInfo('testUser', '123');
+		$resultGetWorkPackageInfo = $service->getWorkPackageInfo('testUser', 123);
 		$this->assertNull($resultGetWorkPackageInfo);
 	}
 
@@ -3645,7 +3625,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 			null,
 			$configMock
 		);
-		$resultGetWorkPackageInfo = $service->getWorkPackageInfo('testUser', '123');
+		$resultGetWorkPackageInfo = $service->getWorkPackageInfo('testUser', 123);
 		$this->assertNull($resultGetWorkPackageInfo);
 	}
 }

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -3475,4 +3475,177 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$result = $service->isAllTermsOfServiceSignedForUserOpenProject($signatoryMapperMock);
 		$this->assertSame($expectedResult, $result);
 	}
+
+	public function testGetSubline() {
+		$configMock = $this->getMockBuilder(IConfig::class)->getMock();
+		$configMock->method('getUserValue')->with('testUser', Application::APP_ID, 'token')
+			->willReturn("access-token");
+		$userManagerMock = $this->getMockBuilder(IUserManager::class)
+			->getMock();
+		$service = $this->getServiceMock(
+			['searchWorkPackage'],
+			null,
+			null,
+			$userManagerMock,
+			null,
+			null,
+			null,
+			null,
+			$configMock
+		);
+		$wpInformationResponse = [
+			"_type" => "WorkPackage",
+			"id" => 123,
+			"identifier" => "dev-custom-fields",
+			"subject" => "New login screen",
+			"_links" => [
+				"type" => [
+					"title" => "User story"
+				],
+				"status" => [
+					"title" => "In specification"
+				],
+				"project" => [
+					"title" => "Scrum project"
+				],
+				"assignee" => [
+					"href" => "/api/v3/users/3",
+					"title" => "OpenProject Admin"
+				]
+			]
+		];
+		$resultTitle = $service->getSubline($wpInformationResponse);
+		$this->assertSame("#123 [In specification] Scrum project", $resultTitle);
+	}
+
+	public function testGetMainText() {
+		$configMock = $this->getMockBuilder(IConfig::class)->getMock();
+		$configMock->method('getUserValue')->with('testUser', Application::APP_ID, 'token')
+			->willReturn("access-token");
+		$userManagerMock = $this->getMockBuilder(IUserManager::class)
+			->getMock();
+		$service = $this->getServiceMock(
+			['searchWorkPackage'],
+			null,
+			null,
+			$userManagerMock,
+			null,
+			null,
+			null,
+			null,
+			$configMock
+		);
+		$wpInformationResponse = [
+			"_type" => "WorkPackage",
+			"id" => 123,
+			"identifier" => "dev-custom-fields",
+			"subject" => "New login screen",
+			"_links" => [
+				"type" => [
+					"title" => "User story"
+				],
+				"status" => [
+					"title" => "In specification"
+				],
+				"project" => [
+					"title" => "Scrum project"
+				],
+				"assignee" => [
+					"href" => "/api/v3/users/3",
+					"title" => "OpenProject Admin"
+				]
+			]
+		];
+		$resultMainText = $service->getMainText($wpInformationResponse);
+		$this->assertSame("USER STORY: New login screen", $resultMainText);
+	}
+
+	public function testGetWorkPackageInfoForExistentWorkPackage(): void {
+		$configMock = $this->getMockBuilder(IConfig::class)->getMock();
+		$configMock->method('getUserValue')->with('testUser', Application::APP_ID, 'token')
+			->willReturn("access-token");
+		$userManagerMock = $this->getMockBuilder(IUserManager::class)
+			->getMock();
+		$service = $this->getServiceMock(
+			['searchWorkPackage'],
+			null,
+			null,
+			$userManagerMock,
+			null,
+			null,
+			null,
+			null,
+			$configMock
+		);
+		$wpInformationResponse = [
+			[
+				"_type" => "WorkPackage",
+				"id" => 123,
+				"identifier" => "dev-custom-fields",
+				"subject" => "New login screen",
+				"_links" => [
+					"type" => [
+						"title" => "User story"
+					],
+					"status" => [
+						"title" => "In specification"
+					],
+					"project" => [
+						"title" => "Scrum project"
+					],
+					"assignee" => [
+						"href" => "/api/v3/users/3",
+						"title" => "OpenProject Admin"
+					]
+				]
+			],
+		];
+		$service->method('searchWorkPackage')->with('testUser', null, null, false, 123)->willReturn($wpInformationResponse);
+		$resultGetWorkPackageInfo = $service->getWorkPackageInfo('testUser', '123');
+		$this->assertNotEmpty($resultGetWorkPackageInfo);
+	}
+
+	public function testGetWorkPackageInfoForNonExistentWorkPackage(): void {
+		$configMock = $this->getMockBuilder(IConfig::class)->getMock();
+		$configMock->method('getUserValue')->with('testUser', Application::APP_ID, 'token')
+			->willReturn("access-token");
+		$userManagerMock = $this->getMockBuilder(IUserManager::class)
+			->getMock();
+		$service = $this->getServiceMock(
+			['searchWorkPackage'],
+			null,
+			null,
+			$userManagerMock,
+			null,
+			null,
+			null,
+			null,
+			$configMock
+		);
+		$wpInformationResponse = ["error" => []];
+		$service->method('searchWorkPackage')->with('testUser', null, null, false, 123)->willReturn($wpInformationResponse);
+		$resultGetWorkPackageInfo = $service->getWorkPackageInfo('testUser', '123');
+		$this->assertNull($resultGetWorkPackageInfo);
+	}
+
+	public function testGetWorkPackageInfoForNoUserAccessToken(): void {
+		$configMock = $this->getMockBuilder(IConfig::class)->getMock();
+		$configMock->method('getUserValue')->with('testUser', Application::APP_ID, 'token')
+			->willReturn(null);
+		$userManagerMock = $this->getMockBuilder(IUserManager::class)
+			->getMock();
+		$service = $this->getServiceMock(
+			['searchWorkPackage'],
+			null,
+			null,
+			$userManagerMock,
+			null,
+			null,
+			null,
+			null,
+			$configMock
+		);
+		$resultGetWorkPackageInfo = $service->getWorkPackageInfo('testUser', '123');
+		$this->assertNull($resultGetWorkPackageInfo);
+	}
 }


### PR DESCRIPTION
## Description
Through the talk app we can search for the work package and we send the link of the work package in the chat where there is minimal UI of the workpackage displayed in the chat section. But when the url have the `work package-id` for eg. `https://openproject.local/wp/<non-existent-workpackage-id>` it throws the error since we did not check the error when doing a search request for the work packge with the id `non-existent-workpackage-id` which seems to be the main cause of this error.

Now when we do the send the url `https://openproject.local/wp/<non-existent-workpackage-id>` some thing like this in the chat we get only warning logs as:

![integration-warning](https://github.com/nextcloud/integration_openproject/assets/46086950/7f4fad4d-234f-4f8a-90af-70c9ecfa97fd)


## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://community.openproject.org/projects/nextcloud-integration/work_packages/52658/activity

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Updated `CHANGELOG.md` file
