### PR TITLE
[WP#57654]switch encryption for oauth secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Enhance project search when creating workpackages from Nextcloud
 - Drop application's support for Nextcloud 26
 - Fix issue preventing direct uploading of resources in Nextcloud that are managed by app `Files Access Control`
+- Hash or encrypt `client_secret` for different Nextcloud versions
 
 ## 2.6.4 - 2024-08-15
 ### Changed

--- a/lib/Service/OauthService.php
+++ b/lib/Service/OauthService.php
@@ -58,18 +58,20 @@ class OauthService {
 		$client->setName($name);
 		$client->setRedirectUri(sprintf($redirectUri, $clientId));
 		$secret = $this->secureRandom->generate(64, self::validChars);
-		if (version_compare(OC_Util::getVersionString(), '30.0.0') >= 0) {
-			$encryptedSecret = bin2hex($this->crypto->calculateHMAC($secret));
-		} elseif (version_compare(OC_Util::getVersionString(), '29.0.7') >= 0 && version_compare(OC_Util::getVersionString(), '30.0.0') < 0) {
-			$encryptedSecret = bin2hex($this->crypto->calculateHMAC($secret));
-		} elseif (version_compare(OC_Util::getVersionString(), '28.0.10') >= 0 && version_compare(OC_Util::getVersionString(), '29.0.0') < 0) {
-			$encryptedSecret = bin2hex($this->crypto->calculateHMAC($secret));
-		} elseif (version_compare(OC_Util::getVersionString(), '27.1.11.8') >= 0 && version_compare(OC_Util::getVersionString(), '28.0.0') < 0) {
-			$encryptedSecret = bin2hex($this->crypto->calculateHMAC($secret));
-		} elseif (version_compare(OC_Util::getVersionString(), '27.0.0') === 0) {
-			$encryptedSecret = $secret;
-		} else {
-			$encryptedSecret = $this->crypto->encrypt($secret);
+		$nextcloudVersion = OC_Util::getVersionString();
+		switch (true) {
+			case version_compare($nextcloudVersion, '30.0.0') >= 0:
+			case version_compare($nextcloudVersion, '29.0.7') >= 0 && version_compare($nextcloudVersion, '30.0.0') < 0:
+			case version_compare($nextcloudVersion, '28.0.10') >= 0 && version_compare($nextcloudVersion, '29.0.0') < 0:
+			case version_compare($nextcloudVersion, '27.1.11.8') >= 0 && version_compare($nextcloudVersion, '28.0.0') < 0:
+				$encryptedSecret = bin2hex($this->crypto->calculateHMAC($secret));
+				break;
+			case version_compare($nextcloudVersion, '27.0.0') === 0:
+				$encryptedSecret = $secret;
+				break;
+			default:
+				$encryptedSecret = $this->crypto->encrypt($secret);
+				break;
 		}
 		$client->setSecret($encryptedSecret);
 		$client->setClientIdentifier($clientId);

--- a/lib/Service/OauthService.php
+++ b/lib/Service/OauthService.php
@@ -52,7 +52,7 @@ class OauthService {
 	 * @param string $nextcloudVersion
 	 * @return string
 	 */
-	public function getHashedOrEncryptedSecretBasedOnNextcloudVersions(string $secret, string $nextcloudVersion): string {
+	public function hashOrEncryptSecretBasedOnNextcloudVersion(string $secret, string $nextcloudVersion): string {
 		switch (true) {
 			case version_compare($nextcloudVersion, '30.0.0') >= 0:
 			case version_compare($nextcloudVersion, '29.0.7') >= 0 && version_compare($nextcloudVersion, '30.0.0') < 0:
@@ -82,7 +82,7 @@ class OauthService {
 		$client->setRedirectUri(sprintf($redirectUri, $clientId));
 		$secret = $this->secureRandom->generate(64, self::validChars);
 		$nextcloudVersion = OC_Util::getVersionString();
-		$client->setSecret($this->getHashedOrEncryptedSecretBasedOnNextcloudVersions($secret, $nextcloudVersion));
+		$client->setSecret($this->hashOrEncryptSecretBasedOnNextcloudVersion($secret, $nextcloudVersion));
 		$client->setClientIdentifier($clientId);
 		$client = $this->clientMapper->insert($client);
 

--- a/tests/acceptance/features/api/setup.feature
+++ b/tests/acceptance/features/api/setup.feature
@@ -656,14 +656,12 @@ Feature: setup the integration through an API
       "required": [
           "nextcloud_oauth_client_name",
           "openproject_redirect_uri",
-          "nextcloud_client_id",
-          "nextcloud_client_secret"
+          "nextcloud_client_id"
        ],
       "properties": {
           "nextcloud_oauth_client_name": {"type": "string", "pattern": "^OpenProject client$"},
           "openproject_redirect_uri": {"type": "string", "pattern": "^http:\/\/some-host.de\/oauth_clients\/[A-Za-z0-9]+\/callback$"},
           "nextcloud_client_id": {"type": "string", "pattern": "[A-Za-z0-9]+"},
-          "nextcloud_client_secret": {"type": "string", "pattern": "[A-Za-z0-9]+"},
           "openproject_user_app_password": {"type": "string", "pattern": "[A-Za-z0-9]+"}
       }
     }

--- a/tests/lib/Service/OauthSeviceTest.php
+++ b/tests/lib/Service/OauthSeviceTest.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * @copyright Copyright (c) 2022 Swikriti Tripathi <swikriti@jankaritech.com>
+ *
+ * @author Your name <swikriti@jankaritech.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\OpenProject\Service;
+
+use OCA\OAuth2\Db\ClientMapper;
+use OCP\Security\ICrypto;
+use OCP\Security\ISecureRandom;
+use PHPUnit\Framework\TestCase;
+
+class OauthServiceTest extends TestCase {
+	protected function getOauthServiceMock(
+		$clientMapperMock = null,
+		$iSecureRandomMock = null,
+		$iCryptoMock = null,
+	): OauthService {
+
+		if ($clientMapperMock === null) {
+			$clientMapperMock = $this->getMockBuilder(ClientMapper::class)->disableOriginalConstructor()->getMock();
+		}
+		if ($iSecureRandomMock === null) {
+			$iSecureRandomMock = $this->getMockBuilder(ISecureRandom::class)->getMock();
+		}
+		if ($iCryptoMock === null) {
+			$iCryptoMock = $this->getMockBuilder(ICrypto::class)->getMock();
+		}
+
+		return new OauthService(
+			$clientMapperMock,
+			$iSecureRandomMock,
+			$iCryptoMock
+		);
+	}
+
+
+	/**
+	 * @return array<mixed>
+	 */
+	public function getHashedOrEncryptedSecretBasedOnNextcloudVersionsDataProvider() {
+		return [
+			[
+				"30.0.0",
+				"calculateHMAC"
+			],
+			[
+				"29.0.7",
+				"calculateHMAC"
+			],
+			[
+				"29.1.0",
+				"calculateHMAC"
+			],
+			[
+				"29.0.6",
+				"encrypt"
+			],
+			[
+				"28.0.10",
+				"calculateHMAC"
+			],
+			[
+				"28.2.0",
+				"calculateHMAC"
+			],
+			[
+				"28.0.0",
+				"encrypt"
+			],
+			[
+				"29.0.0",
+				"encrypt"
+			],
+			[
+				"27.1.11.8",
+				"calculateHMAC"
+			],
+			[
+				"27.1.12.0",
+				"calculateHMAC"
+			],
+			[
+				"27.1.1.0",
+				"encrypt"
+			]
+		];
+	}
+
+
+	/**
+	 * @dataProvider getHashedOrEncryptedSecretBasedOnNextcloudVersionsDataProvider
+	 * @param string $nextcloudVersion
+	 * @param string $hashOrEncryptFunction
+	 *
+	 * @return void
+	 *
+	 */
+	public function testGetHashedOrEncryptedClientSecretBasedOnNextcloudVersions(string $nextcloudVersion, string $hashOrEncryptFunction) {
+		$iCryptoMock = $this->getMockBuilder(ICrypto::class)->getMock();
+		$oAuthService = $this->getOauthServiceMock(null, null, $iCryptoMock);
+		$iCryptoMock->expects($this->once())->method($hashOrEncryptFunction);
+		$oAuthService->getHashedOrEncryptedSecretBasedOnNextcloudVersions("client_secret", $nextcloudVersion);
+	}
+}

--- a/tests/lib/Service/OauthSeviceTest.php
+++ b/tests/lib/Service/OauthSeviceTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @copyright Copyright (c) 2022 Swikriti Tripathi <swikriti@jankaritech.com>
+ * @copyright Copyright (c) 2024 Sagar Gurung <sagar@jankaritech.com>
  *
- * @author Your name <swikriti@jankaritech.com>
+ * @author Your name <sagar@jankaritech.com>
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -56,7 +56,7 @@ class OauthServiceTest extends TestCase {
 	/**
 	 * @return array<mixed>
 	 */
-	public function getHashedOrEncryptedSecretBasedOnNextcloudVersionsDataProvider() {
+	public function gethashOrEncryptSecretBasedOnNextcloudVersion(): array {
 		return [
 			[
 				"30.0.0",
@@ -107,7 +107,7 @@ class OauthServiceTest extends TestCase {
 
 
 	/**
-	 * @dataProvider getHashedOrEncryptedSecretBasedOnNextcloudVersionsDataProvider
+	 * @dataProvider gethashOrEncryptSecretBasedOnNextcloudVersion
 	 * @param string $nextcloudVersion
 	 * @param string $hashOrEncryptFunction
 	 *
@@ -118,6 +118,6 @@ class OauthServiceTest extends TestCase {
 		$iCryptoMock = $this->getMockBuilder(ICrypto::class)->getMock();
 		$oAuthService = $this->getOauthServiceMock(null, null, $iCryptoMock);
 		$iCryptoMock->expects($this->once())->method($hashOrEncryptFunction);
-		$oAuthService->getHashedOrEncryptedSecretBasedOnNextcloudVersions("client_secret", $nextcloudVersion);
+		$oAuthService->hashOrEncryptSecretBasedOnNextcloudVersion("client_secret", $nextcloudVersion);
 	}
 }


### PR DESCRIPTION
## Description
In OAuth, now the client secret are hashed for greater security which is done in this PR https://github.com/nextcloud/server/pull/47635. Previously we just used to encrypt it.

This PR:
- Makes changes for the hash update for different NC versions for our APP
- Also remove `client_secret` when fetching the client info for the existing user.  


## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://community.openproject.org/projects/nextcloud-integration/work_packages/57654

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Updated `CHANGELOG.md` file
