### PR TITLE
[WP #52987] Link to groupfolders app in app store

### DIFF
--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -617,9 +617,11 @@ export default {
 			}
 		},
 		projectFolderSetUpErrorMessageDescription(errorKey) {
+			const linkText = t('integration_openproject', 'from here')
+			const htmlLink = `<a class="link" href="https://apps.nextcloud.com/apps/groupfolders" target="_blank" title="${linkText}">${linkText}</a>`
 			switch (errorKey) {
 			case 'The "Group folders" app is not installed' :
-				return t('integration_openproject', 'Please install the "Group folders" app to be able to use automatic managed folders or deactivate the automatically managed folders.')
+				return t('integration_openproject', 'Please install the "Group folders" app to be able to use automatic managed folders or deactivate the automatically managed folders. You can download and install the "Group folders" app {htmlLink}.', { htmlLink }, null, { escape: false, sanitize: false })
 			default:
 				return this.errorHintForProjectFolderConfigAlreadyExists
 			}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
In this PR, The `Group folders` app store link has been added to the error message regarding missing `Group folders` apps.

## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Related to https://community.openproject.org/work_packages/52987/activity

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->
The red line that follows has been added as shown in figure.
![Screenshot from 2024-02-22 17-46-51](https://github.com/nextcloud/integration_openproject/assets/61624650/5c46c5b3-fa7f-40e3-a72e-76d55eee8a0d)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
