### PR TITLE
Remove only from admin setting tests

### DIFF
--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -425,6 +425,7 @@ export default {
 			// pointer for which form the request is coming
 			isFormStep: null,
 			isDarkTheme: null,
+			isAllTermsOfServiceSignedForUserOpenProject: true,
 		}
 	},
 	computed: {
@@ -497,9 +498,6 @@ export default {
 		isProjectFolderSetupCompleted() {
 			return this.isProjectFolderSetupFormInEdit ? false : this.opUserAppPassword
 		},
-		isAllTermsOfServiceSignedForUserOpenProject() {
-			return this.state.all_terms_of_services_signed
-		},
 		adminFileStorageHref() {
 			let hostPart = ''
 			const urlPart = '%sadmin/settings/storages'
@@ -558,6 +556,9 @@ export default {
 	methods: {
 		init() {
 			if (this.state) {
+				if (this.state.all_terms_of_services_signed === false) {
+					this.isAllTermsOfServiceSignedForUserOpenProject = false
+				}
 				if (this.state.project_folder_info) {
 					this.isProjectFolderSetupCorrect = this.state.project_folder_info.status
 					if (this.state.project_folder_info.status === true) {

--- a/tests/jest/components/AdminSettings.spec.js
+++ b/tests/jest/components/AdminSettings.spec.js
@@ -997,7 +997,7 @@ describe('AdminSettings.vue', () => {
 								'should set the project folder error message and error details when group folders app is not enabled',
 								{
 									error: 'The "Group folders" app is not installed',
-									expectedErrorDetailsMessage: 'Please install the "Group folders" app to be able to use automatic managed folders or deactivate the automatically managed folders.',
+									expectedErrorDetailsMessage: 'Please install the "Group folders" app to be able to use automatically managed folders, {htmlLink}',
 								},
 							],
 							[
@@ -1450,7 +1450,7 @@ describe('AdminSettings.vue', () => {
 				'should set the project folder error message and error details when group folders app is not enabled',
 				{
 					error: 'The "Group folders" app is not installed',
-					expectedErrorDetailsMessage: 'Please install the "Group folders" app to be able to use automatic managed folders or deactivate the automatically managed folders.',
+					expectedErrorDetailsMessage: 'Please install the "Group folders" app to be able to use automatically managed folders, {htmlLink}',
 				},
 			],
 			[
@@ -1789,7 +1789,7 @@ describe('AdminSettings.vue', () => {
 		})
 	})
 
-	describe.only('terms of service', () => {
+	describe('terms of service', () => {
 		const termsOfServiceComponentStub = 'termsofserviceunsigned-stub'
 		const termsOfServiceComponentStubAttribute = 'isalltermsofservicesignedforuseropenproject'
 		it('should show modal when terms of services are not signed', () => {


### PR DESCRIPTION
## Description
The admin setting test was not fully running because of a test with  `.only` tests which was merged accidentally with it in PR https://github.com/nextcloud/integration_openproject/pull/552/files#diff-437209b827b3b0af71027912f456e4ef6a3b7340eb524e754ac53b12e9b4f72dR1792.

- This PR removes the .only and rerun other tests
- This PR adjust the failed tests due to new changes
- This PR adjust the terms of services sign flag in a `data` rather than directly passing from the `loaded state` into the template.

## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
