### PR TITLE
Drop support for nc 26

### DIFF
--- a/.github/workflows/shared_workflow.yml
+++ b/.github/workflows/shared_workflow.yml
@@ -11,11 +11,9 @@ jobs:
     name: unit tests and linting
     strategy:
       matrix:
-        nextcloudVersion: [ stable26, stable27, stable28, stable29, stable30 ]
+        nextcloudVersion: [ stable27, stable28, stable29, stable30 ]
         phpVersion: [ 8.0, 8.1, 8.2, 8.3]
         exclude:
-          - nextcloudVersion: stable26
-            phpVersion: 8.3
           - nextcloudVersion: stable27
             phpVersion: 8.3
           - nextcloudVersion: stable30
@@ -180,15 +178,13 @@ jobs:
     name: API tests
     strategy:
       matrix:
-        nextcloudVersion: [ stable26, stable27, stable28, stable29, stable30 ]
+        nextcloudVersion: [ stable27, stable28, stable29, stable30 ]
         phpVersionMajor: [ 8 ]
         phpVersionMinor: [ 0, 1, 2, 3 ]
         database: [pgsql, mysql]
         isScheduledEventNightly:
           - ${{github.event_name == 'schedule'}}
         exclude:
-          - nextcloudVersion: stable26
-            phpVersionMinor: 3
           - nextcloudVersion: stable27
             phpVersionMinor: 3
           - nextcloudVersion: stable30
@@ -297,10 +293,6 @@ jobs:
       - name: API Tests
         env:
           NEXTCLOUD_BASE_URL: http://nextcloud
-          BEHAT_FILTER_TAGS: ${{
-            matrix.nextcloudVersion == 'stable26' && '~@skipOnStable26' ||
-            ''
-            }}
         run: |
           # The following if block can be removed once Nextcloud no longer supports PHP 8.0
           if [ "${{matrix.phpVersionMajor}}" -eq 8 ] && [ "${{matrix.phpVersionMinor}}" -eq 0 ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix random deactivation of automatically managed project folder
 - Fix avatar not found in openproject
 - Enhance project search when creating workpackages from Nextcloud
+- Drop application's support for Nextcloud 26
 
 ## 2.6.4 - 2024-08-15
 ### Changed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -41,7 +41,7 @@ For more information on how to set up and use the OpenProject application, pleas
 	<screenshot>https://github.com/nextcloud/integration_openproject/raw/master/img/screenshot1.png</screenshot>
 	<screenshot>https://github.com/nextcloud/integration_openproject/raw/master/img/screenshot2.png</screenshot>
 	<dependencies>
-		<nextcloud min-version="26" max-version="30" />
+		<nextcloud min-version="27" max-version="30" />
 	</dependencies>
 	<background-jobs>
 		<job>OCA\OpenProject\BackgroundJob\RemoveExpiredDirectUploadTokens</job>

--- a/tests/acceptance/features/api/setup.feature
+++ b/tests/acceptance/features/api/setup.feature
@@ -678,9 +678,7 @@ Feature: setup the integration through an API
     When user "OpenProject" sends a "PROPFIND" request to "/remote.php/webdav" using old app password
     Then the HTTP status code should be "401"
 
-  # to locally run this test the "project folder" needs to be setup already
-  # issue of group folder https://github.com/nextcloud/groupfolders/issues/2718
-  @skipOnStable25 @skipOnStable26
+
   Scenario: check version of uploaded file inside a group folder
     Given user "Carol" has been created
     And user "Carol" has been added to the group "OpenProject"
@@ -693,9 +691,7 @@ Feature: setup the integration through an API
     When user "Carol" deletes folder "/OpenProject/OpenProject/project-demo"
     Then the HTTP status code should be 204
 
-  # to locally run this test the "project folder" needs to be setup already
-  # issue of group folder https://github.com/nextcloud/groupfolders/issues/2718
-  @skipOnStable25 @skipOnStable26
+
   Scenario: check version of uploaded file after an update inside a group folder
     Given user "Carol" has been created
     And user "Carol" has been added to the group "OpenProject"

--- a/tests/lib/Reference/WorkPackageReferenceProviderTest.php
+++ b/tests/lib/Reference/WorkPackageReferenceProviderTest.php
@@ -34,12 +34,6 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class WorkPackageReferenceProviderTest extends TestCase {
-	protected function setUp(): void {
-		if (version_compare(OC_Util::getVersionString(), '26') < 0) {
-			$this->markTestSkipped('WorkPackageReferenceProvider is only available from nextcloud 26 so skip the tests on versions below');
-		}
-	}
-
 	/**
 	 *
 	 * @param array<string> $onlyMethods

--- a/tests/lib/Reference/WorkPackageReferenceProviderTest.php
+++ b/tests/lib/Reference/WorkPackageReferenceProviderTest.php
@@ -24,7 +24,6 @@
 namespace OCA\OpenProject\Reference;
 
 use OC\Collaboration\Reference\ReferenceManager;
-use OC_Util;
 use OCA\OpenProject\AppInfo\Application;
 use OCA\OpenProject\Service\OpenProjectAPIService;
 use OCP\IConfig;

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -19,7 +19,6 @@ use OC\Authentication\Token\IProvider;
 use OC\Authentication\Token\IToken;
 use OC\Avatar\GuestAvatar;
 use OC\Http\Client\Client;
-use OC_Util;
 use OCA\GroupFolders\Folder\FolderManager;
 use OCA\OpenProject\AppInfo\Application;
 use OCA\OpenProject\Exception\OpenprojectErrorException;

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -639,53 +639,37 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$ocClient = null;
 		$client = new GuzzleClient();
 		$clientConfigMock = $this->getMockBuilder(IConfig::class)->getMock();
-
-		if (version_compare(OC_Util::getVersionString(), '27') >= 0) {
-			$clientConfigMock
-				->method('getSystemValueBool')
-				->withConsecutive(
-					['allow_local_remote_servers', false],
-					['installed', false],
-					['allow_local_remote_servers', false],
-					['allow_local_remote_servers', false],
-					['installed', false],
-					['allow_local_remote_servers', false],
-					['allow_local_remote_servers', false],
-					['installed', false],
-					['allow_local_remote_servers', false]
-				)
-				->willReturnOnConsecutiveCalls(
-					true,
-					true,
-					true,
-					true,
-					true,
-					true,
-					true,
-					true,
-					true
-				);
-			//changed from nextcloud 26
-			$ocClient = new Client(
-				$clientConfigMock,
-				$certificateManager,
-				$client,
-				$this->createMock(IRemoteHostValidator::class),
-				$this->createMock(LoggerInterface::class));
-		} elseif (version_compare(OC_Util::getVersionString(), '26') >= 0) {
-			$clientConfigMock
+		$clientConfigMock
 			->method('getSystemValueBool')
-			->with('allow_local_remote_servers', false)
-			->willReturn(true);
-
-			//changed from nextcloud 26
-			$ocClient = new Client(
-				$clientConfigMock,
-				$certificateManager,
-				$client,
-				$this->createMock(IRemoteHostValidator::class)
+			->withConsecutive(
+				['allow_local_remote_servers', false],
+				['installed', false],
+				['allow_local_remote_servers', false],
+				['allow_local_remote_servers', false],
+				['installed', false],
+				['allow_local_remote_servers', false],
+				['allow_local_remote_servers', false],
+				['installed', false],
+				['allow_local_remote_servers', false]
+			)
+			->willReturnOnConsecutiveCalls(
+				true,
+				true,
+				true,
+				true,
+				true,
+				true,
+				true,
+				true,
+				true
 			);
-		}
+		//changed from nextcloud 26
+		$ocClient = new Client(
+			$clientConfigMock,
+			$certificateManager,
+			$client,
+			$this->createMock(IRemoteHostValidator::class),
+			$this->createMock(LoggerInterface::class));
 
 		$clientService = $this->getMockBuilder('\OCP\Http\Client\IClientService')->getMock();
 		$clientService->method('newClient')->willReturn($ocClient);


### PR DESCRIPTION
## Description
This PR:
- Drops the support for Nextcloud-26 as Nextcloud-26 is not supported for enterprise anymore.
- Removes code dependent or related to Nextcloud-26 in `integration_app`
- Remove Nextcloud-26 support from CI as well (while running tests on CI)


## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://community.openproject.org/projects/nextcloud-integration/work_packages/57384

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Updated `CHANGELOG.md` file
