### PR TITLE
ci: Reduce testing matrix

### DIFF
--- a/.github/workflows/shared_workflow.yml
+++ b/.github/workflows/shared_workflow.yml
@@ -11,15 +11,17 @@ jobs:
     name: unit tests and linting
     strategy:
       matrix:
-        nextcloudVersion: [ stable26, stable27, stable28, stable29, stable30 ]
-        phpVersion: [ 8.0, 8.1, 8.2, 8.3]
-        exclude:
+        nextcloudVersion: [ stable30 ]
+        phpVersion: [ 8.1, 8.2, 8.3 ]
+        include:
           - nextcloudVersion: stable26
-            phpVersion: 8.3
-          - nextcloudVersion: stable27
-            phpVersion: 8.3
-          - nextcloudVersion: stable30
             phpVersion: 8.0
+          - nextcloudVersion: stable27
+            phpVersion: 8.0
+          - nextcloudVersion: stable28
+            phpVersion: 8.1
+          - nextcloudVersion: stable29
+            phpVersion: 8.1
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout for nightly CI
@@ -180,29 +182,40 @@ jobs:
     name: API tests
     strategy:
       matrix:
-        nextcloudVersion: [ stable26, stable27, stable28, stable29, stable30 ]
+        nextcloudVersion: [ stable30 ]
         phpVersionMajor: [ 8 ]
-        phpVersionMinor: [ 0, 1, 2, 3 ]
-        database: [pgsql, mysql]
+        phpVersionMinor: [ 1, 2, 3 ]
+        database: [ mysql ]
         isScheduledEventNightly:
           - ${{github.event_name == 'schedule'}}
-        exclude:
-          - nextcloudVersion: stable26
-            phpVersionMinor: 3
-          - nextcloudVersion: stable27
-            phpVersionMinor: 3
+        include:
+          # Each database once on the newest Server with preinstalled PHP version
           - nextcloudVersion: stable30
-            phpVersionMinor: 0
-          - isScheduledEventNightly: false
-            phpVersionMinor: 0
-          - isScheduledEventNightly: false
+            phpVersionMajor: 8
             phpVersionMinor: 1
-          - isScheduledEventNightly: false
-            nextcloudVersion: stable28
-            phpVersionMinor: 2
-          - isScheduledEventNightly: false
-            nextcloudVersion: stable29
-            phpVersionMinor: 2
+            database: pgsql
+            isScheduledEventNightly: ${{github.event_name == 'schedule'}}
+          # Each oldServer with the oldest PHP version and one database
+          - nextcloudVersion: stable26
+            phpVersionMajor: 8
+            phpVersionMinor: 0
+            database: mysql
+            isScheduledEventNightly: ${{github.event_name == 'schedule'}}
+          - nextcloudVersion: stable27
+            phpVersionMajor: 8
+            phpVersionMinor: 0
+            database: mysql
+            isScheduledEventNightly: ${{github.event_name == 'schedule'}}
+          - nextcloudVersion: stable28
+            phpVersionMajor: 8
+            phpVersionMinor: 1
+            database: mysql
+            isScheduledEventNightly: ${{github.event_name == 'schedule'}}
+          - nextcloudVersion: stable29
+            phpVersionMajor: 8
+            phpVersionMinor: 1
+            database: mysql
+            isScheduledEventNightly: ${{github.event_name == 'schedule'}}
     runs-on: ubuntu-20.04
     container:
       image: public.ecr.aws/ubuntu/ubuntu:latest

--- a/.github/workflows/shared_workflow.yml
+++ b/.github/workflows/shared_workflow.yml
@@ -186,36 +186,29 @@ jobs:
         phpVersionMajor: [ 8 ]
         phpVersionMinor: [ 1, 2, 3 ]
         database: [ mysql ]
-        isScheduledEventNightly:
-          - ${{github.event_name == 'schedule'}}
         include:
           # Each database once on the newest Server with preinstalled PHP version
           - nextcloudVersion: stable30
             phpVersionMajor: 8
             phpVersionMinor: 1
             database: pgsql
-            isScheduledEventNightly: ${{github.event_name == 'schedule'}}
           # Each oldServer with the oldest PHP version and one database
           - nextcloudVersion: stable26
             phpVersionMajor: 8
             phpVersionMinor: 0
             database: mysql
-            isScheduledEventNightly: ${{github.event_name == 'schedule'}}
           - nextcloudVersion: stable27
             phpVersionMajor: 8
             phpVersionMinor: 0
             database: mysql
-            isScheduledEventNightly: ${{github.event_name == 'schedule'}}
           - nextcloudVersion: stable28
             phpVersionMajor: 8
             phpVersionMinor: 1
             database: mysql
-            isScheduledEventNightly: ${{github.event_name == 'schedule'}}
           - nextcloudVersion: stable29
             phpVersionMajor: 8
             phpVersionMinor: 1
             database: mysql
-            isScheduledEventNightly: ${{github.event_name == 'schedule'}}
     runs-on: ubuntu-20.04
     container:
       image: public.ecr.aws/ubuntu/ubuntu:latest


### PR DESCRIPTION
The CI runs of this app are too heavy.
Please reduce the matrix to something suitable. The change in `name: unit tests and linting` looks quite "decent".
The `name: API tests` change was just to prevent this PR from swallowing another 1h55m of CI time.

A recommended matrix is:
- Test each PHP version (8.1, 8.2, 8.3) with 1 database (mysql) against 1 server (stable30)
- Test each additional database (postgres) against 1 PHP (8.1 installs fastest) the latest supported server (stable30)
- Test each older server (stable26, …, stable29) with 1 PHP version (8.1 installs fastest) against 1 database (mysql) only

---

### Matrix

Job | Before | After
---|---|---
unit tests and linting | 17 | 7
X | stable30 php8.1<br>stable30 php8.2<br>stable30 php8.3<br>stable29 php8.0<br>stable29 php8.1<br>stable29 php8.2<br>stable29 php8.3<br>stable28 php8.0<br>stable28 php8.1<br>stable28 php8.2<br>stable28 php8.3<br>stable27 php8.0<br>stable27 php8.1<br>stable27 php8.2<br>stable26 php8.0<br>stable26 php8.1<br>stable26 php8.2|stable30 php8.1<br>stable30 php8.2<br>stable30 php8.3<br>stable29 php8.1<br>stable28 php8.1<br>stable27 php8.0<br>stable26 php8.0
API tests | 34 | 8
X | stable30 php8.1 mysql<br>stable30 php8.2 mysql<br>stable30 php8.3 mysql<br>stable30 php8.1 pgsql<br>stable30 php8.2 pgsql<br>stable30 php8.3 pgsql<br>stable29 php8.0 mysql<br>stable29 php8.1 mysql<br>stable29 php8.2 mysql<br>stable29 php8.3 mysql<br>stable29 php8.0 pgsql<br>stable29 php8.1 pgsql<br>stable29 php8.2 pgsql<br>stable29 php8.3 pgsql<br>stable28 php8.0 mysql<br>stable28 php8.1 mysql<br>stable28 php8.2 mysql<br>stable28 php8.3 mysql<br>stable28 php8.0 pgsql<br>stable28 php8.1 pgsql<br>stable28 php8.2 pgsql<br>stable28 php8.3 pgsql<br>stable27 php8.0 mysql<br>stable27 php8.1 mysql<br>stable27 php8.2 mysql<br>stable27 php8.0 pgsql<br>stable27 php8.1 pgsql<br>stable27 php8.2 pgsql<br>stable26 php8.0 mysql<br>stable26 php8.1 mysql<br>stable26 php8.2 mysql<br>stable26 php8.0 pgsql<br>stable26 php8.1 pgsql<br>stable26 php8.2 pgsql | stable30 php8.1 mysql<br>stable30 php8.2 mysql<br>stable30 php8.3 mysql<br>stable30 php8.1 pgsql<br>stable29 php8.1 mysql<br>stable28 php8.1 mysql<br>stable27 php8.0 mysql<br>stable26 php8.0 mysql