### PR TITLE
[CI] Exclude master nextcloud 31 in nightly release

### DIFF
--- a/.github/workflows/shared_workflow.yml
+++ b/.github/workflows/shared_workflow.yml
@@ -11,8 +11,11 @@ jobs:
     name: unit tests and linting
     strategy:
       matrix:
-        nextcloudVersion: [ stable30, master ]
+        nextcloudVersion: [ stable30 ]
         phpVersion: [ 8.1, 8.2, 8.3 ]
+        # This condition is temporary and can be removed once Nextcloud 31 support is added in the integration app for the release/2.7 branch
+        isReleaseBranch:
+          - ${{ inputs.branch == 'release/2.7'}}
         include:
           - nextcloudVersion: stable27
             phpVersion: 8.0
@@ -22,6 +25,7 @@ jobs:
             phpVersion: 8.1
           - nextcloudVersion: master
             phpVersion: 8.3
+            isReleaseBranch: false
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout for nightly CI


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The `release/2.7` branch does not currently support Nextcloud 31 (master), as Nextcloud 31 has not been officially released.
So it will not be good to support the next cloud 31 on `release/2.7` for now. But we can later add support when there is officially released of nextcloud 31. 
Therefore, in this PR, Nextcloud 31 (master) is excluded for `release/2.7`.


## Problem
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
There is a failure in the ci of `Nightly Release CI`, since it uses branch 2.7 which does not support nextcloud 31(master)
https://github.com/nextcloud/integration_openproject/actions/runs/11225470320

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
