### PR TITLE
[WP#53002]Fix/wrong template and refactor validation for workpackage created from NC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Adjust dashboard panel of `integration app` consistent to that dashboard panel of other nextcloud apps
 - Adjust padding for assignee avatar in `workpackage` template
 - Fixes wrong option text while searching workpackage.
+- Improves form validation for creating workpackages from nextcloud.
 
 ## 2.6.1 - 2024-02-19
 ### Changed

--- a/jest.config.js
+++ b/jest.config.js
@@ -15,5 +15,6 @@ module.exports = {
 	coverageReporters: ['lcov', 'html', 'text'],
 	transformIgnorePatterns: [
 		'node_modules/(?!(vue-material-design-icons|@nextcloud/vue-select)/)',
-	]
+	],
+	setupFiles: ["<rootDir>/tests/jest/global.mock.js"]
 }

--- a/tests/jest/fixtures/workpackageFormValidationProjectSelectedResponse.json
+++ b/tests/jest/fixtures/workpackageFormValidationProjectSelectedResponse.json
@@ -3,7 +3,7 @@
 		"subject": null,
 		"description": {
 			"format": "markdown",
-			"raw": "",
+			"raw": "Default New task template",
 			"html": ""
 		},
 		"scheduleManually": false,

--- a/tests/jest/global.mock.js
+++ b/tests/jest/global.mock.js
@@ -1,0 +1,1 @@
+global.structuredClone = v => JSON.parse(JSON.stringify(v))


### PR DESCRIPTION
## Description
This PR refactors the form validation for creating workpackage from nextcloud.

- Fixes the wrong template shown which does not match according to the selected project types. Previously it might been have been occurred because the all the values passed in the form might have not been reset properly.
- Also makes the form validation functionality same as that of openproject as it was missing in the form validation which includes do not show type and status when those are not available when selecting or switching between projects
- Also not to change the description template once they have been edited by the workpackage creator.


## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://community.openproject.org/projects/nextcloud-integration/work_packages/53002/activity
- potentially fixes this https://community.openproject.org/projects/nextcloud-integration/work_packages/53003

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [x] Updated `CHANGELOG.md` file
