### PR TITLE
[WP#52961]Used the NcButton for create Workpackage

### DIFF
--- a/src/components/tab/SearchInput.vue
+++ b/src/components/tab/SearchInput.vue
@@ -34,14 +34,12 @@
 			{{ stateMessages }}
 		</div>
 		<div v-if="!!isStateOk && !isSmartPicker" class="create-workpackage">
-			<NcActions class="create-workpackage--action">
-				<NcActionButton class="create-workpackage--button" @click="openCreateWorkpackageModal()">
-					<template #icon>
-						<Plus class="plus" :size="26" />
-					</template>
-				</NcActionButton>
-			</NcActions>
-			<span class="create-workpackage--label">{{ t('integration_openproject', 'Create and link a new work package') }}</span>
+			<NcButton class="create-workpackage--button" @click="openCreateWorkpackageModal()">
+				<template #icon>
+					<Plus class="plus" :size="26" />
+				</template>
+				{{ t('integration_openproject', 'Create and link a new work package') }}
+			</NcButton>
 		</div>
 		<CreateWorkPackageModal
 			v-if="!isSmartPicker"
@@ -67,8 +65,7 @@ import { STATE, WORKPACKAGES_SEARCH_ORIGIN } from '../../utils.js'
 import { translate as t } from '@nextcloud/l10n'
 import Plus from 'vue-material-design-icons/Plus.vue'
 import CreateWorkPackageModal from '../../views/CreateWorkPackageModal.vue'
-import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton.js'
-import NcActions from '@nextcloud/vue/dist/Components/NcActions.js'
+import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 
 const SEARCH_CHAR_LIMIT = 1
 const DEBOUNCE_THRESHOLD = 500
@@ -76,8 +73,7 @@ const DEBOUNCE_THRESHOLD = 500
 export default {
 	name: 'SearchInput',
 	components: {
-		NcActions,
-		NcActionButton,
+		NcButton,
 		CreateWorkPackageModal,
 		Plus,
 		WorkPackage,


### PR DESCRIPTION
## Description
This PR Replaces `NcButton` instead of `NcActionsButton` and cover all the text within button which is also left-aligned.


## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes [workpackage-link>](https://community.openproject.org/projects/nextcloud-integration/work_packages/52961)

## Screenshots (if appropriate):

![NcButton](https://github.com/nextcloud/integration_openproject/assets/46086950/1027e9a0-93c6-4fea-ad55-acca38060f61)
![NCbutton](https://github.com/nextcloud/integration_openproject/assets/46086950/7104cee8-50a2-4fb1-9dc5-7e2614d97c12)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
