### PR TITLE
add gd extension in release workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         uses: shivammathur/setup-php@a4e22b60bbb9c1021113f2860347b0759f66fe5d
         with:
           php-version: '8.2'
-          extensions: mbstring, intl, sqlite3
+          extensions: mbstring, intl, sqlite3, gd
           ini-values: post_max_size=256M, max_execution_time=180
           coverage: xdebug
           tools: php-cs-fixer, phpunit


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
In this PR, `gd` extensions is added on release CI since there cames following error:

```zsh
PHP module GD not installed.
{"reqId":"e4tmmptphQoRHQtytlAx","level":3,"time":"2024-08-15T09:46:49+00:00","remoteAddr":"","user":"--","app":"PHP","method":"","url":"--","message":"fopen(/home/runner/html/nextcloud/config/config.php): Failed to open stream: No such file or directory at /home/runner/html/nextcloud/lib/private/Config.php#221","userAgent":"--","version":"","data":{"app":"PHP"}}
Please ask your server administrator to install the module.
```

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
