### PR TITLE
[WP#58859]Change the log for getting `groupfolders` through files endpoint to `info` instead of `error`

### DIFF
--- a/lib/Controller/FilesController.php
+++ b/lib/Controller/FilesController.php
@@ -170,7 +170,7 @@ class FilesController extends OCSController {
 			// Note: in case of groupfolders the internal path is `__groupfolders/<group-folder-id>` so
 			// getInternalPath() functions returns empty string and the internal path fallbacks to the context of requester
 			if (!$internalPath) {
-				$this->logger->error(
+				$this->logger->info(
 					'could not get the file name in the context of the owner,' .
 					' falling back to the context of requester'
 				);


### PR DESCRIPTION
## Description
The fatal error exists when we get information of the `groupfolders` every time we re request through files endpoint. And from the comment it self  https://github.com/nextcloud/integration_openproject/blob/276b637ae07861dd740d26c0f183cfb31ae749ac/lib/Controller/FilesController.php#L170 for group folders we  for group folders the internal path is `__groupfolders/<group-folder-id>` and `getInternalPath()` function returns empty string which seems to be fairly an information not an error as it does not break overall functionality.

A related PR was created and merge here: https://github.com/nextcloud/integration_openproject/pull/468
This PR:
- Changes the log level from `error` to `info` for it.


## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes [WP#58859](https://community.openproject.org/projects/openproject/work_packages/58859)

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
