### PR TITLE
Safer getNextcloudVersion() using the version array

### DIFF
--- a/lib/ServerVersionHelper.php
+++ b/lib/ServerVersionHelper.php
@@ -13,12 +13,14 @@ class ServerVersionHelper {
 	 * @return string
 	 */
 	public static function getNextcloudVersion(): string {
-		// for nextcloud above 31 OC_Util::getVersionString() method does not exists
+		// for nextcloud above 31 OC_Util::getVersion() method does not exists
 		if (class_exists('OCP\ServerVersion')) {
-			return (new \OCP\ServerVersion())->getVersionString();
+			$versionArray = (new \OCP\ServerVersion())->getVersion();
+		} else {
+			/** @psalm-suppress UndefinedMethod getVersion() method is not in stable31 so making psalm not complain */
+			$versionArray = OC_Util::getVersion();
 		}
 
-		/** @psalm-suppress UndefinedMethod getVersionString() method is not in stable31 so making psalm not complain */
-		return OC_Util::getVersionString();
+		return implode('.', $versionArray);
 	}
 }

--- a/psalm.xml
+++ b/psalm.xml
@@ -47,7 +47,7 @@
 		</UndefinedClass>
 		<UndefinedMethod>
 			<errorLevel type="suppress">
-				<referencedMethod name="OC\legacy\OC_Util::getVersionString()"/>
+				<referencedMethod name="OC\legacy\OC_Util::getVersion()"/>
 			</errorLevel>
 		</UndefinedMethod>
 		<TooFewArguments>


### PR DESCRIPTION
Checking the version against the "versionString" can fail (in Nextcloud Enterprise for example, it is "29.0.7 Enterprise"). So it makes the `version_compare` give unexpected results.
It is safer to use the version array so we always get the same clean format for the version.

cc @wielinde 