### PR TITLE
Fix version comparison

### DIFF
--- a/lib/Service/OauthService.php
+++ b/lib/Service/OauthService.php
@@ -53,13 +53,13 @@ class OauthService {
 	 */
 	public function hashOrEncryptSecretBasedOnNextcloudVersion(string $secret, string $nextcloudVersion): string {
 		switch (true) {
-			case version_compare($nextcloudVersion, '30.0.0') >= 0:
-			case version_compare($nextcloudVersion, '29.0.7') >= 0 && version_compare($nextcloudVersion, '30.0.0') < 0:
-			case version_compare($nextcloudVersion, '28.0.10') >= 0 && version_compare($nextcloudVersion, '29.0.0') < 0:
-			case version_compare($nextcloudVersion, '27.1.11.8') >= 0 && version_compare($nextcloudVersion, '28.0.0') < 0:
+			case version_compare($nextcloudVersion, '30.0.0.0') >= 0:
+			case version_compare($nextcloudVersion, '29.0.7.0') >= 0 && version_compare($nextcloudVersion, '30.0.0.0') < 0:
+			case version_compare($nextcloudVersion, '28.0.10.0') >= 0 && version_compare($nextcloudVersion, '29.0.0.0') < 0:
+			case version_compare($nextcloudVersion, '27.1.11.8') >= 0 && version_compare($nextcloudVersion, '28.0.0.0') < 0:
 				$encryptedSecret = bin2hex($this->crypto->calculateHMAC($secret));
 				break;
-			case version_compare($nextcloudVersion, '27.0.0') === 0:
+			case version_compare($nextcloudVersion, '27.0.0.0') >= 0 && version_compare($nextcloudVersion, '27.0.1.0') < 0:
 				$encryptedSecret = $secret;
 				break;
 			default:

--- a/lib/Service/OauthService.php
+++ b/lib/Service/OauthService.php
@@ -56,7 +56,7 @@ class OauthService {
 			case version_compare($nextcloudVersion, '30.0.0.0') >= 0:
 			case version_compare($nextcloudVersion, '29.0.7.0') >= 0 && version_compare($nextcloudVersion, '30.0.0.0') < 0:
 			case version_compare($nextcloudVersion, '28.0.10.0') >= 0 && version_compare($nextcloudVersion, '29.0.0.0') < 0:
-			case version_compare($nextcloudVersion, '27.1.11.8') >= 0 && version_compare($nextcloudVersion, '28.0.0.0') < 0:
+			case version_compare($nextcloudVersion, '27.1.11.9') >= 0 && version_compare($nextcloudVersion, '28.0.0.0') < 0:
 				$encryptedSecret = bin2hex($this->crypto->calculateHMAC($secret));
 				break;
 			case version_compare($nextcloudVersion, '27.0.0.0') >= 0 && version_compare($nextcloudVersion, '27.0.1.0') < 0:

--- a/tests/lib/Service/OauthSeviceTest.php
+++ b/tests/lib/Service/OauthSeviceTest.php
@@ -59,35 +59,51 @@ class OauthServiceTest extends TestCase {
 	public function gethashOrEncryptSecretBasedOnNextcloudVersion(): array {
 		return [
 			[
-				"30.0.0",
+				"30.0.0.0",
 				"calculateHMAC"
 			],
 			[
-				"29.0.7",
+				"30.0.0.1",
 				"calculateHMAC"
 			],
 			[
-				"29.1.0",
+				"29.0.7.0",
 				"calculateHMAC"
 			],
 			[
-				"29.0.6",
+				"29.1.0.0",
+				"calculateHMAC"
+			],
+			[
+				"29.0.6.0",
 				"encrypt"
 			],
 			[
-				"28.0.10",
+				"28.0.10.0",
 				"calculateHMAC"
 			],
 			[
-				"28.2.0",
+				"28.2.0.0",
 				"calculateHMAC"
 			],
 			[
-				"28.0.0",
+				"28.0.0.0",
 				"encrypt"
 			],
 			[
-				"29.0.0",
+				"28.0.10.1",
+				"calculateHMAC"
+			],
+			[
+				"28.0.0.1",
+				"encrypt"
+			],
+			[
+				"29.0.0.0",
+				"encrypt"
+			],
+			[
+				"29.0.0.1",
 				"encrypt"
 			],
 			[
@@ -101,6 +117,26 @@ class OauthServiceTest extends TestCase {
 			[
 				"27.1.1.0",
 				"encrypt"
+			],
+			[
+				"27.0.1.0",
+				"encrypt"
+			],
+			[
+				"27.0.1.1",
+				"encrypt"
+			],
+			[
+				"27.0.0.0",
+				null
+			],
+			[
+				"27.0.0.1",
+				null
+			],
+			[
+				"27.0.0.99",
+				null
 			]
 		];
 	}
@@ -109,15 +145,20 @@ class OauthServiceTest extends TestCase {
 	/**
 	 * @dataProvider gethashOrEncryptSecretBasedOnNextcloudVersion
 	 * @param string $nextcloudVersion
-	 * @param string $hashOrEncryptFunction
+	 * @param string|null $hashOrEncryptFunction
 	 *
 	 * @return void
 	 *
 	 */
-	public function testGetHashedOrEncryptedClientSecretBasedOnNextcloudVersions(string $nextcloudVersion, string $hashOrEncryptFunction) {
+	public function testGetHashedOrEncryptedClientSecretBasedOnNextcloudVersions(string $nextcloudVersion, ?string $hashOrEncryptFunction) {
 		$iCryptoMock = $this->getMockBuilder(ICrypto::class)->getMock();
 		$oAuthService = $this->getOauthServiceMock(null, null, $iCryptoMock);
-		$iCryptoMock->expects($this->once())->method($hashOrEncryptFunction);
+		if ($hashOrEncryptFunction !== null) {
+			$iCryptoMock->expects($this->once())->method($hashOrEncryptFunction);
+		} else {
+			$iCryptoMock->expects($this->never())->method('calculateHMAC');
+			$iCryptoMock->expects($this->never())->method('encrypt');
+		}
 		$oAuthService->hashOrEncryptSecretBasedOnNextcloudVersion("client_secret", $nextcloudVersion);
 	}
 }

--- a/tests/lib/Service/OauthSeviceTest.php
+++ b/tests/lib/Service/OauthSeviceTest.php
@@ -59,7 +59,7 @@ class OauthServiceTest extends TestCase {
 	public function gethashOrEncryptSecretBasedOnNextcloudVersion(): array {
 		return [
 			[
-				"30.0.0.0",
+				"30.0.0.14",
 				"calculateHMAC"
 			],
 			[
@@ -108,7 +108,7 @@ class OauthServiceTest extends TestCase {
 			],
 			[
 				"27.1.11.8",
-				"calculateHMAC"
+				"encrypt"
 			],
 			[
 				"27.1.12.0",
@@ -137,6 +137,14 @@ class OauthServiceTest extends TestCase {
 			[
 				"27.0.0.99",
 				null
+			],
+			[
+				"27.1.11.9",
+				"calculateHMAC"
+			],
+			[
+				"29.0.7.1",
+				"calculateHMAC"
 			]
 		];
 	}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The method getVersion() returns with 4 digit array Example: [27,0,0,7] which fails on the line https://github.com/nextcloud/integration_openproject/blob/master/lib/Service/OauthService.php#L62
This error is seen on nextcloud 27 version (i.e when variable $nextcloudversion is 27.0.0)
So, this PR is for fixing such error

## Step to reproduce
1. Clone the server of branch 27

```zsh
git clone git@github.com:nextcloud/server.git -b stable27
```

2. Go to path `\server` and Checkout to the `v27.0.0`

```zsh
git checkout v27.0.0
```

3. Set up nextcloud, enable integration_opneproject apps and openproject
4. When we try to do oauth connection then the app crashes

## Related Issue or Workpackage
- https://community.openproject.org/projects/nextcloud-integration/work_packages/58464

## Screen Record :
While oauth configuration on stable27 branch we got following error:
[Screencast from 10-25-2024 02:29:03 PM.webm](https://github.com/user-attachments/assets/96ca0b05-815b-4d9f-9347-69501bd2d961)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
