### PR TITLE
Remove version comparision for secret encryption

### DIFF
--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -222,7 +222,7 @@ class ConfigController extends Controller {
 				throw new NoUserException('User "' . Application::OPEN_PROJECT_ENTITIES_NAME . '" does not exists to create application password');
 			}
 			$appPassword = $this->openprojectAPIService->generateAppPasswordTokenForUser();
-			if($isAppPasswordBeingReplaced) {
+			if ($isAppPasswordBeingReplaced) {
 				$this->openprojectAPIService->logToAuditFile(
 					"Application password for user 'OpenProject has been replaced' with new password in application " . Application::APP_ID
 				);
@@ -290,7 +290,7 @@ class ConfigController extends Controller {
 		// resetting and keeping the project folder setup should delete the user app password
 		if (key_exists('setup_app_password', $values) && $values['setup_app_password'] === false) {
 			$this->openprojectAPIService->deleteAppPassword();
-			if(!$runningFullReset) {
+			if (!$runningFullReset) {
 				$this->openprojectAPIService->logToAuditFile(
 					"Project folder setup has been deactivated in application " . Application::APP_ID
 				);
@@ -389,14 +389,14 @@ class ConfigController extends Controller {
 				$values['openproject_client_id'] &&
 				$values['openproject_client_secret'];
 
-			if(key_exists('openproject_instance_url', $values) &&
+			if (key_exists('openproject_instance_url', $values) &&
 				$values['openproject_instance_url'] && !$isOPOAuthCrdentialSet) {
 				// sending admin audit log if admin has changed or added the openproject host url
 				$this->openprojectAPIService->logToAuditFile(
 					"OpenProject host url has been set to '" . $values['openproject_instance_url'] . "' in application " . Application::APP_ID
 				);
 			}
-			if($isOPOAuthCrdentialSet) {
+			if ($isOPOAuthCrdentialSet) {
 				$this->openprojectAPIService->logToAuditFile(
 					"OpenProject OAuth credential 'openproject_client_id' and 'openproject_client_secret' has been set in application " . Application::APP_ID
 				);

--- a/lib/Service/OauthService.php
+++ b/lib/Service/OauthService.php
@@ -58,7 +58,11 @@ class OauthService {
 		$client->setName($name);
 		$client->setRedirectUri(sprintf($redirectUri, $clientId));
 		$secret = $this->secureRandom->generate(64, self::validChars);
-		$encryptedSecret = $this->crypto->encrypt($secret);
+		if (version_compare(OC_Util::getVersionString(), '27.0.1') >= 0) {
+			$encryptedSecret = $this->crypto->encrypt($secret);
+		} else {
+			$encryptedSecret = $secret;
+		}
 		$client->setSecret($encryptedSecret);
 		$client->setClientIdentifier($clientId);
 		$client = $this->clientMapper->insert($client);

--- a/lib/Service/OauthService.php
+++ b/lib/Service/OauthService.php
@@ -58,15 +58,7 @@ class OauthService {
 		$client->setName($name);
 		$client->setRedirectUri(sprintf($redirectUri, $clientId));
 		$secret = $this->secureRandom->generate(64, self::validChars);
-		if (version_compare(OC_Util::getVersionString(), '27.0.1') >= 0) {
-			$encryptedSecret = $this->crypto->encrypt($secret);
-		} elseif (version_compare(OC_Util::getVersionString(), '26.0.4') >= 0 && version_compare(OC_Util::getVersionString(), '27.0.0') < 0) {
-			$encryptedSecret = $this->crypto->encrypt($secret);
-		} elseif (version_compare(OC_Util::getVersionString(), '25.0.8') >= 0 && version_compare(OC_Util::getVersionString(), '26.0.0') < 0) {
-			$encryptedSecret = $this->crypto->encrypt($secret);
-		} else {
-			$encryptedSecret = $secret;
-		}
+		$encryptedSecret = $this->crypto->encrypt($secret);
 		$client->setSecret($encryptedSecret);
 		$client->setClientIdentifier($clientId);
 		$client = $this->clientMapper->insert($client);

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -1112,7 +1112,7 @@ class OpenProjectAPIService {
 	 * @return void
 	 */
 	public function logToAuditFile($auditLogMessage): void {
-		if($this->isAdminAuditConfigSetCorrectly()) {
+		if ($this->isAdminAuditConfigSetCorrectly()) {
 			$this->auditLogger = new AuditLogger($this->logFactory, $this->config);
 			$this->auditLogger->info($auditLogMessage,
 				['app' => 'admin_audit']


### PR DESCRIPTION
## Description
A part of the code maintenance was missed for release `2.7` for the integration app. Since for release `2.7` it supports NC>=27,
This PR removes:
- Code for NC version check to encrypt the oauth client secret. It is available from stable NC-27. 

Part of: https://github.com/nextcloud/integration_openproject/pull/689

Part of this WP: https://community.openproject.org/projects/nextcloud-integration/work_packages/57384/activity?query_id=5464


## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://community.openproject.org/projects/nextcloud-integration/work_packages/57384/activity?query_id=5464

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
