### PR TITLE
forwardport version compare for conflict resolve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Add application's support for Nextcloud 31
 - Make error handling better in `integration_setup.sh` file for integration configuration setup.
+- Improve UI by using Nextcloud's `NoteCard` in project folder setup error.
+- Resolve the issue with retrieving the Nextcloud server version for version compare
 
 ## 2.7.0 - 2024-09-10
 ### Changed


### PR DESCRIPTION
This PR is for resolving the conflict for branch `master` with branch `release 2.7`. That conflict was came due to this backport PR https://github.com/nextcloud/integration_openproject/pull/720. In that backport  [PR](https://github.com/nextcloud/integration_openproject/pull/720) only uses the `getversion` method instead of `getversionstring`, which was done is another file.

