### PR TITLE
Added admin audit log for admin config integration setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 - Add application's support for Nextcloud 30
+- Audit logging in `/audit.log` for admin configuration.
 
 ## 2.6.3 - 2024-04-17
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 - Add application's support for Nextcloud 30
-- Audit logging in `/audit.log` for admin configuration.
+- Log admin configuration to  audit log (`/audit.log`)
 
 ## 2.6.3 - 2024-04-17
 ### Changed

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -384,13 +384,21 @@ class ConfigController extends Controller {
 	public function setAdminConfig(array $values): DataResponse {
 		try {
 			$result = $this->setIntegrationConfig($values);
-			if(key_exists('openproject_client_id', $values) &&
+			$isOPOAuthCrdentialSet = key_exists('openproject_client_id', $values) &&
 				key_exists('openproject_client_secret', $values) &&
 				$values['openproject_client_id'] &&
-				$values['openproject_client_secret']
-			) {
+				$values['openproject_client_secret'];
+
+			if(key_exists('openproject_instance_url', $values) &&
+				$values['openproject_instance_url'] && !$isOPOAuthCrdentialSet) {
+				// sending admin audit log if admin has changed or added the openproject host url
 				$this->openprojectAPIService->logToAuditFile(
-					"OpenProject OAuth credential has been set in application " . Application::APP_ID
+					"OpenProject host url has been set to '" . $values['openproject_instance_url'] . "' in application " . Application::APP_ID
+				);
+			}
+			if($isOPOAuthCrdentialSet) {
+				$this->openprojectAPIService->logToAuditFile(
+					"OpenProject OAuth credential 'openproject_client_id' and 'openproject_client_secret' has been set in application " . Application::APP_ID
 				);
 			}
 			return new DataResponse($result);
@@ -557,7 +565,7 @@ class ConfigController extends Controller {
 	public function autoOauthCreation(): DataResponse {
 		$result = $this->recreateOauthClientInformation();
 		$this->openprojectAPIService->logToAuditFile(
-			"Nextcloud OAuth credential has been set on application " . Application::APP_ID
+			"Nextcloud OAuth credential has been set in application " . Application::APP_ID
 		);
 		return new DataResponse($result);
 	}

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -353,7 +353,7 @@ class ConfigController extends Controller {
 		if ($runningFullReset) {
 			$this->config->setAppValue(Application::APP_ID, 'fresh_project_folder_setup', "1");
 			$this->openprojectAPIService->logToAuditFile(
-				"OpenProject Integration admin configuration has been reset in application " . Application::APP_ID, true
+				"OpenProject Integration admin configuration has been reset in application " . Application::APP_ID
 			);
 		} elseif (key_exists('setup_app_password', $values) && key_exists('setup_project_folder', $values)) {
 			// for other cases when api has key 'setup_app_password' and 'setup_project_folder' we set it to false

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -224,7 +224,7 @@ class ConfigController extends Controller {
 			$appPassword = $this->openprojectAPIService->generateAppPasswordTokenForUser();
 			if($isAppPasswordBeingReplaced) {
 				$this->openprojectAPIService->logToAuditFile(
-					"Application password for user 'OpenProject has been replaced' in application " . Application::APP_ID
+					"Application password for user 'OpenProject has been replaced' with new password in application " . Application::APP_ID
 				);
 			} else {
 				$this->openprojectAPIService->logToAuditFile(

--- a/lib/Controller/OpenProjectAPIController.php
+++ b/lib/Controller/OpenProjectAPIController.php
@@ -547,9 +547,6 @@ class OpenProjectAPIController extends Controller {
 			);
 			return new DataResponse(['result' => 'invalid']);
 		}
-		$oldOpenProjectOauthUrl = $this->config->getAppValue(
-			Application::APP_ID, 'openproject_instance_url', ''
-		);
 		try {
 			$response = $this->openprojectAPIService->rawRequest(
 				'', $url, '', [], 'GET',

--- a/lib/Controller/OpenProjectAPIController.php
+++ b/lib/Controller/OpenProjectAPIController.php
@@ -585,10 +585,6 @@ class OpenProjectAPIController extends Controller {
 				$decodedBody['_type'] === 'Root' &&
 				$decodedBody['instanceName'] !== ''
 			) {
-				// sending admin audit log if admin has changed or added the openproject host url
-				$this->openprojectAPIService->logToAuditFile(
-					"OpenProject host url has been set to '$url' in application " . Application::APP_ID
-				);
 				return new DataResponse(['result' => true]);
 			}
 		} catch (ClientException $e) {
@@ -602,10 +598,6 @@ class OpenProjectAPIController extends Controller {
 				$decodedBody['_type'] === 'Error' &&
 				$decodedBody['errorIdentifier'] !== ''
 			) {
-				// sending admin audit log if admin has changed or added the openproject host url
-				$this->openprojectAPIService->logToAuditFile(
-					"OpenProject host url has been set to '$url' in application " . Application::APP_ID
-				);
 				return new DataResponse(['result' => true]);
 			}
 			$this->logger->error(

--- a/lib/Controller/OpenProjectAPIController.php
+++ b/lib/Controller/OpenProjectAPIController.php
@@ -547,6 +547,9 @@ class OpenProjectAPIController extends Controller {
 			);
 			return new DataResponse(['result' => 'invalid']);
 		}
+		$oldOpenProjectOauthUrl = $this->config->getAppValue(
+			Application::APP_ID, 'openproject_instance_url', ''
+		);
 		try {
 			$response = $this->openprojectAPIService->rawRequest(
 				'', $url, '', [], 'GET',
@@ -585,6 +588,10 @@ class OpenProjectAPIController extends Controller {
 				$decodedBody['_type'] === 'Root' &&
 				$decodedBody['instanceName'] !== ''
 			) {
+				// sending admin audit log if admin has changed or added the openproject host url
+				$this->openprojectAPIService->logToAuditFile(
+					"OpenProject host url has been set to '$url' in application " . Application::APP_ID
+				);
 				return new DataResponse(['result' => true]);
 			}
 		} catch (ClientException $e) {
@@ -598,6 +605,10 @@ class OpenProjectAPIController extends Controller {
 				$decodedBody['_type'] === 'Error' &&
 				$decodedBody['errorIdentifier'] !== ''
 			) {
+				// sending admin audit log if admin has changed or added the openproject host url
+				$this->openprojectAPIService->logToAuditFile(
+					"OpenProject host url has been set to '$url' in application " . Application::APP_ID
+				);
 				return new DataResponse(['result' => true]);
 			}
 			$this->logger->error(

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -1084,7 +1084,8 @@ class OpenProjectAPIService {
 	 * @return void
 	 */
 	public function logToAuditFile($auditLogMessage): void {
-		if($this->isAdminAuditConfigSetCorrectly()) {
+		$result = $this->isAdminAuditConfigSetCorrectly();
+		if($result) {
 			$this->auditLogger = new AuditLogger($this->logFactory, $this->config);
 			$this->auditLogger->info($auditLogMessage,
 				['app' => 'admin_audit']

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -21,6 +21,7 @@ use InvalidArgumentException;
 use OC\Authentication\Events\AppPasswordCreatedEvent;
 use OC\Authentication\Token\IProvider;
 use OC\User\NoUserException;
+use OCA\AdminAudit\AuditLogger;
 use OCA\GroupFolders\Folder\FolderManager;
 use OCA\OpenProject\AppInfo\Application;
 use OCA\OpenProject\Exception\OpenprojectErrorException;
@@ -47,11 +48,14 @@ use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IGroupManager;
 use OCP\IL10N;
+use OCP\ILogger;
 use OCP\IURLGenerator;
 use OCP\IUserManager;
+use OCP\Log\ILogFactory;
 use OCP\PreConditionNotMetException;
 use OCP\Security\ISecureRandom;
 use OCP\Server;
+use phpDocumentor\Reflection\Types\This;
 use Psr\Log\LoggerInterface;
 
 define('CACHE_TTL', 3600);
@@ -115,6 +119,7 @@ class OpenProjectAPIService {
 	 */
 	private ISubAdmin $subAdminManager;
 	private IDBConnection $db;
+	private ILogFactory $logFactory;
 
 
 	/**
@@ -125,6 +130,8 @@ class OpenProjectAPIService {
 	private IProvider $tokenProvider;
 	private ISecureRandom $random;
 	private IEventDispatcher $eventDispatcher;
+	private AuditLogger $auditLogger;
+
 	public function __construct(
 		string $appName,
 		IAvatarManager $avatarManager,
@@ -142,7 +149,8 @@ class OpenProjectAPIService {
 		ISecureRandom $random,
 		IEventDispatcher $eventDispatcher,
 		ISubAdmin $subAdminManager,
-		IDBConnection $db
+		IDBConnection $db,
+		ILogFactory $logFactory,
 	) {
 		$this->appName = $appName;
 		$this->avatarManager = $avatarManager;
@@ -161,6 +169,7 @@ class OpenProjectAPIService {
 		$this->random = $random;
 		$this->eventDispatcher = $eventDispatcher;
 		$this->db = $db;
+		$this->logFactory = $logFactory;
 	}
 
 	/**
@@ -1070,6 +1079,33 @@ class OpenProjectAPIService {
 		);
 	}
 
+	/**
+	 * @param $auditLogMessage
+	 * @return void
+	 */
+	public function logToAuditFile($auditLogMessage): void {
+		if($this->isAdminAuditConfigSetCorrectly()) {
+			$this->auditLogger = new AuditLogger($this->logFactory, $this->config);
+			$this->auditLogger->info($auditLogMessage,
+				['app' => 'admin_audit']
+			);
+		}
+	}
+
+	public function isAdminAuditConfigSetCorrectly(): bool {
+		$logLevel = $this->config->getSystemValue('loglevel', ILogger::WARN);
+		$configAuditFile = $this->config->getSystemValue('logfile_audit', ILogger::WARN);
+		$logCondition = $this->config->getSystemValue('log.condition', []);
+		// All the above config should be satisfied in order for admin audit log for the integration application
+		// if any of the config is failed to be set then we are not able to send the admin audit logging in the audit.log file
+		return (
+			$this->appManager->isInstalled('admin_audit') &&
+			$configAuditFile === $this->config->getSystemValue('datadirectory', \OC::$SERVERROOT . '/data') . '/audit.log' &&
+			(isset($logCondition["apps"]) && in_array('admin_audit', $logCondition["apps"])) &&
+			$logLevel >= 1
+		);
+	}
+
 	public function isTermsOfServiceAppEnabled(): bool {
 		return (
 			class_exists('\OCA\TermsOfService\Db\Entities\Signatory') &&
@@ -1080,6 +1116,8 @@ class OpenProjectAPIService {
 			)
 		);
 	}
+
+
 
 	/**
 	 * @return array<mixed>
@@ -1245,6 +1283,7 @@ class OpenProjectAPIService {
 		$tokens = $this->tokenProvider->getTokenByUser(Application::OPEN_PROJECT_ENTITIES_NAME);
 		foreach ($tokens as $token) {
 			if ($token->getName() === Application::OPEN_PROJECT_ENTITIES_NAME) {
+				$this->logger->info('Application password for user "OpenProject" has been deleted.', ['app' => $this->appName]);
 				return true;
 			}
 		}

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -48,7 +48,6 @@ use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IGroupManager;
 use OCP\IL10N;
-use OCP\ILogger;
 use OCP\IURLGenerator;
 use OCP\IUserManager;
 use OCP\Log\ILogFactory;
@@ -1084,8 +1083,7 @@ class OpenProjectAPIService {
 	 * @return void
 	 */
 	public function logToAuditFile($auditLogMessage): void {
-		$result = $this->isAdminAuditConfigSetCorrectly();
-		if($result) {
+		if($this->isAdminAuditConfigSetCorrectly()) {
 			$this->auditLogger = new AuditLogger($this->logFactory, $this->config);
 			$this->auditLogger->info($auditLogMessage,
 				['app' => 'admin_audit']
@@ -1094,9 +1092,9 @@ class OpenProjectAPIService {
 	}
 
 	public function isAdminAuditConfigSetCorrectly(): bool {
-		$logLevel = $this->config->getSystemValue('loglevel', ILogger::WARN);
-		$configAuditFile = $this->config->getSystemValue('logfile_audit', ILogger::WARN);
-		$logCondition = $this->config->getSystemValue('log.condition', []);
+		$logLevel = $this->config->getSystemValue('loglevel');
+		$configAuditFile = $this->config->getSystemValue('logfile_audit');
+		$logCondition = $this->config->getSystemValue('log.condition');
 		// All the above config should be satisfied in order for admin audit log for the integration application
 		// if any of the config is failed to be set then we are not able to send the admin audit logging in the audit.log file
 		return (

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -54,7 +54,6 @@ use OCP\Log\ILogFactory;
 use OCP\PreConditionNotMetException;
 use OCP\Security\ISecureRandom;
 use OCP\Server;
-use phpDocumentor\Reflection\Types\This;
 use Psr\Log\LoggerInterface;
 
 define('CACHE_TTL', 3600);

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -1269,6 +1269,9 @@ class OpenProjectAPIService {
 			foreach ($tokens as $token) {
 				if ($token->getName() === Application::OPEN_PROJECT_ENTITIES_NAME) {
 					$this->tokenProvider->invalidateTokenById(Application::OPEN_PROJECT_ENTITIES_NAME, $token->getId());
+					$this->logToAuditFile(
+						"Application password for user 'OpenProject has been deleted' in application " . Application::APP_ID
+					);
 				}
 			}
 		}
@@ -1283,7 +1286,6 @@ class OpenProjectAPIService {
 		$tokens = $this->tokenProvider->getTokenByUser(Application::OPEN_PROJECT_ENTITIES_NAME);
 		foreach ($tokens as $token) {
 			if ($token->getName() === Application::OPEN_PROJECT_ENTITIES_NAME) {
-				$this->logger->info('Application password for user "OpenProject" has been deleted.', ['app' => $this->appName]);
 				return true;
 			}
 		}

--- a/psalm.xml
+++ b/psalm.xml
@@ -38,6 +38,8 @@
 				<referencedClass name="Helmich\JsonAssert\JsonAssertions" />
 				<!-- these classes belong to the event app, which isn't compulsory, so might not exist while running psalm -->
 				<referencedClass name="OCP\App\Events\AppEnableEvent" />
+				<referencedClass name="OCA\AdminAudit\AuditLogger" />
+
 			</errorLevel>
 		</UndefinedClass>
 		<TooFewArguments>

--- a/tests/lib/Controller/OpenProjectAPIControllerTest.php
+++ b/tests/lib/Controller/OpenProjectAPIControllerTest.php
@@ -810,8 +810,11 @@ class OpenProjectAPIControllerTest extends TestCase {
 		$response->method('getBody')->willReturn($body);
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
-			->onlyMethods(['rawRequest'])
+			->onlyMethods(['rawRequest','isAdminAuditConfigSetCorrectly'])
 			->getMock();
+		$service
+			->method('isAdminAuditConfigSetCorrectly')
+			->willReturn(false);
 		$service
 			->method('rawRequest')
 			->willReturn($response);
@@ -873,11 +876,14 @@ class OpenProjectAPIControllerTest extends TestCase {
 			->willReturn('');
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
-			->onlyMethods(['rawRequest'])
+			->onlyMethods(['rawRequest','isAdminAuditConfigSetCorrectly'])
 			->getMock();
 		$service
 			->method('rawRequest')
 			->willReturn($response);
+		$service
+			->method('isAdminAuditConfigSetCorrectly')
+			->willReturn(false);
 		$controller = new OpenProjectAPIController(
 			'integration_openproject',
 			$this->requestMock,
@@ -971,8 +977,11 @@ class OpenProjectAPIControllerTest extends TestCase {
 	): void {
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
-			->onlyMethods(['rawRequest'])
+			->onlyMethods(['rawRequest', 'isAdminAuditConfigSetCorrectly'])
 			->getMock();
+		$service
+			->method('isAdminAuditConfigSetCorrectly')
+			->willReturn(false);
 		$service
 			->method('rawRequest')
 			->willThrowException($thrownException);

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -727,6 +727,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 	 * @param IProvider|null $tokenProviderMock
 	 * @param IDBConnection|null $db
 	 * @param IURLGenerator|null $iURLGenerator
+	 * @param ILogFactory|null $iLogFactory
 	 * @return OpenProjectAPIService|MockObject
 	 */
 	private function getServiceMock(
@@ -741,7 +742,8 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$configMock = null,
 		$tokenProviderMock = null,
 		$db = null,
-		$iURLGenerator = null
+		$iURLGenerator = null,
+		$iLogFactory = null
 	): OpenProjectAPIService {
 		$onlyMethods[] = 'getBaseUrl';
 		if ($rootMock === null) {
@@ -777,6 +779,9 @@ class OpenProjectAPIServiceTest extends TestCase {
 		if ($iURLGenerator === null) {
 			$iURLGenerator = $this->createMock(IURLGenerator::class);
 		}
+		if ($iLogFactory === null) {
+			$iLogFactory = $this->createMock(ILogFactory::class);
+		}
 		$mock = $this->getMockBuilder(OpenProjectAPIService::class)
 			->setConstructorArgs(
 				[
@@ -797,6 +802,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 					$this->createMock(IEventDispatcher::class),
 					$subAdminManagerMock,
 					$db,
+					$iLogFactory,
 					$iURLGenerator
 				])
 			->onlyMethods($onlyMethods)

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -3684,7 +3684,13 @@ class OpenProjectAPIServiceTest extends TestCase {
 	 * @return void
 	 */
 
-	public function testIsAdminAuditConfigSetCorrectly(int $logLevel, string $pathToAuditLog, array $logCondition, bool $isAdminAuditAppInstalled, bool $expectedResult): void {
+	public function testIsAdminAuditConfigSetCorrectly(
+		int $logLevel,
+		string $pathToAuditLog,
+		array $logCondition,
+		bool $isAdminAuditAppInstalled,
+		bool $expectedResult
+	): void {
 		$configMock = $this->getMockBuilder(IConfig::class)->getMock();
 		$iAppManagerMock = $this->getMockBuilder(IAppManager::class)->getMock();
 		$configMock

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -44,6 +44,7 @@ use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserManager;
+use OCP\Log\ILogFactory;
 use OCP\Security\IRemoteHostValidator;
 use OCP\Security\ISecureRandom;
 use PhpPact\Consumer\InteractionBuilder;
@@ -708,7 +709,8 @@ class OpenProjectAPIServiceTest extends TestCase {
 			$this->createMock(ISecureRandom::class),
 			$this->createMock(IEventDispatcher::class),
 			$this->createMock(ISubAdmin::class),
-			$this->createMock(IDBConnection::class)
+			$this->createMock(IDBConnection::class),
+			$this->createMock(ILogFactory::class)
 		);
 	}
 
@@ -1926,7 +1928,9 @@ class OpenProjectAPIServiceTest extends TestCase {
 			$this->createMock(ISecureRandom::class),
 			$this->createMock(IEventDispatcher::class),
 			$this->createMock(ISubAdmin::class),
-			$this->createMock(IDBConnection::class)
+			$this->createMock(IDBConnection::class),
+			$this->createMock(ILogFactory::class)
+
 		);
 
 		$response = $service->request('', '', []);
@@ -1995,7 +1999,8 @@ class OpenProjectAPIServiceTest extends TestCase {
 			$this->createMock(ISecureRandom::class),
 			$this->createMock(IEventDispatcher::class),
 			$this->createMock(ISubAdmin::class),
-			$this->createMock(IDBConnection::class)
+			$this->createMock(IDBConnection::class),
+			$this->createMock(ILogFactory::class)
 		);
 
 		$response = $service->request('', '', []);


### PR DESCRIPTION
## Description
This PR:
  - Adds a way to log every activities regarding the admin integration configuration to log them in `audit.log` file in the Nextcloud data.
 
> Note: This PR does not implement the info warning in the UI. Since it is dependent to this bump PR: https://github.com/nextcloud/integration_openproject/pull/654.


## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://community.openproject.org/projects/nextcloud-integration/work_packages/55110

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
