### PR TITLE
check for true false in CI failure

### DIFF
--- a/.github/workflows/shared_workflow.yml
+++ b/.github/workflows/shared_workflow.yml
@@ -11,7 +11,7 @@ jobs:
     name: unit tests and linting
     strategy:
       matrix:
-        nextcloudVersion: [ stable30 ]
+        nextcloudVersion: [ stable30, master ]
         phpVersion: [ 8.1, 8.2, 8.3 ]
         # This condition is temporary and can be removed once Nextcloud 31 support is added in the integration app for the release/2.7 branch
         isReleaseBranch:
@@ -23,9 +23,15 @@ jobs:
             phpVersion: 8.1
           - nextcloudVersion: stable29
             phpVersion: 8.1
+        exclude:
+          - isReleaseBranch: true
+            nextcloudVersion: master
           - isReleaseBranch: false
             nextcloudVersion: master
-            phpVersion: 8.3
+            phpVersion: 8.1
+          - isReleaseBranch: false
+            nextcloudVersion: master
+            phpVersion: 8.2
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout for nightly CI


### PR DESCRIPTION
## Description
This PR:
 - excludes to run unit test for `master branch` for Nightly CI run for `release/2.7` branch
 - Also include to run unit test for `master branch` for Nightly CI run for `master`   branch

## Build link:
1. When `isReleaseBranch` is `true`: https://github.com/nextcloud/integration_openproject/actions/runs/11339542033 (job is not running for `master` branch)
2. When `isReleaseBranch` is `false`: https://github.com/nextcloud/integration_openproject/actions/runs/11339559747 (job is running for `master` branch)


## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/nextcloud/integration_openproject/actions/runs/11336324103
