### PR TITLE
Back port changes to get server version in `release/2.7` branch for server version compare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 - Make error handling better in `integration_setup.sh` file for integration configuration setup.
 - Improve UI by using Nextcloud's `NoteCard` in project folder setup error.
+- Resolve the issue with retrieving the Nextcloud server version for version compare
 
 ## 2.7.0 - 2024-09-10
 ### Changed

--- a/lib/Listener/LoadAdditionalScriptsListener.php
+++ b/lib/Listener/LoadAdditionalScriptsListener.php
@@ -21,7 +21,7 @@ class LoadAdditionalScriptsListener implements IEventListener {
 			return;
 		}
 
-		if (version_compare(OC_Util::getVersionString(), '28') < 0) {
+		if (version_compare(implode('.', OC_Util::getVersion()), '28') < 0) {
 			Util::addScript(Application::APP_ID, Application::APP_ID . '-fileActions');
 			Util::addScript(Application::APP_ID, Application::APP_ID . '-filesPluginLessThan28', 'files');
 		} else {

--- a/lib/Service/OauthService.php
+++ b/lib/Service/OauthService.php
@@ -81,7 +81,7 @@ class OauthService {
 		$client->setName($name);
 		$client->setRedirectUri(sprintf($redirectUri, $clientId));
 		$secret = $this->secureRandom->generate(64, self::validChars);
-		$nextcloudVersion = OC_Util::getVersionString();
+		$nextcloudVersion = implode('.', OC_Util::getVersion());
 		$client->setSecret($this->hashOrEncryptSecretBasedOnNextcloudVersion($secret, $nextcloudVersion));
 		$client->setClientIdentifier($clientId);
 		$client = $this->clientMapper->insert($client);


### PR DESCRIPTION
## Description
Backport changes of https://github.com/nextcloud/integration_openproject/pull/719 in `release/2.7` branch for patch release version `2.7.1`


## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes the issue described in the description of this PR https://github.com/nextcloud/integration_openproject/pull/719

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Updated `CHANGELOG.md` file
