### PR TITLE
Refactor integration script when `project folder` is already setup

### DIFF
--- a/lib/Service/OauthService.php
+++ b/lib/Service/OauthService.php
@@ -92,6 +92,7 @@ class OauthService {
 				'nextcloud_oauth_client_name' => $client->getName(),
 				'openproject_redirect_uri' => $client->getRedirectUri(),
 				'nextcloud_client_id' => $client->getClientIdentifier(),
+				'nextcloud_client_secret' => $this->crypto->decrypt($client->getSecret()),
 			];
 		} catch (ClientNotFoundException $e) {
 			return null;

--- a/tests/acceptance/features/api/setup.feature
+++ b/tests/acceptance/features/api/setup.feature
@@ -656,12 +656,14 @@ Feature: setup the integration through an API
       "required": [
           "nextcloud_oauth_client_name",
           "openproject_redirect_uri",
-          "nextcloud_client_id"
+          "nextcloud_client_id",
+          "nextcloud_client_secret"
        ],
       "properties": {
           "nextcloud_oauth_client_name": {"type": "string", "pattern": "^OpenProject client$"},
           "openproject_redirect_uri": {"type": "string", "pattern": "^http:\/\/some-host.de\/oauth_clients\/[A-Za-z0-9]+\/callback$"},
           "nextcloud_client_id": {"type": "string", "pattern": "[A-Za-z0-9]+"},
+          "nextcloud_client_secret": {"type": "string", "pattern": "[A-Za-z0-9]+"},
           "openproject_user_app_password": {"type": "string", "pattern": "[A-Za-z0-9]+"}
       }
     }


### PR DESCRIPTION
## Description
The integration script failed when we had the `project folder` already setup on `nextcloud` and we try to configure the integration config. It was because when the `project folder` is already set  up on the nextcloud, we use `PATCH` method to setup as using `POST` is not suitable since the `project folder` set up is already done in the nextcloud. Previously the script used to work fine but with this PR https://github.com/nextcloud/integration_openproject/pull/445 the client secret in the `PATCH` response was removed which was the main reason for the failure.

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
