### PR TITLE
[WP#56056]Fix icon color dark mode

### DIFF
--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -48,7 +48,7 @@
 					@click="saveOpenProjectHostUrl">
 					<template #icon>
 						<NcLoadingIcon v-if="loadingServerHostForm" class="loading-spinner" :size="20" />
-						<CheckBoldIcon v-else :size="20" />
+						<CheckBoldIcon v-else fill-color="#FFFFFF" :size="20" />
 					</template>
 					{{ t('integration_openproject', 'Save') }}
 				</NcButton>
@@ -101,7 +101,7 @@
 						@click="saveOPOAuthClientValues">
 						<template #icon>
 							<NcLoadingIcon v-if="loadingOPOauthForm" class="loading-spinner" :size="20" />
-							<CheckBoldIcon v-else :size="20" />
+							<CheckBoldIcon v-else fill-color="#FFFFFF" :size="20" />
 						</template>
 						{{ t('integration_openproject', 'Save') }}
 					</NcButton>
@@ -149,7 +149,7 @@
 						data-test-id="submit-nc-oauth-values-form-btn"
 						@click="setNCOAuthFormToViewMode">
 						<template #icon>
-							<CheckBoldIcon :size="20" />
+							<CheckBoldIcon fill-color="#FFFFFF" :size="20" />
 						</template>
 						{{ t('integration_openproject', 'Yes, I have copied these values') }}
 					</NcButton>
@@ -198,7 +198,7 @@
 								data-test-id="complete-without-project-folder-form-btn"
 								@click="completeIntegrationWithoutProjectFolderSetUp">
 								<template #icon>
-									<CheckBoldIcon :size="20" />
+									<CheckBoldIcon fill-color="#FFFFFF" :size="20" />
 								</template>
 								{{
 									textLabelProjectFolderSetupButton
@@ -233,7 +233,7 @@
 								@click="setUpProjectGroupFolders">
 								<template #icon>
 									<NcLoadingIcon v-if="loadingProjectFolderSetup" class="loading-spinner" :size="20" />
-									<CheckBoldIcon v-else :size="20" />
+									<CheckBoldIcon v-else fill-color="#FFFFFF" :size="20" />
 								</template>
 								{{ textLabelProjectFolderSetupButton }}
 							</NcButton>
@@ -300,7 +300,7 @@
 						data-test-id="submit-op-system-password-form-btn"
 						@click="setOPUserAppPasswordToViewMode">
 						<template #icon>
-							<CheckBoldIcon :size="20" />
+							<CheckBoldIcon fill-color="#FFFFFF" :size="20" />
 						</template>
 						{{ t('integration_openproject', 'Done, complete setup') }}
 					</NcButton>


### PR DESCRIPTION
## Description
The Check icon for the button in admin setting after the version bump (nextcloud/vue) to `8.12.0` seems to be black in dark mode. But it should be white in both light and dark theme.
This PR fix the check icon to make it white in both dark and light mode.


## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://community.openproject.org/projects/nextcloud-integration/work_packages/56056

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
