### PR TITLE
Exclude API test for master branch as well for Nightly CI release/2.7

### DIFF
--- a/.github/workflows/shared_workflow.yml
+++ b/.github/workflows/shared_workflow.yml
@@ -196,8 +196,9 @@ jobs:
         phpVersionMajor: [ 8 ]
         phpVersionMinor: [ 1, 2, 3 ]
         database: [ mysql ]
+        # This condition is temporary and can be removed once Nextcloud 31 support is added in the integration app for the release/2.7 branch
         isReleaseBranch:
-          - true
+          - ${{ inputs.branch == 'release/2.7'}}
         include:
           # Each database once on the newest Server with preinstalled PHP version
           - nextcloudVersion: stable30

--- a/.github/workflows/shared_workflow.yml
+++ b/.github/workflows/shared_workflow.yml
@@ -192,10 +192,12 @@ jobs:
     name: API tests
     strategy:
       matrix:
-        nextcloudVersion: [ stable30 ]
+        nextcloudVersion: [ stable30, master ]
         phpVersionMajor: [ 8 ]
         phpVersionMinor: [ 1, 2, 3 ]
         database: [ mysql ]
+        isReleaseBranch:
+          - true
         include:
           # Each database once on the newest Server with preinstalled PHP version
           - nextcloudVersion: stable30
@@ -214,10 +216,20 @@ jobs:
             phpVersionMajor: 8
             phpVersionMinor: 1
             database: mysql
-          - nextcloudVersion: master
+        exclude:
+          - isReleaseBranch: true
+            nextcloudVersion: master
+          - isReleaseBranch: false
+            nextcloudVersion: master
             phpVersionMajor: 8
-            phpVersionMinor: 3
+            phpVersionMinor: 1
             database: mysql
+          - isReleaseBranch: false
+            nextcloudVersion: master
+            phpVersionMajor: 8
+            phpVersionMinor: 2
+            database: mysql
+        
     runs-on: ubuntu-20.04
     container:
       image: public.ecr.aws/ubuntu/ubuntu:latest


### PR DESCRIPTION
## Description

The API test for the `master` branch is failing because the `release/2.7` branch does not yet support Nextcloud master (NC-31). As a result, we need to skip running the API test for the `master` in the nightly release/2.7 CI as well.

The CI fails as: https://github.com/nextcloud/integration_openproject/pull/716
with error
```log
 [capabilities.integration_openproject] The property integration_openproject is required
```
So This PR:
 - excludes to run API test for `master` for Nightly CI run for `release/2.7` branch
 - Also include to run API test for `master` for Nightly CI run for `master`   branch

## Build link:
1. When `isReleaseBranch` is `true`: https://github.com/nextcloud/integration_openproject/actions/runs/11340633426 (job is not running for `master` branch)
2. When `isReleaseBranch` is `false`: https://github.com/nextcloud/integration_openproject/actions/runs/11340649758 (job is running for `master` branch)


## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/nextcloud/integration_openproject/actions/runs/11336324103
