### PR TITLE
adjust the panel content color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 - Add quick link for `group folder` app when not downloaded and enabled (project folder setup)
+- Adjust dashboard panel of `integration app` consistent to that dashboard panel of other nextcloud apps
 
 ## 2.6.1 - 2024-02-19
 ### Changed

--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -22,6 +22,16 @@ body.theme--dark .icon-openproject {
 	height: 100%;
 	align-items: start;
 	justify-content: center;
+	color: var(--color-text-maxcontrast);
+}
+
+.panel--content .empty-content .empty-content--message--title {
+	font-weight: normal;
+	font-size: 100%;
+}
+
+.panel--content .empty-content .empty-content--icon {
+	opacity: .4;
 }
 
 .panel > .panel--header .icon-openproject::before {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
In this PR there is working for the panel content to adjust the color consistent with the `nextcloud` panel
![image](https://github.com/nextcloud/integration_openproject/assets/61624650/6d38a40c-6df4-4658-9d2b-496b9d5526e9)


## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://community.openproject.org/projects/nextcloud-integration/work_packages/52979/activity

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->
After adjusting the UI look like this
### dark mode
![image](https://github.com/nextcloud/integration_openproject/assets/61624650/f462359d-b2c7-421d-8ed0-a9864d2120eb)

### light mode
![image](https://github.com/nextcloud/integration_openproject/assets/61624650/6473be7b-35bd-4d23-b6b6-23737714efbf)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Updated `CHANGELOG.md` file
