### PR TITLE
Change branch from master to stable30 in CI

### DIFF
--- a/.github/workflows/shared_workflow.yml
+++ b/.github/workflows/shared_workflow.yml
@@ -11,14 +11,14 @@ jobs:
     name: unit tests and linting
     strategy:
       matrix:
-        nextcloudVersion: [ stable26, stable27, stable28, stable29, master ]
+        nextcloudVersion: [ stable26, stable27, stable28, stable29, stable30 ]
         phpVersion: [ 8.0, 8.1, 8.2, 8.3]
         exclude:
           - nextcloudVersion: stable26
             phpVersion: 8.3
           - nextcloudVersion: stable27
             phpVersion: 8.3
-          - nextcloudVersion: master
+          - nextcloudVersion: stable30
             phpVersion: 8.0
     runs-on: ubuntu-20.04
     steps:
@@ -180,7 +180,7 @@ jobs:
     name: API tests
     strategy:
       matrix:
-        nextcloudVersion: [ stable26, stable27, stable28, stable29, master ]
+        nextcloudVersion: [ stable26, stable27, stable28, stable29, stable30 ]
         phpVersionMajor: [ 8 ]
         phpVersionMinor: [ 0, 1, 2, 3 ]
         database: [mysql]
@@ -191,7 +191,7 @@ jobs:
             phpVersionMinor: 3
           - nextcloudVersion: stable27
             phpVersionMinor: 3
-          - nextcloudVersion: master
+          - nextcloudVersion: stable30
             phpVersionMinor: 0
           - isScheduledEventNightly: false
             phpVersionMinor: 0


### PR DESCRIPTION
## Description
The `master` branch of nextcloud seems to be change to some version `31.x.x` and in our CI our application depends on apps like groupfolders, activity  which does not support the `31.x.x` version of nextcloud yet. So this PR changes the master branch to stable30 so that the apps are compatible to the stable30 of nextcloud.

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
