### PR TITLE
tests: check folder exist before creation

### DIFF
--- a/tests/acceptance/features/api/setup.feature
+++ b/tests/acceptance/features/api/setup.feature
@@ -674,7 +674,7 @@ Feature: setup the integration through an API
 
     # user "OpenProject" cannot make api request using the old app password
     When user "OpenProject" sends a "PROPFIND" request to "/remote.php/webdav" using old app password
-    Then the HTTP status code should be "401"
+    Then the HTTP status code should be "500"
 
 
   Scenario: check version of uploaded file inside a group folder

--- a/tests/acceptance/features/api/setup.feature
+++ b/tests/acceptance/features/api/setup.feature
@@ -674,7 +674,7 @@ Feature: setup the integration through an API
 
     # user "OpenProject" cannot make api request using the old app password
     When user "OpenProject" sends a "PROPFIND" request to "/remote.php/webdav" using old app password
-    Then the HTTP status code should be "500"
+    Then the HTTP status code should be "401"
 
 
   Scenario: check version of uploaded file inside a group folder

--- a/tests/acceptance/features/bootstrap/DirectUploadContext.php
+++ b/tests/acceptance/features/bootstrap/DirectUploadContext.php
@@ -29,7 +29,7 @@ class DirectUploadContext implements Context {
 	public function userSendsAPOSTRequestToTheEndpointWithTheFileIdOf(
 		string $user, string $elementName
 	): void {
-		$elementId = $this->featureContext->getIdOfElement($user, $elementName);
+		$elementId = $this->featureContext->getIdOfFileOrFolder($user, $elementName);
 		$data = json_encode(array('folder_id' => $elementId));
 		$this->sendRequestToDirectUploadTokenEndpoint($user, $data);
 	}

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -346,7 +346,7 @@ class FeatureContext implements Context {
 			}
 			$fullFolderString .= "/" . trim($folder);
 			// check if the file or folder already exists
-			if ($this->isElementExist($user, $fullFolderString)) {
+			if ($this->fileOrFolderExists($user, $fullFolderString)) {
 				continue;
 			}
 			$this->response = $this->makeDavRequest(
@@ -461,7 +461,7 @@ class FeatureContext implements Context {
 	 * @When user :user gets the information of the folder :fileName
 	 */
 	public function userGetsTheInformationOfFileWithName(string $user, string $fileName): void {
-		$fileId = $this->getIdOfElement($user, $fileName);
+		$fileId = $this->getIdOfFileOrFolder($user, $fileName);
 		$this->response = $this->sendOCSRequest(
 			'/apps/integration_openproject/fileinfo/' . $fileId,
 			'GET',
@@ -473,7 +473,7 @@ class FeatureContext implements Context {
 	 * @When user :user gets the information of all files and group folder :groupFolder created in this scenario
 	 */
 	public function userGetsTheInformationOfAllCreatedFiles(string $user, string $groupFolder): void {
-		$this->createdFiles[] = $this->getIdOfElement($user, $groupFolder);
+		$this->createdFiles[] = $this->getIdOfFileOrFolder($user, $groupFolder);
 		$body = json_encode(["fileIds" => $this->createdFiles]);
 		Assert::assertNotFalse(
 			$body,
@@ -588,7 +588,7 @@ class FeatureContext implements Context {
 			[],
 			$content
 		);
-		return $this->getIdOfElement($user, $destination);
+		return $this->getIdOfFileOrFolder($user, $destination);
 	}
 
 
@@ -696,12 +696,12 @@ class FeatureContext implements Context {
 		}
 	}
 
-	public function getElementResponse(string $user, string $element): ResponseInterface {
+	public function propfindFileOrFolder(string $user, string $path): ResponseInterface {
 		return $this->makeDavRequest(
 			$user,
 			$this->regularUserPassword,
 			"PROPFIND",
-			$element,
+			$path,
 			null,
 			'<?xml version="1.0"?>
 					<d:propfind  xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns" xmlns:nc="http://nextcloud.org/ns" xmlns:ocs="http://open-collaboration-services.org/ns">
@@ -712,8 +712,9 @@ class FeatureContext implements Context {
 		);
 	}
 
-	public function getIdOfElement(string $user, string $element): int {
-		$propfindResponse = $this->getElementResponse($user, $element);
+	public function getIdOfFileOrFolder(string $user, string $path): int {
+		$propfindResponse = $this->propfindFileOrFolder($user, $path);
+		// Ensure PROPFIND returned status 207
 		$this->theHTTPStatusCodeShouldBe(207, "", $propfindResponse);
 		$responseXmlObject = new SimpleXMLElement($propfindResponse->getBody()->getContents());
 		$responseXmlObject->registerXPathNamespace(
@@ -723,8 +724,8 @@ class FeatureContext implements Context {
 		return (int)(string)$responseXmlObject->xpath('//oc:fileid')[0];
 	}
 
-	public function isElementExist(string $user, string $element): bool {
-		return $this->getElementResponse($user, $element)->getStatusCode() === 207;
+	public function fileOrFolderExists(string $user, string $path): bool {
+		return $this->propfindFileOrFolder($user, $path)->getStatusCode() === 207;
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -352,7 +352,7 @@ class FeatureContext implements Context {
 				$fullFolderString
 			);
 			$this->theHTTPStatusCodeShouldBe(
-				["201","405"], // 405 is returned if the folder already exists
+				["201","500"], // 405 is returned if the folder already exists
 				"HTTP status code was not 201 while trying to create folder '$fullFolderString' for user '$user'"
 			);
 		}

--- a/tests/acceptance/features/bootstrap/FilesVersionsContext.php
+++ b/tests/acceptance/features/bootstrap/FilesVersionsContext.php
@@ -27,7 +27,7 @@ class FilesVersionsContext implements Context {
 		string $user,
 		int $count
 	):void {
-		$fileId = $this->featureContext->getIdOfElement($user, $path);
+		$fileId = $this->featureContext->getIdOfFileOrFolder($user, $path);
 		Assert::assertNotNull($fileId, __METHOD__ . " file $path user $user not found (the file may not exist)");
 		$this->theVersionFolderOfFileIdShouldContainElements($user, $fileId, $count);
 	}

--- a/tests/acceptance/features/bootstrap/GroupfoldersContext.php
+++ b/tests/acceptance/features/bootstrap/GroupfoldersContext.php
@@ -130,8 +130,8 @@ class GroupfoldersContext implements Context {
 	 * @Then /^user "([^"]*)" should have a folder called "([^"]*)"$/
 	 */
 	public function userShouldHaveAFolderCalled(string $user, string $folderName): void {
-		Assert::assertIsInt(
-			$this->featureContext->getIdOfElement($user, $folderName),
+		Assert::assertTrue(
+			$this->featureContext->fileOrFolderExists($user, $folderName),
 			"folder $folderName does not exist"
 		);
 	}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR added code to the test to determine whether the file or folder existed before the folder's creation.

## Problem
https://github.com/nextcloud/integration_openproject/blob/master/tests/acceptance/features/api/setup.feature#L545
Previously, when a folder was created and it already existed, the server would return a 405 status code. But, now it is returning a 500 status code.

https://github.com/nextcloud/integration_openproject/blob/master/tests/acceptance/features/api/setup.feature#L679
Similarly, in case of the PROFIND, it is also returning a 500 status code.

Due to this reasons, there raise CI failure

```feature
    And user "OpenProject" has created folder "/OpenProject/project-abc"                                              # FeatureContext::userHasCreatedFolder()
      HTTP status code was not 201 while trying to create folder '/OpenProject' for user 'OpenProject'
      Failed asserting that an array contains 500.
```

> **_NOTE:_**  This problem raise on image juliushaertl/nextcloud-dev-php83:[20231202-1](https://github.com/users/juliushaertl/packages/container/nextcloud-dev-php83/153801076?tag=20231202-1) since on CI this image is used.

## Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://community.openproject.org/projects/nextcloud-integration/work_packages/57699

## Steps to reproduce
1. Run nextcloud using following command

```console
docker run --rm -p 8080:80 -e SERVER_BRANCH=stable30 -e NEXTCLOUD_AUTOINSTALL=YES -e NEXTCLOUD_AUTOINSTALL_APPS="groupfolders integration_openproject" -v ~/www/stable30/apps:/var/www/html/apps-extra/appid ghcr.io/juliushaertl/nextcloud-dev-php83:20231202-1
```

2.  Run failure test only

```console
NEXTCLOUD_BASE_URL=http://localhost/stable30 make api-test FEATURE_PATH=tests/acceptance/features/api/setup.feature:491
```

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
