### PR TITLE
[WP#59517]change tag for the php setup in action

### DIFF
--- a/.github/workflows/shared_workflow.yml
+++ b/.github/workflows/shared_workflow.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup PHP ${{ matrix.phpVersion }}
-        uses: shivammathur/setup-php@a4e22b60bbb9c1021113f2860347b0759f66fe5d
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.phpVersion }}
           tools: composer, phpunit
@@ -233,7 +233,7 @@ jobs:
 
     runs-on: ubuntu-20.04
     container:
-      image: public.ecr.aws/ubuntu/ubuntu:latest
+      image: public.ecr.aws/lts/ubuntu:20.04
 
     defaults:
       run:
@@ -305,7 +305,7 @@ jobs:
         uses: papodaca/install-docker-action@main
 
       - name: Setup PHP ${{ format('{0}.{1}', matrix.phpVersionMajor,matrix.phpVersionMinor) }}
-        uses: shivammathur/setup-php@a4e22b60bbb9c1021113f2860347b0759f66fe5d
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ format('{0}.{1}', matrix.phpVersionMajor,matrix.phpVersionMinor) }}
           tools: composer


### PR DESCRIPTION
## Description
The problem seems to be with the actions `shivammathur/setup-php@v2` that we are using in the CI. For the latest ubuntu the actions seems to be failing. The issue is reported here: https://github.com/shivammathur/setup-php/issues/880 https://github.com/shivammathur/setup-php/issues/880#issuecomment-2492932960

This PR:
- Downgrade the ubuntu version to 20.04
- Also change the tag for the github actions to `shivammathur/setup-php@v2`



## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://community.openproject.org/projects/nextcloud-integration/work_packages/59517

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
