### PR TITLE
Make API test run for stable 26 and 27 run in php8.2

### DIFF
--- a/.github/workflows/shared_workflow.yml
+++ b/.github/workflows/shared_workflow.yml
@@ -177,6 +177,10 @@ jobs:
           - isScheduledEventNightly: false
             phpVersionMinor: 1
           - isScheduledEventNightly: false
+            nextcloudVersion: stable28
+            phpVersionMinor: 2
+          - isScheduledEventNightly: false
+            nextcloudVersion: stable29
             phpVersionMinor: 2
     runs-on: ubuntu-20.04
     container:


### PR DESCRIPTION
## Description
We changed the CI to run our API tests with PHP version `8.3` in PR https://github.com/nextcloud/integration_openproject/pull/644. But because only NC-28 and NC-29 support PHP 8.3 CI would run only these versions.
Our app also supports NC-26 and NC-27. In this PR API tests for NC 26 & NC-27 are enabled to run with PHP 8.2
The goal is to run API tests in PRs for each NC version.

## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
