### PR TITLE
[WP #54185] Add php version 8.0,8.2,8.3 for nightly build only

### DIFF
--- a/.github/workflows/shared_workflow.yml
+++ b/.github/workflows/shared_workflow.yml
@@ -167,8 +167,21 @@ jobs:
       matrix:
         nextcloudVersion: [ stable26, stable27, stable28, stable29 ]
         phpVersionMajor: [ 8 ]
-        phpVersionMinor: [ 2 ]
+        phpVersionMinor: [ 0, 1, 2, 3 ]
         database: [pgsql, mysql]
+        isScheduledEventNightly:
+          - ${{github.event_name != 'schedule'}}
+        exclude:
+          - nextcloudVersion: stable26
+            phpVersionMinor: 3
+          - nextcloudVersion: stable27
+            phpVersionMinor: 3
+          - isScheduledEventNightly: true
+            phpVersionMinor: 0
+          - isScheduledEventNightly: true
+            phpVersionMinor: 1
+          - isScheduledEventNightly: true
+            phpVersionMinor: 3
     runs-on: ubuntu-20.04
     container:
       image: ubuntu:latest


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Currently, only one PHP version 8.2, is running in the CI. When we include the other versions, 8.0, 8.1, and 8.3, the CI build will take a longer time. Therefore, add them only to the nightly build.

## Related Issue or Workpackage
- https://community.openproject.org/work_packages/54185/activity


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
