### PR TITLE
[WP#56328]Fix error message when upload is restricted by file access control in `Nextcloud`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix random deactivation of automatically managed project folder
 - Fix avatar not found in openproject
 - Enhance project search when creating workpackages from Nextcloud
+- Fix issue preventing direct uploading of resources in Nextcloud that are managed by app `Files Access Control`
 
 ## 2.6.4 - 2024-08-15
 ### Changed

--- a/lib/Controller/DirectUploadController.php
+++ b/lib/Controller/DirectUploadController.php
@@ -277,7 +277,7 @@ class DirectUploadController extends ApiController {
 				'error' => $this->l->t($e->getMessage())
 			], Http::STATUS_BAD_REQUEST);
 		} catch (ForbiddenException | FileAccessForbiddenException $e) {
-			// the FileAccessForbiddenException can occur when we are not allowed to perform certain operation
+			// the FileAccessForbiddenException can occur when we are not allowed to perform certain file operation
 			// which is controlled by Nextcloud app File Access Control.
 			return new DataResponse([
 				'error' => $this->l->t($e->getMessage())

--- a/lib/Controller/DirectUploadController.php
+++ b/lib/Controller/DirectUploadController.php
@@ -277,6 +277,8 @@ class DirectUploadController extends ApiController {
 				'error' => $this->l->t($e->getMessage())
 			], Http::STATUS_BAD_REQUEST);
 		} catch (ForbiddenException | FileAccessForbiddenException $e) {
+			// the FileAccessForbiddenException can occur when we are not allowed to perform certain operation
+			// which is controlled by Nextcloud app File Access Control.
 			return new DataResponse([
 				'error' => $this->l->t($e->getMessage())
 			], Http::STATUS_FORBIDDEN);

--- a/lib/Controller/DirectUploadController.php
+++ b/lib/Controller/DirectUploadController.php
@@ -40,6 +40,7 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\Files\File;
 use OCP\Files\FileInfo;
+use OCP\Files\ForbiddenException as FileAccessForbiddenException;
 use OCP\Files\InvalidCharacterInPathException;
 use OCP\Files\InvalidContentException;
 use OCP\Files\InvalidPathException;
@@ -275,7 +276,7 @@ class DirectUploadController extends ApiController {
 			return new DataResponse([
 				'error' => $this->l->t($e->getMessage())
 			], Http::STATUS_BAD_REQUEST);
-		} catch (ForbiddenException $e) {
+		} catch (ForbiddenException | FileAccessForbiddenException $e) {
 			return new DataResponse([
 				'error' => $this->l->t($e->getMessage())
 			], Http::STATUS_FORBIDDEN);

--- a/tests/lib/Controller/DirectUploadControllerTest.php
+++ b/tests/lib/Controller/DirectUploadControllerTest.php
@@ -25,6 +25,7 @@ namespace OCA\OpenProject\Controller;
 
 use OC\Files\View;
 use OCP\Files\Folder;
+use OCP\Files\ForbiddenException as FileAccessForbiddenException;
 use OCP\Files\InvalidContentException;
 use OCP\IL10N;
 use OCP\IRequest;
@@ -185,6 +186,7 @@ class DirectUploadControllerTest extends TestCase {
 	public function newFileExceptionsDataProvider() {
 		return [
 			[new InvalidContentException('Virus detected'), 'Virus detected', 415],
+			[new FileAccessForbiddenException('Access denied by the access control', false), 'Access denied by the access control', 403],
 			[new \Exception('could not upload'), 'could not upload', 500],
 		];
 	}


### PR DESCRIPTION
## Description
When `Files access control` app is enabled in the Nextcloud and has some restriction to some file for access (read, write, upload and so on) from our application we seems to pass the status code `500` and it resulted as internal server error when we direct upload restricted files/folder from OpenProject.

This PR:
- Catch the exception with proper status code and error message (given by the Nextcloud server).

## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes (https://community.openproject.org/projects/nextcloud-integration/work_packages/56328)

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [x] Updated `CHANGELOG.md` file
