### PR TITLE
Fix release branch failure for nightly CI

### DIFF
--- a/.github/workflows/shared_workflow.yml
+++ b/.github/workflows/shared_workflow.yml
@@ -23,9 +23,9 @@ jobs:
             phpVersion: 8.1
           - nextcloudVersion: stable29
             phpVersion: 8.1
-          - nextcloudVersion: master
+          - isReleaseBranch: false
+            nextcloudVersion: master
             phpVersion: 8.3
-            isReleaseBranch: false
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout for nightly CI


### PR DESCRIPTION
## Description
A syntax mistake was made in PR https://github.com/nextcloud/integration_openproject/pull/712 (could not check locally) to exclude NC-31 (msater) for nighlty CI `release/2.7` branch. This PR fix it.
