### PR TITLE
[WP#54451]Fix the font size for setting documentation

### DIFF
--- a/src/components/settings/SettingsTitle.vue
+++ b/src/components/settings/SettingsTitle.vue
@@ -4,7 +4,7 @@
 			<OpenProjectIcon />
 			<span>{{ title }}</span>
 		</h2>
-		<p class="documentation-info" v-html="sanitizedHintText" /> <!-- eslint-disable-line vue/no-v-html -->
+		<p class="settings--documentation-info" v-html="sanitizedHintText" /> <!-- eslint-disable-line vue/no-v-html -->
 	</div>
 </template>
 
@@ -67,6 +67,9 @@ export default {
 		span {
 			padding-left: 10px;
 		}
+	}
+	&--documentation-info {
+		font-size: 1rem;
 	}
 }
 

--- a/tests/jest/components/AdminSettings.spec.js
+++ b/tests/jest/components/AdminSettings.spec.js
@@ -64,7 +64,7 @@ const selectors = {
 	projectFolderErrorMessage: '.project-folder-error-alert-message',
 	projectFolderErrorMessageDetails: '.project-folder-error > p',
 	userAppPasswordButton: '[data-test-id="reset-user-app-password"]',
-	setupIntegrationDocumentationLinkSelector: '.settings .documentation-info',
+	setupIntegrationDocumentationLinkSelector: '.settings--documentation-info',
 }
 
 const completeIntegrationState = {

--- a/tests/jest/components/PersonalSettings.spec.js
+++ b/tests/jest/components/PersonalSettings.spec.js
@@ -29,7 +29,7 @@ describe('PersonalSettings.vue', () => {
 		const personalSettingsFormSelector = '.openproject-prefs--form'
 		const personalEnableNavigationSelector = '#openproject-prefs--link'
 		const personalEnableSearchSelector = '#openproject-prefs--u-search'
-		const userGuideIntegrationDocumentationLinkSelector = '.settings .documentation-info'
+		const userGuideIntegrationDocumentationLinkSelector = '.settings--documentation-info'
 		let wrapper
 
 		beforeEach(() => {


### PR DESCRIPTION
## Description
This PR fix the font size which was a bit same(inconsistent) in the personal section of the integration setting.


## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes (https://community.openproject.org/projects/nextcloud-integration/work_packages/54451)

## Screenshots (if appropriate):
### Before:
![userGuide](https://github.com/nextcloud/integration_openproject/assets/46086950/85bd1749-9492-4632-b262-020425fc2d70)

### After:
![afterUserGuide](https://github.com/nextcloud/integration_openproject/assets/46086950/fa731c9a-f134-4b7c-bb2d-ec310aaab617)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
