### PR TITLE
[WP#57970]Add warning when encryption for group folders are not enabled explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Make error handling better in `integration_setup.sh` file for integration configuration setup.
 - Improve UI by using Nextcloud's `NoteCard` in project folder setup error.
 - Resolve the issue with retrieving the Nextcloud server version for version compare
+- Add warning UI when encryption is not explicitly enabled for `groupfolders`.
 
 ## 2.7.0 - 2024-09-10
 ### Changed

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -33,6 +33,7 @@ use OCA\TermsOfService\Db\Mapper\SignatoryMapper;
 use OCA\TermsOfService\Db\Mapper\TermsMapper;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Http;
+use OCP\Encryption\IManager;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\InvalidPathException;
 use OCP\Files\IRootFolder;
@@ -119,6 +120,7 @@ class OpenProjectAPIService {
 	private ISubAdmin $subAdminManager;
 	private IDBConnection $db;
 	private ILogFactory $logFactory;
+	private IManager $encryptionManager;
 
 
 	/**
@@ -150,6 +152,7 @@ class OpenProjectAPIService {
 		ISubAdmin $subAdminManager,
 		IDBConnection $db,
 		ILogFactory $logFactory,
+		IManager $encryptionManager
 	) {
 		$this->appName = $appName;
 		$this->avatarManager = $avatarManager;
@@ -169,6 +172,7 @@ class OpenProjectAPIService {
 		$this->eventDispatcher = $eventDispatcher;
 		$this->db = $db;
 		$this->logFactory = $logFactory;
+		$this->encryptionManager = $encryptionManager;
 	}
 
 	/**
@@ -1145,7 +1149,14 @@ class OpenProjectAPIService {
 		);
 	}
 
-
+	public function isServerSideEncryptionEnabled(): bool {
+		$isEncryptionForHomeStorageEnabled = $this->config->getAppValue('encryption', 'encryptHomeStorage', '0') === '1';
+		return (
+			$this->appManager->isInstalled('encryption') &&
+			$this->encryptionManager->isEnabled() &&
+			$isEncryptionForHomeStorageEnabled
+		);
+	}
 
 	/**
 	 * @return array<mixed>

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -70,7 +70,11 @@ class Admin implements ISettings {
 			'project_folder_info' => $projectFolderStatusInformation,
 			'fresh_project_folder_setup' => $this->config->getAppValue(Application::APP_ID, 'fresh_project_folder_setup', '0') === '1',
 			'all_terms_of_services_signed' => $isAllTermsOfServiceSignedForUserOpenProject,
-			'admin_audit_configuration_correct' => $isAdminAuditConfigurationSetUpCorrectly
+			'admin_audit_configuration_correct' => $isAdminAuditConfigurationSetUpCorrectly,
+			'encryption_info' => [
+				'server_side_encryption_enabled' => $this->openProjectAPIService->isServerSideEncryptionEnabled(),
+				'encryption_enabled_for_groupfolders' => $this->config->getAppValue('groupfolders', 'enable_encryption', '') === 'true'
+			]
 		];
 
 		$adminConfigStatus = OpenProjectAPIService::isAdminConfigOk($this->config);

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -182,7 +182,7 @@
 				:title="t('integration_openproject', 'Project folders (recommended)')"
 				:is-setup-complete-without-project-folders="isSetupCompleteWithoutProjectFolders"
 				:is-there-error-after-project-folder-and-app-password-setup="isThereErrorAfterProjectFolderAndAppPasswordSetup"
-				:is-there-group-folders-encryption-warning="showEncryptionWarningForGroupFolders"
+				:show-encryption-warning-for-group-folders="showEncryptionWarningForGroupFolders"
 				:is-complete="isProjectFolderSetupCompleted"
 				:is-disabled="isProjectFolderSetUpInDisableMode"
 				:is-dark-theme="isDarkTheme" />
@@ -268,9 +268,9 @@
 					</NcNoteCard>
 					<NcNoteCard v-else-if="showEncryptionWarningForGroupFolders" class="note-card" type="warning">
 						<p class="note-card--title">
-							<b>{{ t('integration_openproject', 'Encryption for Group Folders are not enabled.') }}</b>
+							<b>{{ t('integration_openproject', 'Encryption for the Group Folders App is not enabled.') }}</b>
 						</p>
-						<p class="note-card--warning-description" v-html="getGroupFolderEncryptionWarningHint" /> <!-- eslint-disable-line vue/no-v-html -->
+						<p class="note-card--warning-description" v-html="getGroupFoldersEncryptionWarningHint" /> <!-- eslint-disable-line vue/no-v-html -->
 					</NcNoteCard>
 					<div class="form-actions">
 						<NcButton
@@ -558,10 +558,10 @@ export default {
 			const hintTextForAdminAudit = t('integration_openproject', 'To activate audit logs for the OpenProject integration, please enable the {htmlLinkForAdminAudit} app and follow the configuration steps outlined in the {htmlLinkForDocumentaion}.', { htmlLinkForAdminAudit, htmlLinkForDocumentaion }, null, { escape: false, sanitize: false })
 			return dompurify.sanitize(hintTextForAdminAudit, { ADD_ATTR: ['target'] })
 		},
-		getGroupFolderEncryptionWarningHint() {
+		getGroupFoldersEncryptionWarningHint() {
 			const linkText = t('integration_openproject', 'documentation')
 			const htmlLink = `<a class="link" href="https://www.openproject.org/docs/system-admin-guide/integrations/nextcloud/#files-are-not-encrypted-when-using-nextcloud-server-side-encryption" target="_blank" title="${linkText}">${linkText}</a>`
-			return t('integration_openproject', 'Server-side encryption is active, but encryption for group folders is not yet enabled. To ensure secure storage of files in project folders, please follow the configuration steps in the {htmlLink}.', { htmlLink }, null, { escape: false, sanitize: false })
+			return t('integration_openproject', 'Server-side encryption is active, but encryption for Group Folders is not yet enabled. To ensure secure storage of files in project folders, please follow the configuration steps in the {htmlLink}.', { htmlLink }, null, { escape: false, sanitize: false })
 		},
 		isIntegrationComplete() {
 			return (this.isServerHostFormComplete

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -182,6 +182,7 @@
 				:title="t('integration_openproject', 'Project folders (recommended)')"
 				:is-setup-complete-without-project-folders="isSetupCompleteWithoutProjectFolders"
 				:is-there-error-after-project-folder-and-app-password-setup="isThereErrorAfterProjectFolderAndAppPasswordSetup"
+				:is-there-group-folders-encryption-warning="showEncryptionWarningForGroupFolders"
 				:is-complete="isProjectFolderSetupCompleted"
 				:is-disabled="isProjectFolderSetUpInDisableMode"
 				:is-dark-theme="isDarkTheme" />
@@ -264,6 +265,10 @@
 							<b>{{ state.project_folder_info.errorMessage }}</b>
 						</p>
 						<p class="note-card--error-description" v-html="projectFolderSetUpErrorMessageDescription(state.project_folder_info.errorMessage)" /> <!-- eslint-disable-line vue/no-v-html -->
+					</NcNoteCard>
+					<NcNoteCard v-else-if="showEncryptionWarningForGroupFolders" class="note-card" type="warning">
+						<p class="note-card--title"><b>Encryption for Group Folders are not enabled.</b></p>
+						<p class="note-card--warning-description" v-html="getGroupFolderEncryptionWarningHint" /> <!-- eslint-disable-line vue/no-v-html -->
 					</NcNoteCard>
 					<div class="form-actions">
 						<NcButton
@@ -551,6 +556,11 @@ export default {
 			const hintTextForAdminAudit = t('integration_openproject', 'To activate audit logs for the OpenProject integration, please enable the {htmlLinkForAdminAudit} app and follow the configuration steps outlined in the {htmlLinkForDocumentaion}.', { htmlLinkForAdminAudit, htmlLinkForDocumentaion }, null, { escape: false, sanitize: false })
 			return dompurify.sanitize(hintTextForAdminAudit, { ADD_ATTR: ['target'] })
 		},
+		getGroupFolderEncryptionWarningHint() {
+			const linkText = t('integration_openproject', 'documentation')
+			const htmlLink = `<a class="link" href="https://www.openproject.org/docs/system-admin-guide/integrations/nextcloud/#files-are-not-encrypted-when-using-nextcloud-server-side-encryption" target="_blank" title="${linkText}">${linkText}</a>`
+			return t('integration_openproject', 'Server-side encryption is active, but encryption for group folders is not yet enabled. To ensure secure storage of files in project folders, please follow the configuration steps in the {htmlLink}.', { htmlLink }, null, { escape: false, sanitize: false })
+		},
 		isIntegrationComplete() {
 			return (this.isServerHostFormComplete
 				 && this.isOPOAuthFormComplete
@@ -570,6 +580,13 @@ export default {
 		},
 		isResetButtonDisabled() {
 			return !(this.state.openproject_client_id || this.state.openproject_client_secret || this.state.openproject_instance_url)
+		},
+		showEncryptionWarningForGroupFolders() {
+			if (!this.isProjectFolderAlreadySetup || !this.state.app_password_set || this.isProjectFolderSetupFormInEdit) {
+				return false
+			}
+			return this.state.encryption_info.server_side_encryption_enabled
+				&& !this.state.encryption_info.encryption_enabled_for_groupfolders
 		},
 	},
 	created() {
@@ -727,6 +744,7 @@ export default {
 				const success = await this.saveOPOptions()
 				if (success) {
 					this.setProjectFolderSetupToViewMode()
+					this.isProjectFolderAlreadySetup = true
 					if ((this.formMode.opUserAppPassword === F_MODES.DISABLE && !this.opUserAppPassword) || this.formMode.opUserAppPassword === F_MODES.DISABLE) {
 						this.formMode.opUserAppPassword = F_MODES.EDIT
 					}
@@ -1198,7 +1216,7 @@ export default {
 	}
 	.note-card {
 		max-width: 900px;
-		&--info-description, &--error-description {
+		&--info-description, &--error-description, &&--warning-description {
 			.link {
 				color: #1a67a3 !important;
 				font-style: normal;

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -1218,7 +1218,7 @@ export default {
 	}
 	.note-card {
 		max-width: 900px;
-		&--info-description, &--error-description, &&--warning-description {
+		&--info-description, &--error-description, &--warning-description {
 			.link {
 				color: #1a67a3 !important;
 				font-style: normal;

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -267,7 +267,9 @@
 						<p class="note-card--error-description" v-html="projectFolderSetUpErrorMessageDescription(state.project_folder_info.errorMessage)" /> <!-- eslint-disable-line vue/no-v-html -->
 					</NcNoteCard>
 					<NcNoteCard v-else-if="showEncryptionWarningForGroupFolders" class="note-card" type="warning">
-						<p class="note-card--title"><b>Encryption for Group Folders are not enabled.</b></p>
+						<p class="note-card--title">
+							<b>Encryption for Group Folders are not enabled.</b>
+						</p>
 						<p class="note-card--warning-description" v-html="getGroupFolderEncryptionWarningHint" /> <!-- eslint-disable-line vue/no-v-html -->
 					</NcNoteCard>
 					<div class="form-actions">

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -268,7 +268,7 @@
 					</NcNoteCard>
 					<NcNoteCard v-else-if="showEncryptionWarningForGroupFolders" class="note-card" type="warning">
 						<p class="note-card--title">
-							<b>Encryption for Group Folders are not enabled.</b>
+							<b>{{ t('integration_openproject', 'Encryption for Group Folders are not enabled.') }}</b>
 						</p>
 						<p class="note-card--warning-description" v-html="getGroupFolderEncryptionWarningHint" /> <!-- eslint-disable-line vue/no-v-html -->
 					</NcNoteCard>

--- a/src/components/admin/FormHeading.vue
+++ b/src/components/admin/FormHeading.vue
@@ -4,7 +4,10 @@
 		<div v-if="isProjectFolderSetupHeading && isSetupCompleteWithoutProjectFolders" class="setup-complete-without-project-folders">
 			<MinusThickIcon :fill-color="isDarkTheme ? '#000000' : '#FFFFFF'" :size="12" />
 		</div>
-		<div v-else-if="isThereErrorAfterProjectFolderAndAppPasswordSetup" class="project-folder-setup-status">
+		<div v-else-if="isThereErrorAfterProjectFolderAndAppPasswordSetup" class="project-folder-setup-error">
+			<ExclamationThickIcon fill-color="#FFFFFF" :size="12" />
+		</div>
+		<div v-else-if="isThereGroupFoldersEncryptionWarning" class="project-folder-setup-warning">
 			<ExclamationThickIcon fill-color="#FFFFFF" :size="12" />
 		</div>
 		<div v-else-if="isComplete" class="complete">
@@ -21,7 +24,8 @@
 		<div class="title"
 			:class="{
 				'green-text': isComplete,
-				'red-text': isThereErrorAfterProjectFolderAndAppPasswordSetup
+				'red-text': isThereErrorAfterProjectFolderAndAppPasswordSetup,
+				'warn-text': isThereGroupFoldersEncryptionWarning
 			}">
 			{{ title }}
 		</div>
@@ -68,6 +72,10 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+		isThereGroupFoldersEncryptionWarning: {
+			type: Boolean,
+			default: false,
+		},
 		isDarkTheme: {
 			type: Boolean,
 			default: false,
@@ -90,6 +98,10 @@ export default {
 		color: var(--color-error);
 	}
 
+	.warn-text {
+		color: var(--color-warning);
+	}
+
 	.complete {
 		height: 16px;
 		width: 16px;
@@ -100,14 +112,21 @@ export default {
 		align-items: center;
 	}
 
-	.project-folder-setup-status {
+	.project-folder-setup-error, .project-folder-setup-warning {
 		height: 16px;
 		width: 16px;
 		border-radius: 50%;
-		background-color: var(--color-error);
 		display: flex;
 		justify-content: center;
 		align-items: center;
+	}
+
+	.project-folder-setup-error {
+		background: var(--color-error);
+	}
+
+	.project-folder-setup-warning {
+		background: var(--color-warning);
 	}
 
 	.setup-complete-without-project-folders {

--- a/src/components/admin/FormHeading.vue
+++ b/src/components/admin/FormHeading.vue
@@ -7,7 +7,7 @@
 		<div v-else-if="isThereErrorAfterProjectFolderAndAppPasswordSetup" class="project-folder-setup-error">
 			<ExclamationThickIcon fill-color="#FFFFFF" :size="12" />
 		</div>
-		<div v-else-if="isThereGroupFoldersEncryptionWarning" class="project-folder-setup-warning">
+		<div v-else-if="showEncryptionWarningForGroupFolders" class="project-folder-setup-warning">
 			<ExclamationThickIcon fill-color="#FFFFFF" :size="12" />
 		</div>
 		<div v-else-if="isComplete" class="complete">
@@ -25,7 +25,7 @@
 			:class="{
 				'green-text': isComplete,
 				'red-text': isThereErrorAfterProjectFolderAndAppPasswordSetup,
-				'warn-text': isThereGroupFoldersEncryptionWarning
+				'warn-text': showEncryptionWarningForGroupFolders
 			}">
 			{{ title }}
 		</div>
@@ -72,7 +72,7 @@ export default {
 			type: Boolean,
 			default: false,
 		},
-		isThereGroupFoldersEncryptionWarning: {
+		showEncryptionWarningForGroupFolders: {
 			type: Boolean,
 			default: false,
 		},

--- a/tests/jest/components/AdminSettings.spec.js
+++ b/tests/jest/components/AdminSettings.spec.js
@@ -91,7 +91,8 @@ const selectors = {
 	projectFolderErrorMessageDetails: '.note-card--error-description',
 	userAppPasswordButton: '[data-test-id="reset-user-app-password"]',
 	setupIntegrationDocumentationLinkSelector: '.settings--documentation-info',
-	adminAuditNoteCardInforSelector: '[type="info"]',
+	adminAuditNoteCardInfoSelector: '[type="info"]',
+	encryptionNoteCardWarningSelector: '.notecard--warning',
 }
 
 const completeIntegrationState = {
@@ -1167,6 +1168,10 @@ describe('AdminSettings.vue', () => {
 									},
 									fresh_project_folder_setup: true,
 									app_password_set: false,
+									encryption_info: {
+										server_side_encryption_enabled: false,
+										encryption_enabled_for_groupfolders: false,
+									},
 								},
 								isGroupFolderAlreadySetup: null,
 							})
@@ -1245,6 +1250,10 @@ describe('AdminSettings.vue', () => {
 									status: true,
 								},
 								app_password_set: true,
+								encryption_info: {
+									server_side_encryption_enabled: false,
+									encryption_enabled_for_groupfolders: false,
+								},
 							},
 						})
 						await wrapper.setData({
@@ -1373,6 +1382,10 @@ describe('AdminSettings.vue', () => {
 									status: true,
 								},
 								app_password_set: true,
+								encryption_info: {
+									server_side_encryption_enabled: false,
+									encryption_enabled_for_groupfolders: false,
+								},
 							},
 							isGroupFolderAlreadySetup: null,
 						})
@@ -1551,6 +1564,61 @@ describe('AdminSettings.vue', () => {
 			} else {
 				expect(projectFolderErrorMessageDetails.text()).toBe(expectedErrorDetails.expectedErrorDetailsMessage)
 			}
+		})
+	})
+
+	describe('Encryption warning after project folder setup', () => {
+		beforeEach(async () => {
+			axios.put.mockReset()
+			axios.get.mockReset()
+		})
+
+		it.each([
+			[
+				'should show warning when server side encryption is enabled but encryption for groupfolders is not enabled',
+				{
+					server_side_encryption_enabled: true,
+					encryption_enabled_for_groupfolders: false,
+				},
+				true,
+			],
+			[
+				'should not show warning when server side encryption and groupfolders encryption is enabled',
+				{
+					server_side_encryption_enabled: true,
+					encryption_enabled_for_groupfolders: true,
+				},
+				false,
+			],
+			[
+				'should not show warning when server side encryption not enabled but groupfolders encryption is enabled',
+				{
+					server_side_encryption_enabled: false,
+					encryption_enabled_for_groupfolders: true,
+				},
+				false,
+			],
+		])('%s', (name, encryptionInfoState, expectedResult) => {
+			const wrapper = getMountedWrapper({
+				state: {
+					openproject_instance_url: 'http://openproject.com',
+					openproject_client_id: 'some-client-id-here',
+					openproject_client_secret: 'some-client-secret-here',
+					default_enable_unified_search: false,
+					default_enable_navigation: false,
+					nc_oauth_client: {
+						nextcloud_client_id: 'some-nc-client-id-here',
+						nextcloud_client_secret: 'some-nc-client-secret-here',
+					},
+					project_folder_info: {
+						status: true,
+					},
+					app_password_set: true,
+					encryption_info: encryptionInfoState,
+				},
+			})
+			const encryptionWarningNoteCard = wrapper.find(selectors.encryptionNoteCardWarningSelector)
+			expect(encryptionWarningNoteCard.exists()).toBe(expectedResult)
 		})
 	})
 
@@ -1890,7 +1958,7 @@ describe('AdminSettings.vue', () => {
 			],
 		])('%s', (name, state, expectedResult) => {
 			const wrapper = getWrapper({ state })
-			const adminAuditLogNoteCard = wrapper.find(selectors.adminAuditNoteCardInforSelector)
+			const adminAuditLogNoteCard = wrapper.find(selectors.adminAuditNoteCardInfoSelector)
 			expect(adminAuditLogNoteCard.exists()).toBe(expectedResult)
 		})
 	})

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -26,6 +26,7 @@ use OCA\OpenProject\Exception\OpenprojectResponseException;
 use OCA\TermsOfService\Db\Mapper\SignatoryMapper;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Http;
+use OCP\Encryption\IManager;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
@@ -747,7 +748,8 @@ class OpenProjectAPIServiceTest extends TestCase {
 			$this->createMock(IEventDispatcher::class),
 			$this->createMock(ISubAdmin::class),
 			$this->createMock(IDBConnection::class),
-			$this->createMock(ILogFactory::class)
+			$this->createMock(ILogFactory::class),
+			$this->createMock(IManager::class),
 		);
 	}
 
@@ -765,6 +767,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 	 * @param IDBConnection|null $db
 	 * @param IURLGenerator|null $iURLGenerator
 	 * @param ILogFactory|null $iLogFactory
+	 * @param IManager|null $iManager
 	 * @return OpenProjectAPIService|MockObject
 	 */
 	private function getServiceMock(
@@ -780,6 +783,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$tokenProviderMock = null,
 		$db = null,
 		$iLogFactory = null,
+		$iManager = null,
 		$iURLGenerator = null
 	): OpenProjectAPIService {
 		$onlyMethods[] = 'getBaseUrl';
@@ -819,6 +823,9 @@ class OpenProjectAPIServiceTest extends TestCase {
 		if ($iLogFactory === null) {
 			$iLogFactory = $this->createMock(ILogFactory::class);
 		}
+		if ($iManager === null) {
+			$iManager = $this->createMock(IManager::class);
+		}
 		$mock = $this->getMockBuilder(OpenProjectAPIService::class)
 			->setConstructorArgs(
 				[
@@ -840,6 +847,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 					$subAdminManagerMock,
 					$db,
 					$iLogFactory,
+					$iManager,
 					$iURLGenerator
 				])
 			->onlyMethods($onlyMethods)
@@ -2106,8 +2114,8 @@ class OpenProjectAPIServiceTest extends TestCase {
 			$this->createMock(IEventDispatcher::class),
 			$this->createMock(ISubAdmin::class),
 			$this->createMock(IDBConnection::class),
-			$this->createMock(ILogFactory::class)
-
+			$this->createMock(ILogFactory::class),
+			$this->createMock(IManager::class),
 		);
 
 		$response = $service->request('', '', []);
@@ -2177,7 +2185,8 @@ class OpenProjectAPIServiceTest extends TestCase {
 			$this->createMock(IEventDispatcher::class),
 			$this->createMock(ISubAdmin::class),
 			$this->createMock(IDBConnection::class),
-			$this->createMock(ILogFactory::class)
+			$this->createMock(ILogFactory::class),
+			$this->createMock(IManager::class)
 		);
 
 		$response = $service->request('', '', []);
@@ -3395,6 +3404,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 			null,
 			null,
 			null,
+			null,
 			$iUrlGeneratorMock
 		);
 		$service->method('request')
@@ -3773,6 +3783,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 			null,
 			null,
 			null,
+			null,
 			$iULGeneratorMock
 		);
 		$imageURL = 'http://nextcloud/server/index.php/apps/integration_openproject/avatar?userId=3&userName=OpenProject Admin';
@@ -3930,6 +3941,98 @@ class OpenProjectAPIServiceTest extends TestCase {
 			$configMock
 		);
 		$actualResult = $service->isAdminAuditConfigSetCorrectly();
+		$this->assertEquals($expectedResult, $actualResult);
+	}
+
+	public function serverSideEncryptionEnabledDataProvider(): array {
+		return [
+			[
+				'1',
+				true,
+				true,
+				true
+			],
+			[
+				'0',
+				true,
+				true,
+				false
+			],
+			[
+				'1',
+				false,
+				true,
+				false
+			],
+			[
+				'1',
+				true,
+				false,
+				false
+			],
+			[
+				'1',
+				false,
+				false,
+				false
+			],
+			[
+				'0',
+				false,
+				false,
+				false
+			]
+		];
+	}
+
+	/**
+	 * @dataProvider serverSideEncryptionEnabledDataProvider
+	 * @param string $encryptionForHomeStorageEnabled
+	 * @param bool $isEncryptionAppInstalled
+	 * @param bool $isEncryptionAppEnabled
+	 * @param bool $expectedResult
+	 *
+	 * @return void
+	 */
+
+	public function testIsServerSideEncryptionEnabled(
+		string $encryptionForHomeStorageEnabled,
+		bool $isEncryptionAppInstalled,
+		bool $isEncryptionAppEnabled,
+		bool $expectedResult
+	): void {
+		$configMock = $this->getMockBuilder(IConfig::class)->getMock();
+		$iManagerMock = $this->getMockBuilder(IManager::class)->getMock();
+		$iAppManagerMock = $this->getMockBuilder(IAppManager::class)->getMock();
+		$configMock
+			->method('getAppValue')
+			->with(
+				'encryption', 'encryptHomeStorage'
+			)
+			->willReturn(
+				$encryptionForHomeStorageEnabled
+			);
+		$userManagerMock = $this->getMockBuilder(IUserManager::class)
+			->getMock();
+		$iAppManagerMock->method('isInstalled')->with('encryption')
+			->willReturn($isEncryptionAppInstalled);
+		$iManagerMock->method('isEnabled')->willReturn($isEncryptionAppEnabled);
+		$service = $this->getServiceMock(
+			[],
+			null,
+			null,
+			$userManagerMock,
+			null,
+			$iAppManagerMock,
+			null,
+			null,
+			$configMock,
+			null,
+			null,
+			null,
+			$iManagerMock
+		);
+		$actualResult = $service->isServerSideEncryptionEnabled();
 		$this->assertEquals($expectedResult, $actualResult);
 	}
 }


### PR DESCRIPTION
## Description
This PR:
- Adds a warning in projectfolder setup UI when server-side encryption is enabled, but not specifically activated for group folders.
- Adds php unit test
- Adds vue ui test for it 


## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://community.openproject.org/projects/nextcloud-integration/work_packages/57970/activity

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [x] Updated `CHANGELOG.md` file
