### PR TITLE
change url for groupfolder apps on admin tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- Add quick link for `group folder` app when not downloaded and enabled (project folder setup)
 
 ## 2.6.1 - 2024-02-19
 ### Changed

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -617,11 +617,12 @@ export default {
 			}
 		},
 		projectFolderSetUpErrorMessageDescription(errorKey) {
-			const linkText = t('integration_openproject', 'from here')
-			const htmlLink = `<a class="link" href="https://apps.nextcloud.com/apps/groupfolders" target="_blank" title="${linkText}">${linkText}</a>`
+			const linkText = t('integration_openproject', 'Download and enable it here')
+			const url = generateUrl('settings/apps/files/groupfolders')
+			const htmlLink = `<a class="link" href="${url}" target="_blank" title="${linkText}">${linkText}</a>`
 			switch (errorKey) {
 			case 'The "Group folders" app is not installed' :
-				return t('integration_openproject', 'Please install the "Group folders" app to be able to use automatic managed folders or deactivate the automatically managed folders. You can download and install the "Group folders" app {htmlLink}.', { htmlLink }, null, { escape: false, sanitize: false })
+				return t('integration_openproject', 'Please install the "Group folders" app to be able to use automatically managed folders, {htmlLink}', { htmlLink }, null, { escape: false, sanitize: false })
 			default:
 				return this.errorHintForProjectFolderConfigAlreadyExists
 			}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Previously in [PR-579](https://github.com/nextcloud/integration_openproject/pull/579) the group folder url was https://apps.nextcloud.com/apps/groupfolders 
and Now in this PR the group folder URL is change which redirect to settings/apps/groupfolder
![image](https://github.com/nextcloud/integration_openproject/assets/61624650/619a6a6b-bbc5-494e-84b7-1d000b5147d7)

## Related issue
https://community.openproject.org/projects/nextcloud-integration/work_packages/52987/activity

## Screenshot
![image](https://github.com/nextcloud/integration_openproject/assets/61624650/d738eaa6-a610-42a4-8a1b-92daf0d62c3f)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
