### PR TITLE
adjust the left align between the row-task-status and row-assigned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 - Add quick link for `group folder` app when not downloaded and enabled (project folder setup)
 - Adjust dashboard panel of `integration app` consistent to that dashboard panel of other nextcloud apps
+- Adjust padding for assignee avatar in `workpackage` template
 
 ## 2.6.1 - 2024-02-19
 ### Changed

--- a/src/components/tab/WorkPackage.vue
+++ b/src/components/tab/WorkPackage.vue
@@ -294,7 +294,6 @@ export default {
 		&__assignee {
 			display: flex;
 			flex-direction: row;
-			padding: 5px;
 
 			&__assignee {
 				font-size: 0.81rem;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
There is a gap which is denoted by a horizontal red arrow line. In this PR, the left align is removed between the the row-task-status and row-assigned.
![3)level-milauni new ra OA lekheko-that means picture](https://github.com/nextcloud/integration_openproject/assets/61624650/f7aaaa9e-bc0f-409b-9605-6540cbdb9f8d)



## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes [issue_link](https://community.openproject.org/projects/nextcloud-integration/work_packages/52957/activity)

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->
After adjusting the UI looks like this
![image](https://github.com/nextcloud/integration_openproject/assets/61624650/94f1e7d1-b013-4024-b2cc-9a6ad836c380)



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Updated `CHANGELOG.md` file
