### PR TITLE
[WP#54507]fix CI false status failure

### DIFF
--- a/.github/scripts/notify-to-element.sh
+++ b/.github/scripts/notify-to-element.sh
@@ -16,7 +16,7 @@ log_success() {
 log_info "Fetching all workflow jobs....."
 
 response=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-  "https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/actions/runs/$RUN_ID/jobs")
+  "https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/actions/runs/$RUN_ID/jobs?per_page=50")
 
 log_info "Fetching jobs informations succeeded!
 "


### PR DESCRIPTION
## Description
The main reason behind the nightly ci bot giving the false status was that the api call to get the jobs information gave only details for 30 jobs. But in nightly we have now 40+ < 50 jobs now (recently). So the script fails to check the details of other jobs (after 30 jobs). This Script increase the job details to 50 which would be enough for getting details of our jobs in the CI.


## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://community.openproject.org/projects/nextcloud-integration/work_packages/54507

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
