### PR TITLE
[WP#5464]Ctime adjustment

### DIFF
--- a/tests/acceptance/features/api/getFileinfoByFileIDAPI.feature
+++ b/tests/acceptance/features/api/getFileinfoByFileIDAPI.feature
@@ -1348,3 +1348,33 @@ Feature: retrieve file information of a single file, using the file ID
       }
       }
       """
+
+  Scenario: check creation date with direct upload
+    Given user "Carol" has been created
+    And user "Carol" got a direct-upload token for "/"
+    When an anonymous user sends a multipart form data POST request to the "direct-upload/%last-created-direct-upload-token%" endpoint with:
+      | file_name | textfile0.txt |
+      | data      | some data     |
+    And user "Carol" gets the information of the folder "/textfile0.txt"
+    Then the HTTP status code should be "200"
+    And the ocs data of the response should match
+    """"
+      {
+      "type": "object",
+      "required": [
+      "id",
+      "name",
+      "ctime"
+      ],
+      "not": {
+      "required": [
+      "trashed"
+      ]
+      },
+      "properties": {
+      "id" : {"type" : "integer", "minimum": 1, "maximum": 99999},
+      "ctime" : {"type" : "integer", "pattern": "^\\d{10}$"},
+      "name": {"type": "string", "pattern": "^textfile0.txt$"}
+      }
+      }
+      """

--- a/tests/acceptance/features/api/getFileinfoByFileIDAPI.feature
+++ b/tests/acceptance/features/api/getFileinfoByFileIDAPI.feature
@@ -1349,32 +1349,23 @@ Feature: retrieve file information of a single file, using the file ID
       }
       """
 
-  Scenario: check creation date with direct upload
+  Scenario: check creation date for a resource with direct upload
     Given user "Carol" has been created
     And user "Carol" got a direct-upload token for "/"
-    When an anonymous user sends a multipart form data POST request to the "direct-upload/%last-created-direct-upload-token%" endpoint with:
+    And an anonymous user has sent a multipart form data POST request to the "direct-upload/%last-created-direct-upload-token%" endpoint with:
       | file_name | textfile0.txt |
       | data      | some data     |
-    And user "Carol" gets the information of the folder "/textfile0.txt"
+    When user "Carol" gets the information of the folder "/textfile0.txt"
     Then the HTTP status code should be "200"
     And the ocs data of the response should match
     """"
       {
       "type": "object",
       "required": [
-      "id",
-      "name",
       "ctime"
       ],
-      "not": {
-      "required": [
-      "trashed"
-      ]
-      },
       "properties": {
-      "id" : {"type" : "integer", "minimum": 1, "maximum": 99999},
-      "ctime" : {"type" : "integer", "pattern": "^\\d{10}$"},
-      "name": {"type": "string", "pattern": "^textfile0.txt$"}
+      "ctime" : {"type" : "integer", "minimum": %now-5s%, "maximum": %now-0s%}
       }
       }
       """

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -639,9 +639,10 @@ class FeatureContext implements Context {
 		}
 
 		$input = preg_replace_callback(
-			'/%now\\+(\\d+)s%/',
+			'/%now([+-])(\\d+)s%/',
 			function ($matches) {
-				$result = time() + (int)$matches[1];
+				$operator = $matches[1];
+				$result = ($operator === '+') ? time() + (int)$matches[2] : time() - (int)$matches[2];
 				return (string) $result;
 			},
 			$input

--- a/tests/lib/Controller/DirectUploadControllerTest.php
+++ b/tests/lib/Controller/DirectUploadControllerTest.php
@@ -23,6 +23,7 @@
 
 namespace OCA\OpenProject\Controller;
 
+use OC\Files\View;
 use OCP\Files\Folder;
 use OCP\Files\InvalidContentException;
 use OCP\IL10N;
@@ -291,12 +292,14 @@ class DirectUploadControllerTest extends TestCase {
 		$userManagerMock->method('get')->willReturn($userMock);
 
 		$requestMock = $this->getMockBuilder(IRequest::class)->disableOriginalConstructor()->getMock();
+
 		$requestMock->method('getUploadedFile')->willReturn([
 			'name' => 'file.txt',
 			'tmp_name' => $uploadedFileTmpName,
 			'size' => $uploadedFileSize,
 			'error' => $uploadedFileError
 		]);
+		$viewMock = $this->getMockBuilder(View::class)->disableOriginalConstructor()->getMock();
 		return new DirectUploadController(
 			'integration_openproject',
 			$requestMock,
@@ -307,6 +310,7 @@ class DirectUploadControllerTest extends TestCase {
 			$this->getMockBuilder('OCA\OpenProject\Service\DatabaseService')->disableOriginalConstructor()->getMock(),
 			$this->l,
 			'testUser',
+			$viewMock
 		);
 	}
 


### PR DESCRIPTION
## Description
This PR
- Adds a timestamp as creation date for a file uploaded through the direct upload endpoint.


## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://community.openproject.org/projects/nextcloud-integration/work_packages/56592/activity?query_id=5464

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
