### PR TITLE
Remove `PGSQL` jobs from CI to reduce docker image pull 

### DIFF
--- a/.github/workflows/shared_workflow.yml
+++ b/.github/workflows/shared_workflow.yml
@@ -166,7 +166,7 @@ jobs:
         nextcloudVersion: [ stable26, stable27, stable28, stable29, master ]
         phpVersionMajor: [ 8 ]
         phpVersionMinor: [ 0, 1, 2, 3 ]
-        database: [pgsql, mysql]
+        database: [mysql]
         isScheduledEventNightly:
           - ${{github.event_name == 'schedule'}}
         exclude:


### PR DESCRIPTION
## Description
This PR removes the `pgsql` jobs from the CI to reduce the docker images pull in CI as the pull rate for the authenticated user is limit to 200 pulls in 6 hours and our CI is failing because of that in nightly as well as in PRs. This is a temporary solution for the CI fix. But the further fix would need to be permanent one (either using caching concepts or using premium version for the docker)


## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes (https://community.openproject.org/projects/nextcloud-integration/work_packages/56155)

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
