### PR TITLE
chore: Remove deprecated ILogger

### DIFF
--- a/lib/Controller/FilesController.php
+++ b/lib/Controller/FilesController.php
@@ -24,12 +24,12 @@ use OCP\Files\DavUtil;
 use OCP\Files\FileInfo;
 use OCP\Files\IRootFolder;
 use OCP\IDBConnection;
-use OCP\ILogger;
 use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\Server;
+use Psr\Log\LoggerInterface;
 
 class FilesController extends OCSController {
 
@@ -54,7 +54,7 @@ class FilesController extends OCSController {
 	protected $connection;
 
 	/**
-	 * @var ILogger
+	 * @var LoggerInterface
 	 */
 	private $logger;
 
@@ -75,7 +75,7 @@ class FilesController extends OCSController {
 	 * @param IMountProviderCollection $mountCollection
 	 * @param IManager $activityManager
 	 * @param IDBConnection $connection
-	 * @param ILogger $logger
+	 * @param LoggerInterface $logger
 	 * @param IUserManager $userManager
 	 * @param DavUtil $davUtils
 	 */
@@ -87,7 +87,7 @@ class FilesController extends OCSController {
 		IMountProviderCollection $mountCollection,
 		IManager $activityManager,
 		IDBConnection $connection,
-		ILogger $logger,
+		LoggerInterface $logger,
 		IUserManager $userManager,
 		DavUtil $davUtils
 	) {

--- a/tests/lib/Controller/FilesControllerTest.php
+++ b/tests/lib/Controller/FilesControllerTest.php
@@ -7,11 +7,11 @@ use OCP\Files\Config\ICachedMountFileInfo;
 use OCP\Files\DavUtil;
 use OCP\Files\Node;
 use OCP\IDBConnection;
-use OCP\ILogger;
 use OCP\IRequest;
 use OCP\IUserManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use function PHPUnit\Framework\assertSame;
 
 /**
@@ -864,7 +864,7 @@ class FilesControllerTest extends TestCase {
 			$mountProviderCollectionMock,
 			$this->createMock(IManager::class),
 			$this->createMock(IDBConnection::class),
-			$this->createMock(ILogger::class),
+			$this->createMock(LoggerInterface::class),
 			$this->createMock(IUserManager::class),
 			$this->createMock(DavUtil::class),
 		);
@@ -915,7 +915,7 @@ class FilesControllerTest extends TestCase {
 					$mountProviderCollectionMock,
 					$this->createMock(IManager::class),
 					$this->createMock(IDBConnection::class),
-					$this->createMock(ILogger::class),
+					$this->createMock(LoggerInterface::class),
 					$this->createMock(IUserManager::class),
 					$davUtilsMock
 				])


### PR DESCRIPTION
This interface is deprecated and the logging will be removed with next release.