### PR TITLE
Fix retry icon color in dark mode

### DIFF
--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -246,7 +246,7 @@
 								@click="setUpProjectGroupFolders">
 								<template #icon>
 									<NcLoadingIcon v-if="loadingProjectFolderSetup" class="loading-spinner" :size="20" />
-									<RestoreIcon v-else :size="20" />
+									<RestoreIcon v-else fill-color="#FFFFFF" :size="20" />
 								</template>
 								{{ t('integration_openproject', 'Retry setup OpenProject user, group and folder') }}
 							</NcButton>


### PR DESCRIPTION
## Description
The retry icon when setting up automatic project folder was inconsistent in the UI for dark theme. 


## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://community.openproject.org/projects/nextcloud-integration/work_packages/58278

## Screenshots (if appropriate):
### Before fix:
![Screenshot from 2024-10-07 14-47-43](https://github.com/user-attachments/assets/3e535faf-142a-457d-9787-a5e07f02de12)


### After fix:

![Screenshot from 2024-10-07 15-43-20](https://github.com/user-attachments/assets/e5729712-e289-46ce-be56-e880ea69eb2a)



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
