### PR TITLE
run psalm with all NC versions

### DIFF
--- a/.github/workflows/shared_workflow.yml
+++ b/.github/workflows/shared_workflow.yml
@@ -73,11 +73,7 @@ jobs:
           ./occ maintenance:install --admin-pass=admin
 
       - name: PHP code analysis
-        run: |
-          if [ ${{ matrix.nextcloudVersion }} == "stable26" -o ${{ matrix.nextcloudVersion }} == "stable27" ]
-          then
-            make phpstan
-          fi
+        run: make psalm
 
       - name: PHP code style
         run: composer run cs:check || ( echo 'Please run `composer run cs:fix` to format your code' && exit 1 )

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -106,10 +106,13 @@ class Application extends App implements IBootstrap {
 		$dispatcher->addServiceListener(BeforeUserDeletedEvent::class, BeforeUserDeletedListener::class);
 		$dispatcher->addServiceListener(BeforeGroupDeletedEvent::class, BeforeGroupDeletedListener::class);
 		$dispatcher->addServiceListener(UserChangedEvent::class, UserChangedListener::class);
+		/** @psalm-suppress InvalidArgument AppEnableEvent event is not in stable25 so making psalm not complain*/
 		// @phpstan-ignore-next-line - make phpstan not complain since AppEnableEvent event is not in stable25
 		$dispatcher->addServiceListener(AppEnableEvent::class, TermsOfServiceEventListener::class);
+		/** @psalm-suppress InvalidArgument TermsCreatedEvent event is not yet registered in terms_of_service app, so making psalm not complain */
 		// @phpstan-ignore-next-line - make phpstan not complain since TermsCreatedEvent event is not yet registered in terms_of_service app
 		$dispatcher->addServiceListener(TermsCreatedEvent::class, TermsOfServiceEventListener::class);
+		/** @psalm-suppress InvalidArgument SignaturesResetEvent event is not yet registered in terms_of_service app, so making psalm not complain*/
 		// @phpstan-ignore-next-line - make phpstan not complain since SignaturesResetEvent event is not yet registered in terms_of_service app
 		$dispatcher->addServiceListener(SignaturesResetEvent::class, TermsOfServiceEventListener::class);
 	}

--- a/lib/Listener/LoadAdditionalScriptsListener.php
+++ b/lib/Listener/LoadAdditionalScriptsListener.php
@@ -9,6 +9,9 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Util;
 
+/**
+ *	@template-implements IEventListener<Event>
+ */
 class LoadAdditionalScriptsListener implements IEventListener {
 	public function __construct() {
 	}

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -1404,7 +1404,7 @@ class OpenProjectAPIService {
 	 * @param string $projectId
 	 * @param array<mixed> $body
 	 *
-	 * @return array<mixed>
+	 * @return array<string,mixed>
 	 * @throws OpenprojectResponseException|PreConditionNotMetException|JsonException|OpenprojectErrorException
 	 */
 	public function getOpenProjectWorkPackageForm(string $userId, string $projectId, array $body): array {
@@ -1418,7 +1418,7 @@ class OpenProjectAPIService {
 			$result['_type'] !== 'Form' ||
 			!isset($result['_embedded']) ||
 			!isset($result['_embedded']['payload']) ||
-				!isset($result['_embedded']['schema'])
+			!isset($result['_embedded']['schema'])
 		) {
 			throw new OpenprojectResponseException('Malformed response');
 		}

--- a/psalm.xml
+++ b/psalm.xml
@@ -9,24 +9,35 @@
 	findUnusedCode="false"
 	autoloader="bootstrap.php"
 >
-    <projectFiles>
-        <directory name="lib" />
+	<projectFiles>
+		<directory name="lib" />
 		<directory name="tests" />
-        <ignoreFiles>
-            <directory name="vendor" />
-        </ignoreFiles>
-    </projectFiles>
+		<ignoreFiles>
+			<directory name="vendor" />
+		</ignoreFiles>
+	</projectFiles>
+	<stubs>
+		<file name="tests/stub.phpstub" preloadClasses="true"/>
+	</stubs>
 	<issueHandlers>
 		<UndefinedClass>
 			<errorLevel type="suppress">
 				<referencedClass name="OC\Http\Client\LocalAddressChecker" />
-				<!-- these are classes form activity app, which isn't cloned while doing static code analysis -->
+				<!-- these classes belong to the terms_of_service app, which isn't compulsory, so might not exist while running psalm -->
+				<referencedClass name="OCA\TermsOfService\Events\TermsCreatedEvent" />
+				<referencedClass name="OCA\TermsOfService\Events\SignaturesResetEvent" />
+				<referencedClass name="OCA\TermsOfService\Db\Mapper\SignatoryMapper" />
+				<referencedClass name="OCA\TermsOfService\Db\Entities\Signatory" />
+				<referencedClass name="OCA\TermsOfService\Db\Mapper\TermsMapper" />
+				<!-- these classes belong to the activity app, which isn't compulsory, so might not exist while running psalm -->
 				<referencedClass name="OCA\Activity\UserSettings" />
 				<referencedClass name="OCA\Activity\GroupHelperDisabled" />
 				<referencedClass name="OCA\Activity\Data" />
-				<!-- this is a class form groupsfolder app, which isn't available while doing static code analysis -->
+				<!-- these classes belong to the groupfolders app, which isn't compulsory, so might not exist while running psalm -->
 				<referencedClass name="OCA\GroupFolders\Folder\FolderManager" />
 				<referencedClass name="Helmich\JsonAssert\JsonAssertions" />
+				<!-- these classes belong to the event app, which isn't compulsory, so might not exist while running psalm -->
+				<referencedClass name="OCP\App\Events\AppEnableEvent" />
 			</errorLevel>
 		</UndefinedClass>
 		<TooFewArguments>
@@ -60,6 +71,12 @@
 				<!-- make psalm not complain if groupfolders app does not exist -->
 				<referencedClass name="OCA\GroupFolders\Folder\FolderManager"/>
 				<referencedClass name="OC\Http\Client\LocalAddressChecker"/>
+				<!-- these are classes form terms_of_service app, which isn't cloned while doing static code analysis -->
+				<referencedClass name="OCA\TermsOfService\Db\Mapper\SignatoryMapper" />
+				<!-- these are classes form activity app, which isn't cloned while doing static code analysis -->
+				<referencedClass name="OCA\Activity\UserSettings" />
+				<referencedClass name="OCA\Activity\GroupHelperDisabled" />
+				<referencedClass name="OCA\Activity\Data" />
 			</errorLevel>
 		</UndefinedDocblockClass>
 	</issueHandlers>

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -609,6 +609,7 @@ class FeatureContext implements Context {
 			$expectedHeaderValue = $header['value'];
 			$returnedHeader = $this->response->getHeader($headerName);
 
+			$headerValue = $returnedHeader;
 			if (\is_array($returnedHeader)) {
 				if (empty($returnedHeader)) {
 					throw new Exception(
@@ -619,10 +620,6 @@ class FeatureContext implements Context {
 					);
 				}
 				$headerValue = $returnedHeader[0];
-			}
-			// @phpstan-ignore-next-line
-			else {
-				$headerValue = $returnedHeader;
 			}
 
 			Assert::assertEquals(

--- a/tests/lib/Controller/ConfigControllerTest.php
+++ b/tests/lib/Controller/ConfigControllerTest.php
@@ -836,6 +836,7 @@ class ConfigControllerTest extends TestCase {
 	public function checkForUsersCountBeforeTest($expectedCount = 1): IUserManager {
 		$actualCount = 1;
 		$userManager = \OC::$server->getUserManager();
+		$count = 0;
 		$function = function (IUser $user) use (&$count) {
 			$count++;
 			return null;

--- a/tests/stub.phpstub
+++ b/tests/stub.phpstub
@@ -1,0 +1,63 @@
+// CacheItem implementation of CacheItemInterface doesn't have the exact structure in terms of return type
+// and the psalm analyzer fails early with this error:
+// PHP Fatal error:  Declaration of Doctrine\Common\Cache\Psr6\CacheItem::get() must be compatible
+// with Psr\Cache\CacheItemInterface::get(): mixed in nextcloud/master/3rdparty/doctrine/cache/lib/Doctrine/Common/Cache/Psr6/CacheItem.php on line 51
+// So the class CacheItem is stubbed
+
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2024 Nabin Ale <nabin@jankaritech.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Doctrine\Common\Cache\Psr6 {
+	use Psr\Cache\CacheItemInterface;
+
+	class CacheItem implements CacheItemInterface
+	{
+		public function getKey(): string
+		{
+		}
+
+		public function get(): mixed
+		{
+		}
+
+		public function isHit(): bool
+		{
+		}
+
+		public function set($value): self
+		{
+		}
+
+		public function expiresAt($expiration): self
+		{
+		}
+
+		public function expiresAfter($time): self
+		{
+		}
+
+		public function getExpiry(): ?float
+		{
+		}
+	}
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR following activities are performed: 
- fixes the error while running psalm 

```console
PHP Fatal error:  Declaration of Doctrine\Common\Cache\Psr6\CacheItem::get() must be compatible with Psr\Cache\CacheItemInterface::get(): mixed in nextcloud/master/3rdparty/doctrine/cache/lib/Doctrine/Common/Cache/Psr6/CacheItem.php on line 51
```

- Removing the phpstan from the CI

## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://community.openproject.org/projects/nextcloud-integration/work_packages/50516/activity

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
