### PR TITLE
[WP#5464]Apply `typeahead` with `debounce` while searching projects to create workpackage from Nextcloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Bump packages version
 - Fix random deactivation of automatically managed project folder
 - Fix avatar not found in openproject
+- Enhance project search when creating workpackages from Nextcloud
 
 ## 2.6.3 - 2024-04-17
 ### Changed

--- a/lib/Controller/OpenProjectAPIController.php
+++ b/lib/Controller/OpenProjectAPIController.php
@@ -361,15 +361,17 @@ class OpenProjectAPIController extends Controller {
 
 	/**
 	 * @NoAdminRequired
+	 * @param string|null $searchQuery
+	 * @return DataResponse
 	 */
-	public function getAvailableOpenProjectProjects(): DataResponse {
+	public function getAvailableOpenProjectProjects(?string $searchQuery = null): DataResponse {
 		if ($this->accessToken === '') {
 			return new DataResponse('', Http::STATUS_UNAUTHORIZED);
 		} elseif (!OpenProjectAPIService::validateURL($this->openprojectUrl)) {
 			return new DataResponse('', Http::STATUS_BAD_REQUEST);
 		}
 		try {
-			$result = $this->openprojectAPIService->getAvailableOpenProjectProjects($this->userId);
+			$result = $this->openprojectAPIService->getAvailableOpenProjectProjects($this->userId, $searchQuery);
 		} catch (OpenprojectErrorException $e) {
 			return new DataResponse($e->getMessage(), $e->getCode());
 		} catch (\Exception $e) {

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -1421,7 +1421,7 @@ class OpenProjectAPIService {
 	public function getAvailableOpenProjectProjects(string $userId, string $searchQuery = null): array {
 		$resultsById = [];
 		$filters = [];
-		if($searchQuery) {
+		if ($searchQuery) {
 			$filters[] = ['typeahead' => ['operator' => '**', 'values' => [$searchQuery]]];
 		}
 		$filters[] = [

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -1411,14 +1411,19 @@ class OpenProjectAPIService {
 
 	/**
 	 * @param string $userId
+	 * @param string|null $searchQuery
 	 *
 	 * @return array<mixed>
 	 *
 	 * @throws OpenprojectErrorException
 	 * @throws OpenprojectResponseException|PreConditionNotMetException|\JsonException
 	 */
-	public function getAvailableOpenProjectProjects(string $userId): array {
+	public function getAvailableOpenProjectProjects(string $userId, string $searchQuery = null): array {
 		$resultsById = [];
+		$filters = [];
+		if($searchQuery) {
+			$filters[] = ['typeahead' => ['operator' => '**', 'values' => [$searchQuery]]];
+		}
 		$filters[] = [
 			'storageUrl' =>
 				['operator' => '=', 'values' => [$this->urlGenerator->getBaseUrl()]],
@@ -1426,7 +1431,8 @@ class OpenProjectAPIService {
 				['operator' => '&=', 'values' => ["file_links/manage", "work_packages/create"]]
 		];
 		$params = [
-			'filters' => json_encode($filters, JSON_THROW_ON_ERROR)
+			'filters' => json_encode($filters, JSON_THROW_ON_ERROR),
+			'pageSize' => 100
 		];
 		$result = $this->request($userId, 'work_packages/available_projects', $params);
 		if (isset($result['error'])) {

--- a/src/views/CreateWorkPackageModal.vue
+++ b/src/views/CreateWorkPackageModal.vue
@@ -293,7 +293,7 @@ export default {
 			return this.mappedProjects()
 		},
 		getNoOptionText() {
-			if(this.availableProjects.length === 0) {
+			if (this.availableProjects.length === 0) {
 				return t('integration_openproject', 'No matching work projects found!')
 			}
 			// while projects are being searched we make the no text option empty

--- a/tests/jest/fixtures/openprojectAvailableProjectResponseAfterSearch.json
+++ b/tests/jest/fixtures/openprojectAvailableProjectResponseAfterSearch.json
@@ -1,0 +1,76 @@
+{
+	"12": {
+		"_type": "Project",
+		"id": 12,
+		"identifier": "searchedProject",
+		"name": "searchedProject",
+		"active": true,
+		"public": false,
+		"description": {
+			"format": "markdown",
+			"raw": "",
+			"html": ""
+		},
+		"createdAt": "2023-10-10T11:20:55Z",
+		"updatedAt": "2023-10-10T11:20:55Z",
+		"statusExplanation": {
+			"format": "markdown",
+			"raw": "",
+			"html": ""
+		},
+		"_links": {
+			"self": {
+				"href": "/api/v3/projects/12",
+				"title": "searchedProject"
+			},
+			"createWorkPackage": {
+				"href": "/api/v3/projects/12/work_packages/form",
+				"method": "post"
+			},
+			"createWorkPackageImmediately": {
+				"href": "/api/v3/projects/12/work_packages",
+				"method": "post"
+			},
+			"workPackages": {
+				"href": "/api/v3/projects/12/work_packages"
+			},
+			"categories": {
+				"href": "/api/v3/projects/12/categories"
+			},
+			"versions": {
+				"href": "/api/v3/projects/12/versions"
+			},
+			"memberships": {
+				"href": "/api/v3/memberships?filters=%5B%7B%22project%22%3A%7B%22operator%22%3A%22%3D%22%2C%22values%22%3A%5B%227%22%5D%7D%7D%5D"
+			},
+			"types": {
+				"href": "/api/v3/projects/12/types"
+			},
+			"update": {
+				"href": "/api/v3/projects/12/form",
+				"method": "post"
+			},
+			"updateImmediately": {
+				"href": "/api/v3/projects/12",
+				"method": "patch"
+			},
+			"delete": {
+				"href": "/api/v3/projects/12",
+				"method": "delete"
+			},
+			"schema": {
+				"href": "/api/v3/projects/schema"
+			},
+			"status": {
+				"href": null
+			},
+			"projectStorages": {
+				"href": "/api/v3/project_storages?filters=%5B%7B%22projectId%22%3A%7B%22operator%22%3A%22%3D%22%2C%22values%22%3A%5B%227%22%5D%7D%7D%5D"
+			},
+			"parent": {
+				"href": "/api/v3/projects/5",
+				"title": "[dev] Large child"
+			}
+		}
+	}
+}

--- a/tests/jest/views/CreateWorkpackageModal.spec.js
+++ b/tests/jest/views/CreateWorkpackageModal.spec.js
@@ -90,6 +90,7 @@ describe('CreateWorkPackageModal.vue', () => {
 			})
 			it('should send a search query request when searched project is not found', async () => {
 				await inputField.setValue('Scw')
+				// for a search debounce request, minimum 500 ms wait is required
 				await new Promise(resolve => setTimeout(resolve, 500))
 				expect(axiosSpy).toHaveBeenCalledWith('http://localhost/apps/integration_openproject/projects',
 					{
@@ -100,18 +101,6 @@ describe('CreateWorkPackageModal.vue', () => {
 				)
 			})
 
-			it('should send a search query request when searched project is not found', async () => {
-				await inputField.setValue('Scw')
-				await new Promise(resolve => setTimeout(resolve, 500))
-				expect(wrapper.vm.isFetchingProjectsFromOpenProjectWithQuery).toBe(true)
-				expect(axiosSpy).toHaveBeenCalledWith('http://localhost/apps/integration_openproject/projects',
-					{
-						params: {
-							searchQuery: 'Scw',
-						},
-					},
-				)
-			})
 			it('should show "No matching work projects found!" when the searched project is not found', async () => {
 				const axiosSpyWithSearchQuery = jest.spyOn(axios, 'get')
 					.mockImplementationOnce(() => Promise.resolve({
@@ -120,6 +109,7 @@ describe('CreateWorkPackageModal.vue', () => {
 					}))
 				await inputField.setValue('Scw')
 				expect(wrapper.vm.isFetchingProjectsFromOpenProjectWithQuery).toBe(true)
+				// for a search debounce request, minimum 500 ms wait is required
 				await new Promise(resolve => setTimeout(resolve, 500))
 				expect(axiosSpyWithSearchQuery).toHaveBeenCalledWith('http://localhost/apps/integration_openproject/projects',
 					{
@@ -132,7 +122,7 @@ describe('CreateWorkPackageModal.vue', () => {
 				expect(searchResult.text()).toBe('No matching work projects found!')
 			})
 
-			it('should fetch searched when project is not found in initial list', async () => {
+			it('should fetch projects when not found in initial available projects', async () => {
 				const axiosSpyWithSearchQuery = jest.spyOn(axios, 'get')
 					.mockImplementationOnce(() => Promise.resolve({
 						status: 200,
@@ -140,6 +130,7 @@ describe('CreateWorkPackageModal.vue', () => {
 					}))
 				const inputField = wrapper.find(projectInputField)
 				await inputField.setValue('se')
+				// for a search debounce request, minimum 500 ms wait is required
 				await new Promise(resolve => setTimeout(resolve, 500))
 				expect(axiosSpyWithSearchQuery).toHaveBeenCalledWith('http://localhost/apps/integration_openproject/projects',
 					{
@@ -152,10 +143,10 @@ describe('CreateWorkPackageModal.vue', () => {
 				expect(searchResult.text()).toBe('searchedProject')
 			})
 
-			it('should always initially fetched projects when nothing searched', async () => {
+			it('should set available projects to initially fetched projects when nothing searched', async () => {
 				await inputField.setValue(' ')
 				const searchResult = wrapper.findAll(projectOptionsSelector)
-				// the initially fetched available project includes 7 openproject projects
+				// the initially fetched available projects include 7 openproject projects
 				expect(searchResult.length).toBe(7)
 			})
 		})


### PR DESCRIPTION
## Description
Previously we used to fetch all the projects (linked to `Nextcloud` host) to create WorkPackages from Nextcloud. But now based on the `pageSize` parameter set on `OpenProject`, they provides the the available projects response. 
So this PR
- Make the default `pageSize` for the available OpenProject response to `100` or can be decided
- Make search request to the OpenPtoject when the available project is not in the initially fetched OpenProject available projects.

Also:
- [x] Add UI Unit tests
- [x] Add php Unit tests


## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://community.openproject.org/projects/nextcloud-integration/work_packages/56588/activity?query_id=5464
## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
