### PR TITLE
Refactor the runningFullReset varaible

### DIFF
--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -263,13 +263,13 @@ class ConfigController extends Controller {
 
 		$runningFullReset = (
 
-			$oldClientSecret &&
-
-			$oldClientId &&
+			key_exists('openproject_instance_url', $values) &&
 
 			key_exists('openproject_client_id', $values) &&
 
 			key_exists('openproject_client_secret', $values) &&
+
+			$values['openproject_instance_url'] === null &&
 
 			$values['openproject_client_id'] === null &&
 


### PR DESCRIPTION
## Description
The full reset of the integration means resetting all the values that has been set already default null. Some how the `runningFullReset` was resulting `false` even when we were resetting the whole integration. It was because of `$oldClientSecret` `$oldClientId` which made it `false`. These 2 checks has been removed since it seems to be non relevant to resetting the integration.


## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
