### PR TITLE
Fix workpackage not found when searching workpackage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add quick link for `group folder` app when not downloaded and enabled (project folder setup)
 - Adjust dashboard panel of `integration app` consistent to that dashboard panel of other nextcloud apps
 - Adjust padding for assignee avatar in `workpackage` template
-- Fixes wrong option text while searching workpackage. [582](https://github.com/nextcloud/integration_openproject/pull/582)
+- Fixes wrong option text while searching workpackage.
 
 ## 2.6.1 - 2024-02-19
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add quick link for `group folder` app when not downloaded and enabled (project folder setup)
 - Adjust dashboard panel of `integration app` consistent to that dashboard panel of other nextcloud apps
 - Adjust padding for assignee avatar in `workpackage` template
+- Fixes wrong option text while searching workpackage. [582](https://github.com/nextcloud/integration_openproject/pull/582)
 
 ## 2.6.1 - 2024-02-19
 ### Changed

--- a/src/components/tab/SearchInput.vue
+++ b/src/components/tab/SearchInput.vue
@@ -134,7 +134,7 @@ export default {
 			if (this.noOptionTextState === NO_OPTION_TEXT_STATE.START_TYPING) {
 				return t('integration_openproject', 'Start typing to search')
 			} else if (this.noOptionTextState === NO_OPTION_TEXT_STATE.RESULT && this.searchResults.length === 0) {
-				return t('integration_openproject', 'There were no workpackages found!')
+				return t('integration_openproject', 'There were no workpackages found')
 			} else {
 				// while workpackages are being searched we make the no text option empty
 				return t('integration_openproject', '')

--- a/src/components/tab/SearchInput.vue
+++ b/src/components/tab/SearchInput.vue
@@ -63,7 +63,7 @@ import WorkPackage from './WorkPackage.vue'
 import { showError, showSuccess } from '@nextcloud/dialogs'
 import '@nextcloud/dialogs/styles/toast.scss'
 import { workpackageHelper } from '../../utils/workpackageHelper.js'
-import { NO_OPTION_TEXT, STATE, WORKPACKAGES_SEARCH_ORIGIN } from '../../utils.js'
+import { NO_OPTION_TEXT_STATE, STATE, WORKPACKAGES_SEARCH_ORIGIN } from '../../utils.js'
 import { translate as t } from '@nextcloud/l10n'
 import Plus from 'vue-material-design-icons/Plus.vue'
 import CreateWorkPackageModal from '../../views/CreateWorkPackageModal.vue'
@@ -113,7 +113,7 @@ export default {
 		isCreateWorkpackageModalVisible: false,
 		newWorkpackageCreated: false,
 		workpackageData: [], // only for newly created workpackages
-		noOptionTextState: NO_OPTION_TEXT.START_TYPING,
+		noOptionTextState: NO_OPTION_TEXT_STATE.START_TYPING,
 	}),
 	computed: {
 		isStateOk() {
@@ -131,9 +131,9 @@ export default {
 			return ''
 		},
 		getNoOptionText() {
-			if (this.noOptionTextState === NO_OPTION_TEXT.START_TYPING) {
+			if (this.noOptionTextState === NO_OPTION_TEXT_STATE.START_TYPING) {
 				return t('integration_openproject', 'Start typing to search')
-			} else if (this.noOptionTextState === NO_OPTION_TEXT.RESULT && this.searchResults.length === 0) {
+			} else if (this.noOptionTextState === NO_OPTION_TEXT_STATE.RESULT && this.searchResults.length === 0) {
 				return t('integration_openproject', 'There were no workpackages found!')
 			} else {
 				// while workpackages are being searched we make the no text option empty
@@ -207,7 +207,7 @@ export default {
 			}
 		},
 		async asyncFind(query) {
-			this.noOptionTextState = (!query) ? NO_OPTION_TEXT.START_TYPING : NO_OPTION_TEXT.SEARCHING
+			this.noOptionTextState = (query.trim() === '') ? NO_OPTION_TEXT_STATE.START_TYPING : NO_OPTION_TEXT_STATE.SEARCHING
 			this.resetState()
 			if (this.searchOrigin === WORKPACKAGES_SEARCH_ORIGIN.PROJECT_TAB) {
 				await this.debounceMakeSearchRequest(query, this.fileInfo.id)
@@ -272,9 +272,10 @@ export default {
 			}
 			if (this.isStateLoading) {
 				this.state = STATE.OK
-				this.noOptionTextState = NO_OPTION_TEXT.RESULT
 			}
-
+			if (search.trim() !== '') {
+				this.noOptionTextState = NO_OPTION_TEXT_STATE.RESULT
+			}
 		},
 		async processWorkPackages(workPackages, fileId) {
 			for (let workPackage of workPackages) {

--- a/src/components/tab/SearchInput.vue
+++ b/src/components/tab/SearchInput.vue
@@ -20,7 +20,7 @@
 					:is-smart-picker="isSmartPicker" />
 			</template>
 			<template #no-options>
-				{{ noOptionsText }}
+				{{ getNoOptionText }}
 			</template>
 			<template v-if="!isSmartPicker" #list-footer>
 				<li class="create-workpackage-footer-option" @click="openCreateWorkpackageModal()">
@@ -63,7 +63,7 @@ import WorkPackage from './WorkPackage.vue'
 import { showError, showSuccess } from '@nextcloud/dialogs'
 import '@nextcloud/dialogs/styles/toast.scss'
 import { workpackageHelper } from '../../utils/workpackageHelper.js'
-import { STATE, WORKPACKAGES_SEARCH_ORIGIN } from '../../utils.js'
+import { NO_OPTION_TEXT, STATE, WORKPACKAGES_SEARCH_ORIGIN } from '../../utils.js'
 import { translate as t } from '@nextcloud/l10n'
 import Plus from 'vue-material-design-icons/Plus.vue'
 import CreateWorkPackageModal from '../../views/CreateWorkPackageModal.vue'
@@ -109,11 +109,11 @@ export default {
 	data: () => ({
 		state: STATE.OK,
 		searchResults: [],
-		noOptionsText: t('integration_openproject', 'Start typing to search'),
 		openprojectUrl: loadState('integration_openproject', 'openproject-url'),
 		isCreateWorkpackageModalVisible: false,
 		newWorkpackageCreated: false,
 		workpackageData: [], // only for newly created workpackages
+		noOptionTextState: NO_OPTION_TEXT.START_TYPING,
 	}),
 	computed: {
 		isStateOk() {
@@ -129,6 +129,16 @@ export default {
 				return t('integration_openproject', 'Error connecting to OpenProject')
 			}
 			return ''
+		},
+		getNoOptionText() {
+			if (this.noOptionTextState === NO_OPTION_TEXT.START_TYPING) {
+				return t('integration_openproject', 'Start typing to search')
+			} else if (this.noOptionTextState === NO_OPTION_TEXT.RESULT && this.searchResults.length === 0) {
+				return t('integration_openproject', 'There were no workpackages found!')
+			} else {
+				// while workpackages are being searched we make the no text option empty
+				return t('integration_openproject', '')
+			}
 		},
 		setOptionForSearch() {
 			if (this.searchOrigin === WORKPACKAGES_SEARCH_ORIGIN.PROJECT_TAB || this.isSmartPicker) {
@@ -197,6 +207,7 @@ export default {
 			}
 		},
 		async asyncFind(query) {
+			this.noOptionTextState = (!query) ? NO_OPTION_TEXT.START_TYPING : NO_OPTION_TEXT.SEARCHING
 			this.resetState()
 			if (this.searchOrigin === WORKPACKAGES_SEARCH_ORIGIN.PROJECT_TAB) {
 				await this.debounceMakeSearchRequest(query, this.fileInfo.id)
@@ -256,8 +267,14 @@ export default {
 				response = e.response
 			}
 			this.checkForErrorCode(response.status)
-			if (response.status === 200) await this.processWorkPackages(response.data, fileId)
-			if (this.isStateLoading) this.state = STATE.OK
+			if (response.status === 200) {
+				await this.processWorkPackages(response.data, fileId)
+			}
+			if (this.isStateLoading) {
+				this.state = STATE.OK
+				this.noOptionTextState = NO_OPTION_TEXT.RESULT
+			}
+
 		},
 		async processWorkPackages(workPackages, fileId) {
 			for (let workPackage of workPackages) {

--- a/src/components/tab/SearchInput.vue
+++ b/src/components/tab/SearchInput.vue
@@ -131,14 +131,17 @@ export default {
 			return ''
 		},
 		getNoOptionText() {
-			if (this.noOptionTextState === NO_OPTION_TEXT_STATE.START_TYPING) {
+			switch (this.noOptionTextState) {
+			case NO_OPTION_TEXT_STATE.START_TYPING :
 				return t('integration_openproject', 'Start typing to search')
-			} else if (this.noOptionTextState === NO_OPTION_TEXT_STATE.RESULT && this.searchResults.length === 0) {
-				return t('integration_openproject', 'There were no workpackages found')
-			} else {
-				// while workpackages are being searched we make the no text option empty
-				return t('integration_openproject', '')
+			case NO_OPTION_TEXT_STATE.RESULT :
+				if (this.searchResults.length === 0) {
+					return t('integration_openproject', 'There were no workpackages found')
+				}
+				break
 			}
+			// while workpackages are being searched we make the no text option empty
+			return ''
 		},
 		setOptionForSearch() {
 			if (this.searchOrigin === WORKPACKAGES_SEARCH_ORIGIN.PROJECT_TAB || this.isSmartPicker) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -54,7 +54,7 @@ export const WORKPACKAGES_SEARCH_ORIGIN = {
 	LINK_MULTIPLE_FILES_MODAL: 'link-multiple-files-modal',
 }
 
-export const NO_OPTION_TEXT = {
+export const NO_OPTION_TEXT_STATE = {
 	START_TYPING: 0,
 	SEARCHING: 1,
 	RESULT: 2,

--- a/src/utils.js
+++ b/src/utils.js
@@ -53,3 +53,9 @@ export const WORKPACKAGES_SEARCH_ORIGIN = {
 	PROJECT_TAB: 'project-tab',
 	LINK_MULTIPLE_FILES_MODAL: 'link-multiple-files-modal',
 }
+
+export const NO_OPTION_TEXT = {
+	START_TYPING: 0,
+	SEARCHING: 1,
+	RESULT: 2,
+}

--- a/tests/jest/components/tab/SearchInput.spec.js
+++ b/tests/jest/components/tab/SearchInput.spec.js
@@ -604,10 +604,10 @@ describe('SearchInput.vue', () => {
 				},
 			],
 			[
-				'should set no option text to "There were no workpackages found!" for search query not matched',
+				'should set no option text to "There were no workpackages found" for search query not matched',
 				{
 					searchQuery: 'query-not-matched',
-					expectedNoOptionText: 'There were no workpackages found!',
+					expectedNoOptionText: 'There were no workpackages found',
 				},
 			],
 		])('%s', async (name, expectedDetails) => {

--- a/tests/jest/components/tab/SearchInput.spec.js
+++ b/tests/jest/components/tab/SearchInput.spec.js
@@ -71,6 +71,7 @@ describe('SearchInput.vue', () => {
 	const createWorkpackageButtonSelector = '.create-workpackage--button'
 	const createWorkPackageNcSelectOptionListSelector = '.create-workpackage-footer-option'
 	const createWorkpackageModalSelector = '[data-test-id="create-workpackage-modal"]'
+	const noOptionTextSelector = '[role="listbox"] .vs__no-options'
 
 	afterEach(() => {
 		wrapper.destroy()
@@ -593,6 +594,40 @@ describe('SearchInput.vue', () => {
 			id: 456,
 			name: 'pogo.png',
 		}]
+
+		it.only.each([
+			[
+				'should set no option text to "Start typing to search" for empty search',
+				{
+					searchQuery: ' ',
+					expectedNoOptionText: 'Start typing to search',
+				},
+			],
+			[
+				'should set no option text to "There were no workpackages found!" for search query not matched',
+				{
+					searchQuery: 'query-not-matched',
+					expectedNoOptionText: 'There were no workpackages found!',
+				},
+			],
+		])('%s', async (name, expectedDetails) => {
+			wrapper = mountSearchInput(singleFileInfo)
+			await wrapper.setProps({
+				searchOrigin: WORKPACKAGES_SEARCH_ORIGIN.PROJECT_TAB,
+			})
+			jest.spyOn(axios, 'get')
+				.mockImplementationOnce(() => Promise.resolve({
+					status: 200,
+					data: [],
+				}))
+			const inputField = wrapper.find(inputSelector)
+			await inputField.setValue(expectedDetails.searchQuery)
+			await localVue.nextTick()
+			const noOptionText = wrapper.find(noOptionTextSelector)
+			expect(noOptionText.isVisible()).toBe(true)
+			expect(noOptionText.text()).toBe(expectedDetails.expectedNoOptionText)
+		})
+
 		describe('single file selected', () => {
 			describe('select a work package for linking', () => {
 				let axiosGetSpy


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR fixes the the display of the text when there is search query typed already while searching the workpackes but still gives the wrong text as `Start typing to search`.


## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://community.openproject.org/projects/nextcloud-integration/work_packages/52956

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [x] Updated `CHANGELOG.md` file
