### PR TITLE
[WP#52955]Added link to documentation and user guide for integration setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Adjust padding for assignee avatar in `workpackage` template
 - Fixes wrong option text while searching workpackage.
 - Improves form validation for creating workpackages from nextcloud.
+- Added setup and user guide documentation link for integration app
 
 ## 2.6.1 - 2024-02-19
 ### Changed

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -574,6 +574,7 @@ export default {
 				}
 				if (this.state.openproject_instance_url && this.state.openproject_client_id && this.state.openproject_client_secret && this.state.nc_oauth_client) {
 					this.showDefaultManagedProjectFolders = true
+					this.showIntegrationSetupLinkInformation = false
 				}
 				if (this.state.openproject_instance_url) {
 					this.formMode.server = F_MODES.VIEW
@@ -607,7 +608,6 @@ export default {
 				if (this.showDefaultManagedProjectFolders) {
 					this.formMode.projectFolderSetUp = F_MODES.VIEW
 					this.isFormCompleted.projectFolderSetUp = true
-					this.showIntegrationSetupLinkInformation = false
 				}
 				if (this.state.app_password_set) {
 					this.formMode.opUserAppPassword = F_MODES.VIEW

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -1,7 +1,7 @@
 <template>
 	<div id="openproject_prefs" class="section">
 		<TermsOfServiceUnsigned :is-all-terms-of-service-signed-for-user-open-project="isAllTermsOfServiceSignedForUserOpenProject" />
-		<SettingsTitle />
+		<SettingsTitle :show-integration-setup-link-information="showIntegrationSetupLinkInformation" is-setting="admin" />
 		<div class="openproject-server-host">
 			<FormHeading index="1"
 				:title="t('integration_openproject', 'OpenProject server')"
@@ -426,6 +426,7 @@ export default {
 			isFormStep: null,
 			isDarkTheme: null,
 			isAllTermsOfServiceSignedForUserOpenProject: true,
+			showIntegrationSetupLinkInformation: true,
 		}
 	},
 	computed: {
@@ -606,6 +607,7 @@ export default {
 				if (this.showDefaultManagedProjectFolders) {
 					this.formMode.projectFolderSetUp = F_MODES.VIEW
 					this.isFormCompleted.projectFolderSetUp = true
+					this.showIntegrationSetupLinkInformation = false
 				}
 				if (this.state.app_password_set) {
 					this.formMode.opUserAppPassword = F_MODES.VIEW

--- a/src/components/PersonalSettings.vue
+++ b/src/components/PersonalSettings.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="openproject-prefs section">
-		<SettingsTitle />
+		<SettingsTitle :is-connected-with-openproject="!!connected" is-setting="personal" />
 		<div v-if="connected" class="openproject-prefs--connected">
 			<label>
 				<CheckIcon :size="20" />

--- a/src/components/settings/SettingsTitle.vue
+++ b/src/components/settings/SettingsTitle.vue
@@ -1,39 +1,85 @@
 <template>
-	<h2 class="settings-title">
-		<OpenProjectIcon />
-		<span>{{ title }}</span>
-	</h2>
+	<div class="settings">
+		<h2 class="settings--title">
+			<OpenProjectIcon />
+			<span>{{ title }}</span>
+		</h2>
+		<p v-html="sanitizedHintText" /> <!-- eslint-disable-line vue/no-v-html -->
+	</div>
 </template>
 
 <script>
 import { translate as t } from '@nextcloud/l10n'
 import OpenProjectIcon from '../icons/OpenProjectIcon.vue'
+import dompurify from 'dompurify'
 
 export default {
 	name: 'SettingsTitle',
 	components: {
 		OpenProjectIcon,
 	},
+	props: {
+		isSetting: {
+			type: String,
+			required: true,
+		},
+		isConnectedWithOpenproject: {
+			type: Boolean,
+			required: false,
+		},
+		showIntegrationSetupLinkInformation: {
+			type: Boolean,
+			required: false,
+		},
+	},
 	computed: {
 		title() {
 			return t('integration_openproject', 'OpenProject Integration')
 		},
+		getSetUpIntegrationDocumentationLinkText() {
+			const linkText = t('integration_openproject', 'setting up a Nextcloud file storage')
+			const htmlLink = `<a class="link" href="https://www.openproject.org/docs/system-admin-guide/integrations/nextcloud/" target="_blank" title="${linkText}">${linkText}</a>`
+			return t('integration_openproject', 'Visit our documentation for in-depth information on {htmlLink} integration.', { htmlLink }, null, { escape: false, sanitize: false })
+		},
+		getUserGuideDocumentationLinkText() {
+			const linkText = t('integration_openproject', 'Nextcloud integration user guide')
+			const htmlLink = `<a class="link" href="https://www.openproject.org/docs/user-guide/file-management/nextcloud-integration/" target="_blank" title="${linkText}">${linkText}</a>`
+			return t('integration_openproject', 'Please go to our {htmlLink} to learn more about how to work with the Nextcloud integration.', { htmlLink }, null, { escape: false, sanitize: false })
+		},
+		sanitizedHintText() {
+			if (this.isSetting === 'admin' && this.showIntegrationSetupLinkInformation) {
+				return dompurify.sanitize(this.getSetUpIntegrationDocumentationLinkText, { ADD_ATTR: ['target'] })
+			} else if (this.isSetting === 'personal' && this.isConnectedWithOpenproject) {
+				return dompurify.sanitize(this.getUserGuideDocumentationLinkText, { ADD_ATTR: ['target'] })
+			}
+			return ''
+		},
+	},
+	methods: {
+
 	},
 }
 </script>
 <style lang="scss">
 @import '../../../css/dashboard.css';
 
-.settings-title {
-	display: flex;
-	align-items: center;
-	.icon-openproject {
-		min-height: 32px;
-		min-width: 32px;
-		background-size: cover;
-	}
-	span {
-		padding-left: 10px;
+.settings {
+	&--title {
+		display: flex;
+		align-items: center;
+		.icon-openproject {
+			min-height: 32px;
+			min-width: 32px;
+			background-size: cover;
+		}
+		span {
+			padding-left: 10px;
+		}
 	}
 }
+
+.settings .link {
+	color: #1a67a3 !important;
+}
+
 </style>

--- a/src/components/settings/SettingsTitle.vue
+++ b/src/components/settings/SettingsTitle.vue
@@ -4,7 +4,7 @@
 			<OpenProjectIcon />
 			<span>{{ title }}</span>
 		</h2>
-		<p v-html="sanitizedHintText" /> <!-- eslint-disable-line vue/no-v-html -->
+		<p class="documentation-info" v-html="sanitizedHintText" /> <!-- eslint-disable-line vue/no-v-html -->
 	</div>
 </template>
 
@@ -44,7 +44,7 @@ export default {
 		getUserGuideDocumentationLinkText() {
 			const linkText = t('integration_openproject', 'Nextcloud integration user guide')
 			const htmlLink = `<a class="link" href="https://www.openproject.org/docs/user-guide/file-management/nextcloud-integration/" target="_blank" title="${linkText}">${linkText}</a>`
-			return t('integration_openproject', 'Please go to our {htmlLink} to learn more about how to work with the Nextcloud integration.', { htmlLink }, null, { escape: false, sanitize: false })
+			return t('integration_openproject', 'Please go to our {htmlLink} to learn more about how to work with the OpenProject integration.', { htmlLink }, null, { escape: false, sanitize: false })
 		},
 		sanitizedHintText() {
 			if (this.isSetting === 'admin' && this.showIntegrationSetupLinkInformation) {

--- a/tests/jest/components/AdminSettings.spec.js
+++ b/tests/jest/components/AdminSettings.spec.js
@@ -64,6 +64,7 @@ const selectors = {
 	projectFolderErrorMessage: '.project-folder-error-alert-message',
 	projectFolderErrorMessageDetails: '.project-folder-error > p',
 	userAppPasswordButton: '[data-test-id="reset-user-app-password"]',
+	setupIntegrationDocumentationLinkSelector: '.settings .documentation-info',
 }
 
 const completeIntegrationState = {
@@ -228,6 +229,48 @@ describe('AdminSettings.vue', () => {
 			expect(wrapper.vm.isFormCompleted.ncOauth).toBe(expectedFormState.ncOauth)
 			expect(wrapper.vm.isFormCompleted.projectFolderSetUp).toBe(expectedFormState.projectFolderSetUp)
 			expect(wrapper.vm.isFormCompleted.opUserAppPassword).toBe(expectedFormState.opUserAppPassword)
+		})
+	})
+
+	describe('documentation link', () => {
+		it.each([
+			[
+				'with all empty state',
+				{
+					openproject_instance_url: null,
+					openproject_client_id: null,
+					openproject_client_secret: null,
+					nc_oauth_client: null,
+				},
+			],
+			[
+				'with incomplete OpenProject OAuth and NC OAuth values',
+				{
+					openproject_instance_url: 'https://openproject.example.com',
+					openproject_client_id: null,
+					openproject_client_secret: null,
+					nc_oauth_client: null,
+				},
+			],
+			[
+				'with incomplete NC OAuth values',
+				{
+					openproject_instance_url: 'https://openproject.example.com',
+					openproject_client_id: 'client-id-here',
+					openproject_client_secret: 'client-secret-here',
+					nc_oauth_client: null,
+				},
+			],
+		])('should be visible %s', (name, state) => {
+			const wrapper = getMountedWrapper({ state })
+			const setupIntegrationDocumentationLink = wrapper.find(selectors.setupIntegrationDocumentationLinkSelector)
+			expect(setupIntegrationDocumentationLink.text()).toBe('Visit our documentation for in-depth information on {htmlLink} integration.')
+		})
+
+		it('should not be visible when integration is completed', () => {
+			const wrapper = getMountedWrapper({ state: completeIntegrationState })
+			const setupIntegrationDocumentationLink = wrapper.find(selectors.setupIntegrationDocumentationLinkSelector)
+			expect(setupIntegrationDocumentationLink.text()).toBe('')
 		})
 	})
 

--- a/tests/jest/components/PersonalSettings.spec.js
+++ b/tests/jest/components/PersonalSettings.spec.js
@@ -29,6 +29,7 @@ describe('PersonalSettings.vue', () => {
 		const personalSettingsFormSelector = '.openproject-prefs--form'
 		const personalEnableNavigationSelector = '#openproject-prefs--link'
 		const personalEnableSearchSelector = '#openproject-prefs--u-search'
+		const userGuideIntegrationDocumentationLinkSelector = '.settings .documentation-info'
 		let wrapper
 
 		beforeEach(() => {
@@ -72,6 +73,11 @@ describe('PersonalSettings.vue', () => {
 				it('oAuth disconnect button is not displayed', () => {
 					expect(wrapper.find(oAuthDisconnectButtonSelector).exists()).toBeFalsy()
 				})
+				it('should show not show user guide documentation link', () => {
+					const wrapper = getMountedWrapper({ state: { admin_config_ok: true, cases } })
+					const userGuideIntegrationDocumentationLink = wrapper.find(userGuideIntegrationDocumentationLinkSelector)
+					expect(userGuideIntegrationDocumentationLink.text()).toBe('')
+				})
 			})
 			describe('when username and token are given', () => {
 				beforeEach(async () => {
@@ -91,7 +97,13 @@ describe('PersonalSettings.vue', () => {
 				it('personal settings form is displayed', () => {
 					expect(wrapper.find(personalSettingsFormSelector).exists()).toBeTruthy()
 				})
+				it('should show not show user guide documentation link', () => {
+					const wrapper = getMountedWrapper({ state: { user_name: 'test', token: '123', admin_config_ok: true } })
+					const userGuideIntegrationDocumentationLink = wrapper.find(userGuideIntegrationDocumentationLinkSelector)
+					expect(userGuideIntegrationDocumentationLink.text()).toBe('Please go to our {htmlLink} to learn more about how to work with the OpenProject integration.')
+				})
 			})
+
 		})
 		describe('when the admin config is not okay', () => {
 			beforeEach(async () => {


### PR DESCRIPTION
## Description
This PR adds an new UI providing the link to documentation on setting up integration in admin setting and provides a user guide link in the personal setting when integration with openproject


## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://community.openproject.org/projects/nextcloud-integration/work_packages/52955/activity

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->
## UI changes with this PR:

### In Personal Section
![userGuideDocumentationLink](https://github.com/nextcloud/integration_openproject/assets/46086950/104df7ef-1426-459b-8267-06a48243a06b)

### In Admin Section
![setupIntegrationDocumentationLink](https://github.com/nextcloud/integration_openproject/assets/46086950/c3bdbbd8-1ab2-4aa4-a1af-c10227702785)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
