### PR TITLE
chore: setup new keycloak realm on startup

### DIFF
--- a/dev/keycloak.yaml
+++ b/dev/keycloak.yaml
@@ -17,6 +17,7 @@ services:
         'start-dev',
         '--proxy edge',
         '--spi-connections-http-client-default-disable-trust-manager=true',
+        '--import-realm'
       ]
     environment:
       KC_DB: postgres
@@ -32,6 +33,7 @@ services:
     networks:
       - nc-op
     volumes:
+      - ./opnc-realm.json:/opt/keycloak/data/import/opnc-realm.json
       - step:/step:ro
       - keycloakdata:/opt/keycloak/data/
     labels:

--- a/dev/opnc-realm.json
+++ b/dev/opnc-realm.json
@@ -1,0 +1,2053 @@
+{
+  "id" : "2fba1b4c-3c7c-47d4-9148-0e04f61b5d89",
+  "realm" : "opnc",
+  "notBefore" : 0,
+  "defaultSignatureAlgorithm" : "RS256",
+  "revokeRefreshToken" : false,
+  "refreshTokenMaxReuse" : 0,
+  "accessTokenLifespan" : 300,
+  "accessTokenLifespanForImplicitFlow" : 900,
+  "ssoSessionIdleTimeout" : 1800,
+  "ssoSessionMaxLifespan" : 36000,
+  "ssoSessionIdleTimeoutRememberMe" : 0,
+  "ssoSessionMaxLifespanRememberMe" : 0,
+  "offlineSessionIdleTimeout" : 2592000,
+  "offlineSessionMaxLifespanEnabled" : false,
+  "offlineSessionMaxLifespan" : 5184000,
+  "clientSessionIdleTimeout" : 0,
+  "clientSessionMaxLifespan" : 0,
+  "clientOfflineSessionIdleTimeout" : 0,
+  "clientOfflineSessionMaxLifespan" : 0,
+  "accessCodeLifespan" : 60,
+  "accessCodeLifespanUserAction" : 300,
+  "accessCodeLifespanLogin" : 1800,
+  "actionTokenGeneratedByAdminLifespan" : 43200,
+  "actionTokenGeneratedByUserLifespan" : 300,
+  "oauth2DeviceCodeLifespan" : 600,
+  "oauth2DevicePollingInterval" : 5,
+  "enabled" : true,
+  "sslRequired" : "external",
+  "registrationAllowed" : false,
+  "registrationEmailAsUsername" : false,
+  "rememberMe" : false,
+  "verifyEmail" : false,
+  "loginWithEmailAllowed" : true,
+  "duplicateEmailsAllowed" : false,
+  "resetPasswordAllowed" : false,
+  "editUsernameAllowed" : false,
+  "bruteForceProtected" : false,
+  "permanentLockout" : false,
+  "maxFailureWaitSeconds" : 900,
+  "minimumQuickLoginWaitSeconds" : 60,
+  "waitIncrementSeconds" : 60,
+  "quickLoginCheckMilliSeconds" : 1000,
+  "maxDeltaTimeSeconds" : 43200,
+  "failureFactor" : 30,
+  "roles" : {
+    "realm" : [ {
+      "id" : "cdcf9eae-eca5-4404-a0f3-64d42ad5ac93",
+      "name" : "uma_authorization",
+      "description" : "${role_uma_authorization}",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "2fba1b4c-3c7c-47d4-9148-0e04f61b5d89",
+      "attributes" : { }
+    }, {
+      "id" : "dde19435-d760-4a70-a500-3d21d038271b",
+      "name" : "offline_access",
+      "description" : "${role_offline-access}",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "2fba1b4c-3c7c-47d4-9148-0e04f61b5d89",
+      "attributes" : { }
+    }, {
+      "id" : "67292fc2-70b7-4bcc-ae54-a8230be99645",
+      "name" : "default-roles-opnc",
+      "description" : "${role_default-roles}",
+      "composite" : true,
+      "composites" : {
+        "realm" : [ "offline_access", "uma_authorization" ],
+        "client" : {
+          "account" : [ "manage-account", "view-profile" ]
+        }
+      },
+      "clientRole" : false,
+      "containerId" : "2fba1b4c-3c7c-47d4-9148-0e04f61b5d89",
+      "attributes" : { }
+    } ],
+    "client" : {
+      "nextcloud" : [ ],
+      "realm-management" : [ {
+        "id" : "d2baef93-65c3-4590-9ccc-c4b65f389651",
+        "name" : "manage-authorization",
+        "description" : "${role_manage-authorization}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "caeb1678-f1f1-4530-8b50-eb53f6f7987b",
+        "attributes" : { }
+      }, {
+        "id" : "5937b16c-05b4-4bfd-9821-94bd91480e83",
+        "name" : "manage-clients",
+        "description" : "${role_manage-clients}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "caeb1678-f1f1-4530-8b50-eb53f6f7987b",
+        "attributes" : { }
+      }, {
+        "id" : "2870ae57-7180-4e23-8e8c-e52ed4b8575b",
+        "name" : "create-client",
+        "description" : "${role_create-client}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "caeb1678-f1f1-4530-8b50-eb53f6f7987b",
+        "attributes" : { }
+      }, {
+        "id" : "b52871cc-57e3-4b6b-92c4-fc7013c5de5e",
+        "name" : "query-realms",
+        "description" : "${role_query-realms}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "caeb1678-f1f1-4530-8b50-eb53f6f7987b",
+        "attributes" : { }
+      }, {
+        "id" : "c01cd940-b681-4f6b-b6a7-d538bc95fae6",
+        "name" : "query-users",
+        "description" : "${role_query-users}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "caeb1678-f1f1-4530-8b50-eb53f6f7987b",
+        "attributes" : { }
+      }, {
+        "id" : "dca3e695-9d65-4b15-8b27-b742216869b5",
+        "name" : "manage-users",
+        "description" : "${role_manage-users}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "caeb1678-f1f1-4530-8b50-eb53f6f7987b",
+        "attributes" : { }
+      }, {
+        "id" : "798d0bf9-3c62-46ff-b26f-41324804c69c",
+        "name" : "query-groups",
+        "description" : "${role_query-groups}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "caeb1678-f1f1-4530-8b50-eb53f6f7987b",
+        "attributes" : { }
+      }, {
+        "id" : "5893f99f-1ec6-4a8c-91d2-e38adf5d46bd",
+        "name" : "manage-events",
+        "description" : "${role_manage-events}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "caeb1678-f1f1-4530-8b50-eb53f6f7987b",
+        "attributes" : { }
+      }, {
+        "id" : "71c68a37-0d59-46ae-824c-8cddd9d91f72",
+        "name" : "view-events",
+        "description" : "${role_view-events}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "caeb1678-f1f1-4530-8b50-eb53f6f7987b",
+        "attributes" : { }
+      }, {
+        "id" : "ad772cec-9519-480d-b5cc-85b44fa9bbe5",
+        "name" : "view-identity-providers",
+        "description" : "${role_view-identity-providers}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "caeb1678-f1f1-4530-8b50-eb53f6f7987b",
+        "attributes" : { }
+      }, {
+        "id" : "cb5e1124-2944-4a97-9487-5c810f4d727c",
+        "name" : "view-authorization",
+        "description" : "${role_view-authorization}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "caeb1678-f1f1-4530-8b50-eb53f6f7987b",
+        "attributes" : { }
+      }, {
+        "id" : "5474b8bb-4c7d-4142-a43c-ba3c0fd9c38d",
+        "name" : "manage-identity-providers",
+        "description" : "${role_manage-identity-providers}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "caeb1678-f1f1-4530-8b50-eb53f6f7987b",
+        "attributes" : { }
+      }, {
+        "id" : "a624faa9-707d-4064-85ee-c835fd3a9770",
+        "name" : "query-clients",
+        "description" : "${role_query-clients}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "caeb1678-f1f1-4530-8b50-eb53f6f7987b",
+        "attributes" : { }
+      }, {
+        "id" : "e37c6ecf-2ac6-4b10-9789-b8f3f631222b",
+        "name" : "impersonation",
+        "description" : "${role_impersonation}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "caeb1678-f1f1-4530-8b50-eb53f6f7987b",
+        "attributes" : { }
+      }, {
+        "id" : "e6b9da8c-94a5-4e5e-9c2f-9378e9239a89",
+        "name" : "realm-admin",
+        "description" : "${role_realm-admin}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "manage-clients", "manage-authorization", "create-client", "query-users", "query-realms", "manage-users", "query-groups", "view-events", "view-identity-providers", "manage-events", "view-authorization", "manage-identity-providers", "query-clients", "impersonation", "view-users", "view-clients", "view-realm", "manage-realm" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "caeb1678-f1f1-4530-8b50-eb53f6f7987b",
+        "attributes" : { }
+      }, {
+        "id" : "2fd6f7f3-d87a-4c1f-811b-e25c523a872c",
+        "name" : "view-users",
+        "description" : "${role_view-users}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "query-users", "query-groups" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "caeb1678-f1f1-4530-8b50-eb53f6f7987b",
+        "attributes" : { }
+      }, {
+        "id" : "470a3d77-4acd-4e9f-8b24-ae480fcfa6a0",
+        "name" : "view-clients",
+        "description" : "${role_view-clients}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "query-clients" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "caeb1678-f1f1-4530-8b50-eb53f6f7987b",
+        "attributes" : { }
+      }, {
+        "id" : "389a660c-66aa-4e9a-b9d7-98d7d5aea28b",
+        "name" : "view-realm",
+        "description" : "${role_view-realm}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "caeb1678-f1f1-4530-8b50-eb53f6f7987b",
+        "attributes" : { }
+      }, {
+        "id" : "70ef187c-8884-4820-ad04-d40e53a58444",
+        "name" : "manage-realm",
+        "description" : "${role_manage-realm}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "caeb1678-f1f1-4530-8b50-eb53f6f7987b",
+        "attributes" : { }
+      } ],
+      "openproject" : [ ],
+      "security-admin-console" : [ ],
+      "admin-cli" : [ ],
+      "account-console" : [ ],
+      "broker" : [ {
+        "id" : "552e6287-5e03-4131-a4a0-0c18349f7cb2",
+        "name" : "read-token",
+        "description" : "${role_read-token}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "07fe7fd4-0949-4a4d-8f16-136231ef7194",
+        "attributes" : { }
+      } ],
+      "account" : [ {
+        "id" : "61ace768-e1a3-4a22-b3a7-b3b374998636",
+        "name" : "manage-account",
+        "description" : "${role_manage-account}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "account" : [ "manage-account-links" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "9cd66f6b-5c0a-4b37-9a0c-e222d8dcf4db",
+        "attributes" : { }
+      }, {
+        "id" : "29b8f96d-5b9a-47b1-a9bd-4a422bd6cadf",
+        "name" : "manage-consent",
+        "description" : "${role_manage-consent}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "account" : [ "view-consent" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "9cd66f6b-5c0a-4b37-9a0c-e222d8dcf4db",
+        "attributes" : { }
+      }, {
+        "id" : "50480628-e5b0-47c6-b8a2-1b1ae50b07d9",
+        "name" : "view-profile",
+        "description" : "${role_view-profile}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "9cd66f6b-5c0a-4b37-9a0c-e222d8dcf4db",
+        "attributes" : { }
+      }, {
+        "id" : "17aba603-6b4f-48ec-ae6d-a6c542253caa",
+        "name" : "manage-account-links",
+        "description" : "${role_manage-account-links}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "9cd66f6b-5c0a-4b37-9a0c-e222d8dcf4db",
+        "attributes" : { }
+      }, {
+        "id" : "e8f7f5e4-5bc4-4625-8ec5-fce5dd150d01",
+        "name" : "view-consent",
+        "description" : "${role_view-consent}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "9cd66f6b-5c0a-4b37-9a0c-e222d8dcf4db",
+        "attributes" : { }
+      }, {
+        "id" : "72a891c0-deb4-447d-9c04-c092de56109e",
+        "name" : "view-groups",
+        "description" : "${role_view-groups}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "9cd66f6b-5c0a-4b37-9a0c-e222d8dcf4db",
+        "attributes" : { }
+      }, {
+        "id" : "ce410a42-bc9f-4c0d-af9d-fc7c30052077",
+        "name" : "delete-account",
+        "description" : "${role_delete-account}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "9cd66f6b-5c0a-4b37-9a0c-e222d8dcf4db",
+        "attributes" : { }
+      }, {
+        "id" : "bd56b5b3-633f-415e-baeb-7f5537fbafb0",
+        "name" : "view-applications",
+        "description" : "${role_view-applications}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "9cd66f6b-5c0a-4b37-9a0c-e222d8dcf4db",
+        "attributes" : { }
+      } ]
+    }
+  },
+  "groups" : [ ],
+  "defaultRole" : {
+    "id" : "67292fc2-70b7-4bcc-ae54-a8230be99645",
+    "name" : "default-roles-opnc",
+    "description" : "${role_default-roles}",
+    "composite" : true,
+    "clientRole" : false,
+    "containerId" : "2fba1b4c-3c7c-47d4-9148-0e04f61b5d89"
+  },
+  "requiredCredentials" : [ "password" ],
+  "otpPolicyType" : "totp",
+  "otpPolicyAlgorithm" : "HmacSHA1",
+  "otpPolicyInitialCounter" : 0,
+  "otpPolicyDigits" : 6,
+  "otpPolicyLookAheadWindow" : 1,
+  "otpPolicyPeriod" : 30,
+  "otpPolicyCodeReusable" : false,
+  "otpSupportedApplications" : [ "totpAppMicrosoftAuthenticatorName", "totpAppFreeOTPName", "totpAppGoogleName" ],
+  "webAuthnPolicyRpEntityName" : "keycloak",
+  "webAuthnPolicySignatureAlgorithms" : [ "ES256" ],
+  "webAuthnPolicyRpId" : "",
+  "webAuthnPolicyAttestationConveyancePreference" : "not specified",
+  "webAuthnPolicyAuthenticatorAttachment" : "not specified",
+  "webAuthnPolicyRequireResidentKey" : "not specified",
+  "webAuthnPolicyUserVerificationRequirement" : "not specified",
+  "webAuthnPolicyCreateTimeout" : 0,
+  "webAuthnPolicyAvoidSameAuthenticatorRegister" : false,
+  "webAuthnPolicyAcceptableAaguids" : [ ],
+  "webAuthnPolicyPasswordlessRpEntityName" : "keycloak",
+  "webAuthnPolicyPasswordlessSignatureAlgorithms" : [ "ES256" ],
+  "webAuthnPolicyPasswordlessRpId" : "",
+  "webAuthnPolicyPasswordlessAttestationConveyancePreference" : "not specified",
+  "webAuthnPolicyPasswordlessAuthenticatorAttachment" : "not specified",
+  "webAuthnPolicyPasswordlessRequireResidentKey" : "not specified",
+  "webAuthnPolicyPasswordlessUserVerificationRequirement" : "not specified",
+  "webAuthnPolicyPasswordlessCreateTimeout" : 0,
+  "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister" : false,
+  "webAuthnPolicyPasswordlessAcceptableAaguids" : [ ],
+  "users" : [ {
+    "id" : "1076ebf3-ccc2-4091-b069-ceba72f004d3",
+    "createdTimestamp" : 1737352864431,
+    "username" : "alice",
+    "enabled" : true,
+    "totp" : false,
+    "emailVerified" : true,
+    "firstName" : "Alice",
+    "lastName" : "Hansen",
+    "email" : "alice@example.com",
+    "credentials" : [ {
+      "id" : "c01deac1-4d97-43b9-8456-40593d230fe6",
+      "type" : "password",
+      "userLabel" : "My password",
+      "createdDate" : 1737352881517,
+      "secretData" : "{\"value\":\"8AXeIG4iLYAZPYgUNz7virM4LKnKjyirf4AZQNHKh7Q=\",\"salt\":\"zEyXllPP9MTU2ugff3dRag==\",\"additionalParameters\":{}}",
+      "credentialData" : "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\",\"additionalParameters\":{}}"
+    } ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "default-roles-opnc" ],
+    "notBefore" : 0,
+    "groups" : [ ]
+  }, {
+    "id" : "9029d561-2961-4fad-a020-23a55dcbfc45",
+    "createdTimestamp" : 1737352905962,
+    "username" : "brian",
+    "enabled" : true,
+    "totp" : false,
+    "emailVerified" : true,
+    "firstName" : "Brian",
+    "lastName" : "Murphy",
+    "email" : "brian@example.com",
+    "credentials" : [ {
+      "id" : "b785f6ac-6ef0-4810-9c08-d1e2088a2e32",
+      "type" : "password",
+      "userLabel" : "My password",
+      "createdDate" : 1737352915050,
+      "secretData" : "{\"value\":\"+PuxOfqX7niBLLY0fYGO87UuBrbzmB/C9JgBfi3kJtY=\",\"salt\":\"m1Ych5sGSV0OszPryMXY3g==\",\"additionalParameters\":{}}",
+      "credentialData" : "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\",\"additionalParameters\":{}}"
+    } ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "default-roles-opnc" ],
+    "notBefore" : 0,
+    "groups" : [ ]
+  } ],
+  "scopeMappings" : [ {
+    "clientScope" : "offline_access",
+    "roles" : [ "offline_access" ]
+  } ],
+  "clientScopeMappings" : {
+    "account" : [ {
+      "client" : "account-console",
+      "roles" : [ "manage-account", "view-groups" ]
+    } ]
+  },
+  "clients" : [ {
+    "id" : "9cd66f6b-5c0a-4b37-9a0c-e222d8dcf4db",
+    "clientId" : "account",
+    "name" : "${client_account}",
+    "rootUrl" : "${authBaseUrl}",
+    "baseUrl" : "/realms/opnc/account/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/realms/opnc/account/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "post.logout.redirect.uris" : "+"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "ece7e373-cefc-4908-b73f-3615a8503fdf",
+    "clientId" : "account-console",
+    "name" : "${client_account-console}",
+    "rootUrl" : "${authBaseUrl}",
+    "baseUrl" : "/realms/opnc/account/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/realms/opnc/account/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "post.logout.redirect.uris" : "+",
+      "pkce.code.challenge.method" : "S256"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "08d83117-570e-49e4-8f6f-799b6156374c",
+      "name" : "audience resolve",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-resolve-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "aafb9491-c20f-4287-9847-84d24f175e3b",
+    "clientId" : "admin-cli",
+    "name" : "${client_admin-cli}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : false,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : true,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : { },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "07fe7fd4-0949-4a4d-8f16-136231ef7194",
+    "clientId" : "broker",
+    "name" : "${client_broker}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : true,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : { },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "79bb0619-22fd-46df-9bad-3b81753cd557",
+    "clientId" : "nextcloud",
+    "name" : "",
+    "description" : "",
+    "rootUrl" : "https://nextcloud.local",
+    "adminUrl" : "https://nextcloud.local",
+    "baseUrl" : "",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "GGACnANGMdlZqMzfmsbsoqURykF8oTm0",
+    "redirectUris" : [ "https://nextcloud.local/*" ],
+    "webOrigins" : [ "https://nextcloud.local" ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : true,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : true,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "oidc.ciba.grant.enabled" : "false",
+      "oauth2.device.authorization.grant.enabled" : "false",
+      "client.secret.creation.time" : "1737352683",
+      "backchannel.logout.session.required" : "true",
+      "backchannel.logout.revoke.offline.tokens" : "false"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "702bd1fc-0132-4863-a4db-5961d572c1c2",
+    "clientId" : "openproject",
+    "name" : "",
+    "description" : "",
+    "rootUrl" : "https://openproject.local",
+    "adminUrl" : "https://openproject.local",
+    "baseUrl" : "",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "ntM20VjXl3sgBSrcD1V5LyNcxI7s23oN",
+    "redirectUris" : [ "https://openproject.local/*" ],
+    "webOrigins" : [ "https://openproject.local" ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : true,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : true,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "oidc.ciba.grant.enabled" : "false",
+      "oauth2.device.authorization.grant.enabled" : "false",
+      "client.secret.creation.time" : "1737352699",
+      "backchannel.logout.session.required" : "true",
+      "backchannel.logout.revoke.offline.tokens" : "false"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "caeb1678-f1f1-4530-8b50-eb53f6f7987b",
+    "clientId" : "realm-management",
+    "name" : "${client_realm-management}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : true,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "authorizationServicesEnabled" : true,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : { },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ],
+    "authorizationSettings" : {
+      "allowRemoteResourceManagement" : false,
+      "policyEnforcementMode" : "ENFORCING",
+      "resources" : [ {
+        "name" : "client.resource.79bb0619-22fd-46df-9bad-3b81753cd557",
+        "type" : "Client",
+        "ownerManagedAccess" : false,
+        "attributes" : { },
+        "_id" : "11fdad89-038d-44f8-b795-376c87080dad",
+        "uris" : [ ],
+        "scopes" : [ {
+          "name" : "view"
+        }, {
+          "name" : "map-roles-client-scope"
+        }, {
+          "name" : "map-roles"
+        }, {
+          "name" : "configure"
+        }, {
+          "name" : "manage"
+        }, {
+          "name" : "map-roles-composite"
+        }, {
+          "name" : "token-exchange"
+        } ]
+      } ],
+      "policies" : [ {
+        "id" : "04466f53-43cf-4cef-b39b-3756beef91ff",
+        "name" : "opnc-policy",
+        "description" : "",
+        "type" : "client",
+        "logic" : "POSITIVE",
+        "decisionStrategy" : "UNANIMOUS",
+        "config" : {
+          "clients" : "[\"openproject\",\"nextcloud\"]"
+        }
+      }, {
+        "id" : "4523f650-8566-4560-84a5-35c50de6b81c",
+        "name" : "manage.permission.client.79bb0619-22fd-46df-9bad-3b81753cd557",
+        "type" : "scope",
+        "logic" : "POSITIVE",
+        "decisionStrategy" : "UNANIMOUS",
+        "config" : {
+          "resources" : "[\"client.resource.79bb0619-22fd-46df-9bad-3b81753cd557\"]",
+          "scopes" : "[\"manage\"]"
+        }
+      }, {
+        "id" : "2470e0af-f622-4a18-9d79-c76f9892a58e",
+        "name" : "configure.permission.client.79bb0619-22fd-46df-9bad-3b81753cd557",
+        "type" : "scope",
+        "logic" : "POSITIVE",
+        "decisionStrategy" : "UNANIMOUS",
+        "config" : {
+          "resources" : "[\"client.resource.79bb0619-22fd-46df-9bad-3b81753cd557\"]",
+          "scopes" : "[\"configure\"]"
+        }
+      }, {
+        "id" : "10627712-4e80-4ca2-8986-449a7b564aa7",
+        "name" : "view.permission.client.79bb0619-22fd-46df-9bad-3b81753cd557",
+        "type" : "scope",
+        "logic" : "POSITIVE",
+        "decisionStrategy" : "UNANIMOUS",
+        "config" : {
+          "resources" : "[\"client.resource.79bb0619-22fd-46df-9bad-3b81753cd557\"]",
+          "scopes" : "[\"view\"]"
+        }
+      }, {
+        "id" : "691f337f-c571-47d6-8b33-ad0af3fb423f",
+        "name" : "map-roles.permission.client.79bb0619-22fd-46df-9bad-3b81753cd557",
+        "type" : "scope",
+        "logic" : "POSITIVE",
+        "decisionStrategy" : "UNANIMOUS",
+        "config" : {
+          "resources" : "[\"client.resource.79bb0619-22fd-46df-9bad-3b81753cd557\"]",
+          "scopes" : "[\"map-roles\"]"
+        }
+      }, {
+        "id" : "d96c786d-e8c2-4d8f-b3b2-33653f2210bb",
+        "name" : "map-roles-client-scope.permission.client.79bb0619-22fd-46df-9bad-3b81753cd557",
+        "type" : "scope",
+        "logic" : "POSITIVE",
+        "decisionStrategy" : "UNANIMOUS",
+        "config" : {
+          "resources" : "[\"client.resource.79bb0619-22fd-46df-9bad-3b81753cd557\"]",
+          "scopes" : "[\"map-roles-client-scope\"]"
+        }
+      }, {
+        "id" : "efb00f38-f84a-4984-a378-31a1bbf5895e",
+        "name" : "map-roles-composite.permission.client.79bb0619-22fd-46df-9bad-3b81753cd557",
+        "type" : "scope",
+        "logic" : "POSITIVE",
+        "decisionStrategy" : "UNANIMOUS",
+        "config" : {
+          "resources" : "[\"client.resource.79bb0619-22fd-46df-9bad-3b81753cd557\"]",
+          "scopes" : "[\"map-roles-composite\"]"
+        }
+      }, {
+        "id" : "09693ff7-9807-4958-964c-525f8383a785",
+        "name" : "token-exchange.permission.client.79bb0619-22fd-46df-9bad-3b81753cd557",
+        "description" : "",
+        "type" : "scope",
+        "logic" : "POSITIVE",
+        "decisionStrategy" : "UNANIMOUS",
+        "config" : {
+          "resources" : "[\"client.resource.79bb0619-22fd-46df-9bad-3b81753cd557\"]",
+          "scopes" : "[\"token-exchange\"]",
+          "applyPolicies" : "[\"opnc-policy\"]"
+        }
+      } ],
+      "scopes" : [ {
+        "id" : "5565b754-d2c9-4e6f-80bf-057c71579e84",
+        "name" : "manage"
+      }, {
+        "id" : "16a52349-67f4-474a-92f8-cf3ee6e026a8",
+        "name" : "view"
+      }, {
+        "id" : "d765dcde-2a80-47ae-a4ed-9cf1c9bf8ecc",
+        "name" : "map-roles"
+      }, {
+        "id" : "5a71772a-dbc6-4792-84c8-2601341e09b2",
+        "name" : "map-roles-client-scope"
+      }, {
+        "id" : "7642b189-2f54-4f10-835f-4d6db694d6d1",
+        "name" : "map-roles-composite"
+      }, {
+        "id" : "d9a42fe8-5768-4412-8fcd-907a69069f13",
+        "name" : "configure"
+      }, {
+        "id" : "c109d6e0-f138-4c67-856f-f9a47655c775",
+        "name" : "token-exchange"
+      } ],
+      "decisionStrategy" : "UNANIMOUS"
+    }
+  }, {
+    "id" : "e4adecda-f015-4f5e-92fc-4e6c9b996a33",
+    "clientId" : "security-admin-console",
+    "name" : "${client_security-admin-console}",
+    "rootUrl" : "${authAdminUrl}",
+    "baseUrl" : "/admin/opnc/console/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/admin/opnc/console/*" ],
+    "webOrigins" : [ "+" ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "post.logout.redirect.uris" : "+",
+      "pkce.code.challenge.method" : "S256"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "56e21007-f216-46bf-8b32-38591bdda030",
+      "name" : "locale",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "locale",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "locale",
+        "jsonType.label" : "String"
+      }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  } ],
+  "clientScopes" : [ {
+    "id" : "836d01fa-c66e-4e91-8462-96462a4eb603",
+    "name" : "email",
+    "description" : "OpenID Connect built-in scope: email",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${emailScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "34efe1a7-36cf-4c2d-95f6-21ad02fefffd",
+      "name" : "email verified",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "emailVerified",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email_verified",
+        "jsonType.label" : "boolean"
+      }
+    }, {
+      "id" : "1efae721-667f-4ede-95cc-0acbbda9afea",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "d395a999-614f-452a-b426-e842d99d9b73",
+    "name" : "microprofile-jwt",
+    "description" : "Microprofile - JWT built-in scope",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "b760ad78-431c-4556-a2d9-ea67e90e7d7b",
+      "name" : "upn",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "upn",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "632428ab-d460-478b-a5a8-3f49db1a813b",
+      "name" : "groups",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-realm-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "multivalued" : "true",
+        "user.attribute" : "foo",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "groups",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "570ac884-4a8f-4184-81c5-b2fb1e4c558a",
+    "name" : "profile",
+    "description" : "OpenID Connect built-in scope: profile",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${profileScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "12cd562c-ff76-467f-a435-c60f60787951",
+      "name" : "locale",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "locale",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "locale",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "d4560f2a-0fbb-40a9-a996-53fa04b8704f",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "c0354661-0edc-4690-878e-12f2ea4693f1",
+      "name" : "updated at",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "updatedAt",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "updated_at",
+        "jsonType.label" : "long"
+      }
+    }, {
+      "id" : "1892bc44-8e3c-44c4-92d3-1f017b77e12c",
+      "name" : "birthdate",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "birthdate",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "birthdate",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "bfe6e0e8-f7c4-440b-82b7-28373d621c30",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "474a8a9b-e4df-409b-b31d-def76d383973",
+      "name" : "website",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "website",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "website",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "3a76edf8-04fb-4784-a29d-ae7866d9de68",
+      "name" : "zoneinfo",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "zoneinfo",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "zoneinfo",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "78fd2179-eddb-4531-ac45-a9d79cc14703",
+      "name" : "nickname",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "nickname",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "nickname",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "73cca7c4-5248-4fbd-9443-86ec45079f44",
+      "name" : "gender",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "gender",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "gender",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "cc7d8ba2-17d0-40e6-a603-f5b5397bcbe3",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "userinfo.token.claim" : "true"
+      }
+    }, {
+      "id" : "ad2b7296-b187-45aa-a5b4-4ca5a667f4d8",
+      "name" : "picture",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "picture",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "picture",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "75d9d7d0-267b-4dd9-8178-081bf2c6b576",
+      "name" : "profile",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "profile",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "profile",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "5a3983e7-877a-4dc0-b59b-5a78b27b2aaa",
+      "name" : "middle name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "middleName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "middle_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "b4decea7-7b91-4892-ab90-0daeb4df2da5",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "3693f287-35c7-47b0-b380-d322ecebe1a1",
+    "name" : "acr",
+    "description" : "OpenID Connect scope for add acr (authentication context class reference) to the token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "f61be5d9-e091-405e-900a-36da1d8d1b19",
+      "name" : "acr loa level",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-acr-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    } ]
+  }, {
+    "id" : "e4c2f56b-40a4-497c-b7f0-7b37e1b41ae0",
+    "name" : "offline_access",
+    "description" : "OpenID Connect built-in scope: offline_access",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "consent.screen.text" : "${offlineAccessScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    }
+  }, {
+    "id" : "8e270b8b-5ec5-4c4b-9198-d5be836a320f",
+    "name" : "phone",
+    "description" : "OpenID Connect built-in scope: phone",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${phoneScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "4d29d213-993b-4f50-904f-49adaeb4fd67",
+      "name" : "phone number",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "phoneNumber",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "phone_number",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "ea0c6b35-8273-47c5-b023-337f47b4b927",
+      "name" : "phone number verified",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "phoneNumberVerified",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "phone_number_verified",
+        "jsonType.label" : "boolean"
+      }
+    } ]
+  }, {
+    "id" : "237f4c90-5c4c-4579-9091-b953bde627f5",
+    "name" : "role_list",
+    "description" : "SAML role list",
+    "protocol" : "saml",
+    "attributes" : {
+      "consent.screen.text" : "${samlRoleListScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "0e196c05-169b-4688-a9f9-1920e33c32f1",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    } ]
+  }, {
+    "id" : "a3d18233-07b5-4c39-9fda-7253dc84700d",
+    "name" : "roles",
+    "description" : "OpenID Connect scope for add user roles to the access token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${rolesScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "ed5480f7-7908-4a44-8d1f-49b17c0f8489",
+      "name" : "realm roles",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-realm-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute" : "foo",
+        "access.token.claim" : "true",
+        "claim.name" : "realm_access.roles",
+        "jsonType.label" : "String",
+        "multivalued" : "true"
+      }
+    }, {
+      "id" : "909c9260-75a5-4867-b2d2-e643faacdc5e",
+      "name" : "audience resolve",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-resolve-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    }, {
+      "id" : "d0fd48fb-f7d8-4161-ba5e-47df53319fba",
+      "name" : "client roles",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-client-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute" : "foo",
+        "access.token.claim" : "true",
+        "claim.name" : "resource_access.${client_id}.roles",
+        "jsonType.label" : "String",
+        "multivalued" : "true"
+      }
+    } ]
+  }, {
+    "id" : "57906f2f-662b-41b3-b4a2-e16d72bb77c4",
+    "name" : "address",
+    "description" : "OpenID Connect built-in scope: address",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${addressScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "f516175e-4afa-4d78-9353-40f5eef91076",
+      "name" : "address",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-address-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute.formatted" : "formatted",
+        "user.attribute.country" : "country",
+        "user.attribute.postal_code" : "postal_code",
+        "userinfo.token.claim" : "true",
+        "user.attribute.street" : "street",
+        "id.token.claim" : "true",
+        "user.attribute.region" : "region",
+        "access.token.claim" : "true",
+        "user.attribute.locality" : "locality"
+      }
+    } ]
+  }, {
+    "id" : "3ce4a601-8680-4aa6-acb2-a52db1c4d8f6",
+    "name" : "web-origins",
+    "description" : "OpenID Connect scope for add allowed web origins to the access token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "false",
+      "consent.screen.text" : ""
+    },
+    "protocolMappers" : [ {
+      "id" : "eb7c9661-bdc3-4a68-96b3-6a6a8a1b28b5",
+      "name" : "allowed web origins",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-allowed-origins-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    } ]
+  } ],
+  "defaultDefaultClientScopes" : [ "role_list", "profile", "email", "roles", "web-origins", "acr" ],
+  "defaultOptionalClientScopes" : [ "offline_access", "address", "phone", "microprofile-jwt" ],
+  "browserSecurityHeaders" : {
+    "contentSecurityPolicyReportOnly" : "",
+    "xContentTypeOptions" : "nosniff",
+    "xRobotsTag" : "none",
+    "xFrameOptions" : "SAMEORIGIN",
+    "contentSecurityPolicy" : "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "xXSSProtection" : "1; mode=block",
+    "strictTransportSecurity" : "max-age=31536000; includeSubDomains"
+  },
+  "smtpServer" : { },
+  "eventsEnabled" : false,
+  "eventsListeners" : [ "jboss-logging" ],
+  "enabledEventTypes" : [ ],
+  "adminEventsEnabled" : false,
+  "adminEventsDetailsEnabled" : false,
+  "identityProviders" : [ ],
+  "identityProviderMappers" : [ ],
+  "components" : {
+    "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy" : [ {
+      "id" : "6cc33d6b-6880-4994-b327-f105b51c1f4b",
+      "name" : "Allowed Protocol Mapper Types",
+      "providerId" : "allowed-protocol-mappers",
+      "subType" : "authenticated",
+      "subComponents" : { },
+      "config" : {
+        "allowed-protocol-mapper-types" : [ "oidc-sha256-pairwise-sub-mapper", "oidc-full-name-mapper", "saml-user-property-mapper", "oidc-usermodel-attribute-mapper", "oidc-address-mapper", "saml-user-attribute-mapper", "oidc-usermodel-property-mapper", "saml-role-list-mapper" ]
+      }
+    }, {
+      "id" : "a36caeaa-5e2d-45cb-ba42-81f1ec56dd83",
+      "name" : "Trusted Hosts",
+      "providerId" : "trusted-hosts",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "host-sending-registration-request-must-match" : [ "true" ],
+        "client-uris-must-match" : [ "true" ]
+      }
+    }, {
+      "id" : "4f391901-3a13-4df9-82a1-f8980ba30021",
+      "name" : "Max Clients Limit",
+      "providerId" : "max-clients",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "max-clients" : [ "200" ]
+      }
+    }, {
+      "id" : "cee04451-a2a5-4ca9-a942-39da816ff0f1",
+      "name" : "Allowed Client Scopes",
+      "providerId" : "allowed-client-templates",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "allow-default-scopes" : [ "true" ]
+      }
+    }, {
+      "id" : "625c7bb5-49af-4946-b9e2-8d566838feb8",
+      "name" : "Allowed Protocol Mapper Types",
+      "providerId" : "allowed-protocol-mappers",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "allowed-protocol-mapper-types" : [ "oidc-usermodel-attribute-mapper", "oidc-address-mapper", "saml-role-list-mapper", "oidc-usermodel-property-mapper", "saml-user-attribute-mapper", "saml-user-property-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-full-name-mapper" ]
+      }
+    }, {
+      "id" : "22679df7-c92d-4a96-ac79-17d10e72c473",
+      "name" : "Allowed Client Scopes",
+      "providerId" : "allowed-client-templates",
+      "subType" : "authenticated",
+      "subComponents" : { },
+      "config" : {
+        "allow-default-scopes" : [ "true" ]
+      }
+    }, {
+      "id" : "8e736fd3-96a0-452e-810d-263d79772f1f",
+      "name" : "Consent Required",
+      "providerId" : "consent-required",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : { }
+    }, {
+      "id" : "303355db-376e-426f-a74f-4a93d4d2910c",
+      "name" : "Full Scope Disabled",
+      "providerId" : "scope",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : { }
+    } ],
+    "org.keycloak.keys.KeyProvider" : [ {
+      "id" : "578cb54a-05fc-47c9-b70c-573aa41d30b3",
+      "name" : "rsa-enc-generated",
+      "providerId" : "rsa-enc-generated",
+      "subComponents" : { },
+      "config" : {
+        "privateKey" : [ "MIIEpQIBAAKCAQEAzsEJpswGyxttxLz/Ogh1ZZgN5mthyZ+uO4WhYv0Ai3mfFCViGvscAis804wa7zWl5kszbpEhIl6fleTZke7N9VIjnwM6QzhsiqBq3hS3jAvZzkOFcm3L545mFLWz5yKV+RfS4TZBdkQHbP5Sb4xV4KcI0Q6aJGvL5uVfwiImhLsIUdMR9g+gT6f1np/dPhU9mV/gX6hYPOaFZK7jjtnZwlGkA4JPwQT4Je7VzJKEIrXVewFGGsM0b21OX+O53uakTNrFMJODWb17ABYCdfVgUaSfXTmYTmguP0uX6f/93wuJe8WZtvm0+IA6HRziyUKANQ8W/70YRAcOOzh0+5GsewIDAQABAoIBAGT1EuLtNpX//0I1rYUnczfYH1V38uiSve/XqT4eX6E7kqeyN20IWB1hApMkE1TiQ++noeYoHN9dCB0YAfuF+fEEGlu/pjgDudCZU4W85QGQGdtj0ipVnd8khAkxzrabB1N6RCFvrlhzEJMyvos0ogyQU7hNoowNTSQitfckWN2vW5rhkWgU1u/HjtxUuVFjhW3eARtN2MBibv5gskVKJjCb6LtnbsHLQR1OCMEvKHO4dsF5u1JcVs13K05LvtpnrTsHaQM/dCvads2Rt8zUv8P8D42AX8DvTMNgAJisMSus0E5vafV3pZi4gPNhEdvqMdn2+qsIpCCOuKKJKPOztPkCgYEA76JldETn5IkKETeu4FUamYWRrkHVSnqvuxLuPIqXFB2G2txSv3sljDG2sPjL7gz7+eoXDCKPRXa8ttIB1Ktyqn1SCa7kHsuWED5r8oSG2HEVtwe7Nqn5CrX9GvFORsetMB1KRWB4DpR9Fq+wGwRBbETQ6p7YiF/lxD23DKyQk6kCgYEA3N/I12ZtwhEMoDnoI5+UbVtYvMuoGnK9gkvV1pYmj8CO25sPHaT+AEEqoMWNl4OGiUlSiQFOHnNmeSr9mc+yjUMag2Zi/TCOqbWToulsemRWYsquRvHyMfE5PcwJuW2g7hyy9rQIgM0uuhr164YkicBsJm9GD2pijGWnfWF3VYMCgYEAoeXQr2XiWZdwUsORBYTZzMDd9KILrR8IXNZkWEi122Q7eOADk9RqQLZRnGzqsjDZiDXsTkmHDEI1Kzrk+769YIv8gghDnL6k6uKRYa7Bv7dfGWJCzKK3W9IqZyqCXPWIf4o6ZHbRheAyRsJ5szcD0FcJ4olg93n6rMOZSRnJL8kCgYEAwfn3FNTsB8eZYw34BXEclX3nzMa+95tVO50GS9LKQu1FiTAAcnR4bhjNKyzUUQA9o0w1pAT1amDG2hsbZX22vcD1A/ljbiC66eiBpE2D62k7RL/jloLdxWaoctFCqQrSjsu9kFREM3n/U4ph91pztFa9pHOM//TaX5rXIZH7j6kCgYEA5ObFgXGAh7WoJg4Yz8vfdovKhW7CwAwjUAUXgdDYxQotgz9DvHUwQm5H0lH3tWcZNQ3qgyxnDhrxs4vNDWJVj0TicaNxGbpwmJIFc/acAy+U/ipbcKsYe5ByYb8xi/5bB7Q0YH+g6sIE1kDIT6rnXoRa0AKIPwUo6uTGafKUwiQ=" ],
+        "keyUse" : [ "ENC" ],
+        "certificate" : [ "MIIClzCCAX8CBgGUgknmoTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDDARvcG5jMB4XDTI1MDEyMDA1NTYwOFoXDTM1MDEyMDA1NTc0OFowDzENMAsGA1UEAwwEb3BuYzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAM7BCabMBssbbcS8/zoIdWWYDeZrYcmfrjuFoWL9AIt5nxQlYhr7HAIrPNOMGu81peZLM26RISJen5Xk2ZHuzfVSI58DOkM4bIqgat4Ut4wL2c5DhXJty+eOZhS1s+cilfkX0uE2QXZEB2z+Um+MVeCnCNEOmiRry+blX8IiJoS7CFHTEfYPoE+n9Z6f3T4VPZlf4F+oWDzmhWSu447Z2cJRpAOCT8EE+CXu1cyShCK11XsBRhrDNG9tTl/jud7mpEzaxTCTg1m9ewAWAnX1YFGkn105mE5oLj9Ll+n//d8LiXvFmbb5tPiAOh0c4slCgDUPFv+9GEQHDjs4dPuRrHsCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEATkOkUvCCcI7Tcy2MBBJnfrLkEBlkBdnjeTBgshYdLEEUSEwnaU/XlUwg1EhPwmLm1AWWj023JMK1oa9noDjIU6M/ZYFzDI1T4JuE3Kzbs0xMVu4drbbN2VUWVpXY+r2LeqUbxVH8odPCv+exQ/3R+0TESmFp9NkiIbcsC/YLsyBUQvbOC7vd/eoVQh208i0OC6mkg8UDFAmAMCJ+mP4fDCpq0Ys4QYkd6xY7+YJl8C165jHBs0T9uwa1Hl9vFMj3hEFQkN+wJNYjIG5rQSApVnxYMXRw8oMAru57I8nc8CDIyU9YQOqCW+sa1CPQ6L1+Hm+b75YeK1fpjopxtLMtbw==" ],
+        "priority" : [ "100" ],
+        "algorithm" : [ "RSA-OAEP" ]
+      }
+    }, {
+      "id" : "a12ce523-09aa-49b3-8dbd-daa24319a44e",
+      "name" : "hmac-generated",
+      "providerId" : "hmac-generated",
+      "subComponents" : { },
+      "config" : {
+        "kid" : [ "55e0ca86-e5a9-46d0-85b1-a2f9f00adca2" ],
+        "secret" : [ "uFeCYxY_fJS_7LFYsv1coFU90FFkfz29Rq94PuxznOa7PivJ4zDipfGpG2ZAEvKnjm8AV2P-n3IcZjcBIkc33A" ],
+        "priority" : [ "100" ],
+        "algorithm" : [ "HS256" ]
+      }
+    }, {
+      "id" : "0614e4cb-cfda-452a-9920-339a993d39eb",
+      "name" : "rsa-generated",
+      "providerId" : "rsa-generated",
+      "subComponents" : { },
+      "config" : {
+        "privateKey" : [ "MIIEowIBAAKCAQEAqlZK90gmoGtKUMTJTxpWi6n4jl25s3kkkvP6E+OaJkMEo6z2dT/YegiVZtBF21PDGJ/std6OZcSaPAtOrxv5EHDxvVNExqKo5K6R+NEc/bkRkgEo+WUzYTPoGn00bAyHgjbEuNfWHOgT2k/mI1Ou5j5OpjIVmgcAsEfaU6xPhKNRJ2z5pQOri/NXkauXzCWSTK0oi4k9WZ72XiaAY5P8FjJWghVjrndqFiLHFqa3MKOFsqA51uaLd88JZeCvZ+O84ESCC/LDiJIWZpi9Q/7CaTV0S9TT1CnSr/Hf/aVQ3cx2JVWt1ujMG/4GwJjip7XUj4lxVQ0ZJkxcwGgtjR1rpwIDAQABAoIBAEacvzcDkf+ueoBBE7LXGEmNjJx3/iOIdMD2oxTbpWt3HNU9Pm4cqYDtTgHxFQR3FMmAgoBiYmWNuuJpTZUJ45YNPClf+4Lcq2chdyHOjlYgAkikcnfwm/wPqIhSnwirqQEx8xstXnVdP92ggabjaf3IlpIO8SWJAaASKU/GfrBc1bgyoiUxzQE0ngSAkeeAXBKOyLv2UMmGd8pWUCHiDKFpB/Zx9rXFTnpY4EYn5W5Kunsmvkc8rjHbiLwYSKIyaxDttrJW+vM49ZUq8akmX4RRJN4kL84rhiP7bSPP6d4X8unqHj3Joj3jjLwzC2vMrfC1oFQ0/cUZlHnpAW9aGgECgYEA5ebgxgmwhT8VtOG2iwdgiOtCmq7qNZHsGow2LhD5gYTSWP0LG+6eNpoaZZeHIKkJlhcWNsDP6QhdgS/q8Bjs7gYbQ8aX/KM7sFNJ3l3KgptvmNhU/lHAqb2mmgqOWQhlqugKk1qcOUB2m+SIBFKYe8pdVTb9Bp2JbwneqHlWHr8CgYEAvaxqyPESwIFRIRf/saFRhDodaBGzHOOFndkK6I8KNclBcoTLvUYRPvIp5shRiHM/F6fj7iYd+IlIkyUQif1Ltv/rqLX/ltszCV9J+1r4xBNFBFC86dcvYEg3NfnATLvBF8+QYPgnfCv7tVcXu12hxye9SY5VQVPGASEAXfNBVRkCgYEAsciw2XR0xRXbu10wxKKXzEnh36yUAYkug/kZjNYjnD0STS6hgKAuSRsyfo2HOYJ+n0qLKxw/q32EkXp0u+cKkaa3Pto8fmncpqZB4Wu2Rvncet4QG/ssehbm1wiCu+b6eAeo5fqUBNIM5tD7PhyBPnlnY5Z6ZLs+pFeFj9ME/hECgYA1YepoBZl+fqbjxopbZwi3S1fta1Xa4po/k8+DJob8HlmCLqfc7HR8H9H1NxnjanQuZz06UJYM1i6L41mlTJnbtmmQATEfNzBFCgGbcb4kCTxae5K/yaV21rxbP6CEuC8fUXbUI+ORChv8rLdsL20RzTh0FFAgY8CNnskoqAcSOQKBgEh2uTyjAnm0e2kCRxANkMvgDrug30gvE+fEHIyrVUlnTY4xnpJnMJ88SJ1PfPmmoEtifH8cOoqbG5eGFojcTjLRTyw3/sNjkCW3b2ENvqc+HMLvaCqwywssb4Cf/4X0S7YonrbOmjBYx0Vita6zywTmYVemnbtCK0sVmEnOYJxX" ],
+        "keyUse" : [ "SIG" ],
+        "certificate" : [ "MIIClzCCAX8CBgGUgknmKDANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDDARvcG5jMB4XDTI1MDEyMDA1NTYwOFoXDTM1MDEyMDA1NTc0OFowDzENMAsGA1UEAwwEb3BuYzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKpWSvdIJqBrSlDEyU8aVoup+I5dubN5JJLz+hPjmiZDBKOs9nU/2HoIlWbQRdtTwxif7LXejmXEmjwLTq8b+RBw8b1TRMaiqOSukfjRHP25EZIBKPllM2Ez6Bp9NGwMh4I2xLjX1hzoE9pP5iNTruY+TqYyFZoHALBH2lOsT4SjUSds+aUDq4vzV5Grl8wlkkytKIuJPVme9l4mgGOT/BYyVoIVY653ahYixxamtzCjhbKgOdbmi3fPCWXgr2fjvOBEggvyw4iSFmaYvUP+wmk1dEvU09Qp0q/x3/2lUN3MdiVVrdbozBv+BsCY4qe11I+JcVUNGSZMXMBoLY0da6cCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAoJ7Sb2rHghm/fw9mAo0G2cAD/nQmFRoPyKv8ZDntiXDV+aSXfN/vinpzvGE/EHESUGXUcZ/jH5/L23il2Vmrqt6PFT8r+QvbBhWW3rzqtMZIRMaD2AOQqwlaJJqvbnZ6JxXANigTkqPgtrPp+5gUP8491FSfqO2eip9EbU2WCQrfbb5PStsUZlsftkhdhXLHg/EMWIuDKtwk9mjM4iCQoucVefCPAT7XKR1mjfQ7Wh4Wm2jq7XYNgp7mO2D+uWlrbPNYzdeAvSAICvYsAIaDckADrnNoJJZxSSYnasmHp2hsk3DvmIHeo4hY9gTbupAiKOI7BC7kWBCxMTYSGyGbTw==" ],
+        "priority" : [ "100" ]
+      }
+    }, {
+      "id" : "842afda1-2c36-463f-b8da-1534d0bb3b83",
+      "name" : "aes-generated",
+      "providerId" : "aes-generated",
+      "subComponents" : { },
+      "config" : {
+        "kid" : [ "dca9b20e-b993-4f63-9bf7-01a627c5f760" ],
+        "secret" : [ "lpgsre26xwuVQp94RCVzuw" ],
+        "priority" : [ "100" ]
+      }
+    } ]
+  },
+  "internationalizationEnabled" : false,
+  "supportedLocales" : [ ],
+  "authenticationFlows" : [ {
+    "id" : "a7b0ce87-a65b-440d-9f8f-a995e0ee7071",
+    "alias" : "Account verification options",
+    "description" : "Method with which to verity the existing account",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-email-verification",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Verify Existing Account by Re-authentication",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "9a131341-d657-4a47-8381-1ea6912c88a1",
+    "alias" : "Authentication Options",
+    "description" : "Authentication options.",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "basic-auth",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "basic-auth-otp",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-spnego",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 30,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "b07078a0-0df4-4f85-aff6-b068c8c5f394",
+    "alias" : "Browser - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-otp-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "0aa5586d-0950-457b-b813-82a7a2742554",
+    "alias" : "Direct Grant - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "direct-grant-validate-otp",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "968b9a71-2ebe-4ebc-a67c-e0407aa19bbc",
+    "alias" : "First broker login - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-otp-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "bd03b55a-41bb-441e-95d3-550c81a9780b",
+    "alias" : "Handle Existing Account",
+    "description" : "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-confirm-link",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Account verification options",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "a4750f56-052e-4535-8c3d-4a28790059af",
+    "alias" : "Reset - Conditional OTP",
+    "description" : "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "reset-otp",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "9501892b-e5a0-4795-b886-ce9073970336",
+    "alias" : "User creation or linking",
+    "description" : "Flow for the existing/non-existing user alternatives",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticatorConfig" : "create unique user config",
+      "authenticator" : "idp-create-user-if-unique",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Handle Existing Account",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "94d53f20-d89a-440b-be3b-4300c9dc8dae",
+    "alias" : "Verify Existing Account by Re-authentication",
+    "description" : "Reauthentication of existing account",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-username-password-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "First broker login - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "f5940a28-8792-419f-ae59-062df295f701",
+    "alias" : "browser",
+    "description" : "browser based authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "auth-cookie",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-spnego",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "identity-provider-redirector",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 25,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 30,
+      "autheticatorFlow" : true,
+      "flowAlias" : "forms",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "c603913c-4462-4b12-b6ab-4d049a2befa6",
+    "alias" : "clients",
+    "description" : "Base authentication for clients",
+    "providerId" : "client-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "client-secret",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "client-jwt",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "client-secret-jwt",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 30,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "client-x509",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 40,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "9cf72091-1a8c-4be8-aecb-75bbc460e1ff",
+    "alias" : "direct grant",
+    "description" : "OpenID Connect Resource Owner Grant",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "direct-grant-validate-username",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "direct-grant-validate-password",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 30,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Direct Grant - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "d4b30090-4656-4724-a76a-cc38e9c94932",
+    "alias" : "docker auth",
+    "description" : "Used by Docker clients to authenticate against the IDP",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "docker-http-basic-authenticator",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "3bbe783d-2a09-4624-a160-5733e9cc26d3",
+    "alias" : "first broker login",
+    "description" : "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticatorConfig" : "review profile config",
+      "authenticator" : "idp-review-profile",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "User creation or linking",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "1830f487-41d3-4c65-ad1a-0496fab73023",
+    "alias" : "forms",
+    "description" : "Username, password, otp and other auth forms.",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "auth-username-password-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Browser - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "017b7fcf-dce2-4d85-a540-d78ba1b74542",
+    "alias" : "http challenge",
+    "description" : "An authentication flow based on challenge-response HTTP Authentication Schemes",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "no-cookie-redirect",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Authentication Options",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "73b3a53a-5502-4b34-9ca3-1edbfe6f85ca",
+    "alias" : "registration",
+    "description" : "registration flow",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "registration-page-form",
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : true,
+      "flowAlias" : "registration form",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "5cf01140-9868-4133-a1c3-e043d46d06af",
+    "alias" : "registration form",
+    "description" : "registration form",
+    "providerId" : "form-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "registration-user-creation",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "registration-profile-action",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 40,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "registration-password-action",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 50,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "registration-recaptcha-action",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 60,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "aa18f410-0040-4132-b43f-51d97ba64f14",
+    "alias" : "reset credentials",
+    "description" : "Reset credentials for a user if they forgot their password or something",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "reset-credentials-choose-user",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "reset-credential-email",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "reset-password",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 30,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 40,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Reset - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "3aa09d0c-7005-4629-a5ad-15f7d18eb610",
+    "alias" : "saml ecp",
+    "description" : "SAML ECP Profile Authentication Flow",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "http-basic-authenticator",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  } ],
+  "authenticatorConfig" : [ {
+    "id" : "43121cc6-c53f-47ee-ac64-d911c908d173",
+    "alias" : "create unique user config",
+    "config" : {
+      "require.password.update.after.registration" : "false"
+    }
+  }, {
+    "id" : "71b2b979-b339-4c25-b44f-288cc7d42628",
+    "alias" : "review profile config",
+    "config" : {
+      "update.profile.on.first.login" : "missing"
+    }
+  } ],
+  "requiredActions" : [ {
+    "alias" : "CONFIGURE_TOTP",
+    "name" : "Configure OTP",
+    "providerId" : "CONFIGURE_TOTP",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 10,
+    "config" : { }
+  }, {
+    "alias" : "TERMS_AND_CONDITIONS",
+    "name" : "Terms and Conditions",
+    "providerId" : "TERMS_AND_CONDITIONS",
+    "enabled" : false,
+    "defaultAction" : false,
+    "priority" : 20,
+    "config" : { }
+  }, {
+    "alias" : "UPDATE_PASSWORD",
+    "name" : "Update Password",
+    "providerId" : "UPDATE_PASSWORD",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 30,
+    "config" : { }
+  }, {
+    "alias" : "UPDATE_PROFILE",
+    "name" : "Update Profile",
+    "providerId" : "UPDATE_PROFILE",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 40,
+    "config" : { }
+  }, {
+    "alias" : "VERIFY_EMAIL",
+    "name" : "Verify Email",
+    "providerId" : "VERIFY_EMAIL",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 50,
+    "config" : { }
+  }, {
+    "alias" : "delete_account",
+    "name" : "Delete Account",
+    "providerId" : "delete_account",
+    "enabled" : false,
+    "defaultAction" : false,
+    "priority" : 60,
+    "config" : { }
+  }, {
+    "alias" : "CONFIGURE_RECOVERY_AUTHN_CODES",
+    "name" : "Recovery Authentication Codes",
+    "providerId" : "CONFIGURE_RECOVERY_AUTHN_CODES",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 70,
+    "config" : { }
+  }, {
+    "alias" : "UPDATE_EMAIL",
+    "name" : "Update Email",
+    "providerId" : "UPDATE_EMAIL",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 70,
+    "config" : { }
+  }, {
+    "alias" : "webauthn-register",
+    "name" : "Webauthn Register",
+    "providerId" : "webauthn-register",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 70,
+    "config" : { }
+  }, {
+    "alias" : "webauthn-register-passwordless",
+    "name" : "Webauthn Register Passwordless",
+    "providerId" : "webauthn-register-passwordless",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 80,
+    "config" : { }
+  }, {
+    "alias" : "update_user_locale",
+    "name" : "Update User Locale",
+    "providerId" : "update_user_locale",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 1000,
+    "config" : { }
+  } ],
+  "browserFlow" : "browser",
+  "registrationFlow" : "registration",
+  "directGrantFlow" : "direct grant",
+  "resetCredentialsFlow" : "reset credentials",
+  "clientAuthenticationFlow" : "clients",
+  "dockerAuthenticationFlow" : "docker auth",
+  "attributes" : {
+    "cibaBackchannelTokenDeliveryMode" : "poll",
+    "cibaExpiresIn" : "120",
+    "cibaAuthRequestedUserHint" : "login_hint",
+    "oauth2DeviceCodeLifespan" : "600",
+    "oauth2DevicePollingInterval" : "5",
+    "parRequestUriLifespan" : "60",
+    "cibaInterval" : "5",
+    "realmReusableOtpCode" : "false"
+  },
+  "keycloakVersion" : "21.1.2",
+  "userManagedAccessAllowed" : false,
+  "clientProfiles" : {
+    "profiles" : [ ]
+  },
+  "clientPolicies" : {
+    "policies" : [ ]
+  }
+}

--- a/dev/opnc-realm.json
+++ b/dev/opnc-realm.json
@@ -1,5 +1,5 @@
 {
-  "id" : "2fba1b4c-3c7c-47d4-9148-0e04f61b5d89",
+  "id" : "b7fbca5e-5d61-474d-b405-d25ec3a2230d",
   "realm" : "opnc",
   "notBefore" : 0,
   "defaultSignatureAlgorithm" : "RS256",
@@ -45,23 +45,23 @@
   "failureFactor" : 30,
   "roles" : {
     "realm" : [ {
-      "id" : "cdcf9eae-eca5-4404-a0f3-64d42ad5ac93",
-      "name" : "uma_authorization",
-      "description" : "${role_uma_authorization}",
-      "composite" : false,
-      "clientRole" : false,
-      "containerId" : "2fba1b4c-3c7c-47d4-9148-0e04f61b5d89",
-      "attributes" : { }
-    }, {
-      "id" : "dde19435-d760-4a70-a500-3d21d038271b",
+      "id" : "2675ae7a-c5e4-490a-a44c-9471b8f5e989",
       "name" : "offline_access",
       "description" : "${role_offline-access}",
       "composite" : false,
       "clientRole" : false,
-      "containerId" : "2fba1b4c-3c7c-47d4-9148-0e04f61b5d89",
+      "containerId" : "b7fbca5e-5d61-474d-b405-d25ec3a2230d",
       "attributes" : { }
     }, {
-      "id" : "67292fc2-70b7-4bcc-ae54-a8230be99645",
+      "id" : "084b7e13-f4b4-41b5-b3c7-324484bf27c6",
+      "name" : "uma_authorization",
+      "description" : "${role_uma_authorization}",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "b7fbca5e-5d61-474d-b405-d25ec3a2230d",
+      "attributes" : { }
+    }, {
+      "id" : "ffb4c044-77b2-408d-b954-10e3578afa51",
       "name" : "default-roles-opnc",
       "description" : "${role_default-roles}",
       "composite" : true,
@@ -72,151 +72,13 @@
         }
       },
       "clientRole" : false,
-      "containerId" : "2fba1b4c-3c7c-47d4-9148-0e04f61b5d89",
+      "containerId" : "b7fbca5e-5d61-474d-b405-d25ec3a2230d",
       "attributes" : { }
     } ],
     "client" : {
       "nextcloud" : [ ],
       "realm-management" : [ {
-        "id" : "d2baef93-65c3-4590-9ccc-c4b65f389651",
-        "name" : "manage-authorization",
-        "description" : "${role_manage-authorization}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "caeb1678-f1f1-4530-8b50-eb53f6f7987b",
-        "attributes" : { }
-      }, {
-        "id" : "5937b16c-05b4-4bfd-9821-94bd91480e83",
-        "name" : "manage-clients",
-        "description" : "${role_manage-clients}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "caeb1678-f1f1-4530-8b50-eb53f6f7987b",
-        "attributes" : { }
-      }, {
-        "id" : "2870ae57-7180-4e23-8e8c-e52ed4b8575b",
-        "name" : "create-client",
-        "description" : "${role_create-client}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "caeb1678-f1f1-4530-8b50-eb53f6f7987b",
-        "attributes" : { }
-      }, {
-        "id" : "b52871cc-57e3-4b6b-92c4-fc7013c5de5e",
-        "name" : "query-realms",
-        "description" : "${role_query-realms}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "caeb1678-f1f1-4530-8b50-eb53f6f7987b",
-        "attributes" : { }
-      }, {
-        "id" : "c01cd940-b681-4f6b-b6a7-d538bc95fae6",
-        "name" : "query-users",
-        "description" : "${role_query-users}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "caeb1678-f1f1-4530-8b50-eb53f6f7987b",
-        "attributes" : { }
-      }, {
-        "id" : "dca3e695-9d65-4b15-8b27-b742216869b5",
-        "name" : "manage-users",
-        "description" : "${role_manage-users}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "caeb1678-f1f1-4530-8b50-eb53f6f7987b",
-        "attributes" : { }
-      }, {
-        "id" : "798d0bf9-3c62-46ff-b26f-41324804c69c",
-        "name" : "query-groups",
-        "description" : "${role_query-groups}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "caeb1678-f1f1-4530-8b50-eb53f6f7987b",
-        "attributes" : { }
-      }, {
-        "id" : "5893f99f-1ec6-4a8c-91d2-e38adf5d46bd",
-        "name" : "manage-events",
-        "description" : "${role_manage-events}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "caeb1678-f1f1-4530-8b50-eb53f6f7987b",
-        "attributes" : { }
-      }, {
-        "id" : "71c68a37-0d59-46ae-824c-8cddd9d91f72",
-        "name" : "view-events",
-        "description" : "${role_view-events}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "caeb1678-f1f1-4530-8b50-eb53f6f7987b",
-        "attributes" : { }
-      }, {
-        "id" : "ad772cec-9519-480d-b5cc-85b44fa9bbe5",
-        "name" : "view-identity-providers",
-        "description" : "${role_view-identity-providers}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "caeb1678-f1f1-4530-8b50-eb53f6f7987b",
-        "attributes" : { }
-      }, {
-        "id" : "cb5e1124-2944-4a97-9487-5c810f4d727c",
-        "name" : "view-authorization",
-        "description" : "${role_view-authorization}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "caeb1678-f1f1-4530-8b50-eb53f6f7987b",
-        "attributes" : { }
-      }, {
-        "id" : "5474b8bb-4c7d-4142-a43c-ba3c0fd9c38d",
-        "name" : "manage-identity-providers",
-        "description" : "${role_manage-identity-providers}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "caeb1678-f1f1-4530-8b50-eb53f6f7987b",
-        "attributes" : { }
-      }, {
-        "id" : "a624faa9-707d-4064-85ee-c835fd3a9770",
-        "name" : "query-clients",
-        "description" : "${role_query-clients}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "caeb1678-f1f1-4530-8b50-eb53f6f7987b",
-        "attributes" : { }
-      }, {
-        "id" : "e37c6ecf-2ac6-4b10-9789-b8f3f631222b",
-        "name" : "impersonation",
-        "description" : "${role_impersonation}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "caeb1678-f1f1-4530-8b50-eb53f6f7987b",
-        "attributes" : { }
-      }, {
-        "id" : "e6b9da8c-94a5-4e5e-9c2f-9378e9239a89",
-        "name" : "realm-admin",
-        "description" : "${role_realm-admin}",
-        "composite" : true,
-        "composites" : {
-          "client" : {
-            "realm-management" : [ "manage-clients", "manage-authorization", "create-client", "query-users", "query-realms", "manage-users", "query-groups", "view-events", "view-identity-providers", "manage-events", "view-authorization", "manage-identity-providers", "query-clients", "impersonation", "view-users", "view-clients", "view-realm", "manage-realm" ]
-          }
-        },
-        "clientRole" : true,
-        "containerId" : "caeb1678-f1f1-4530-8b50-eb53f6f7987b",
-        "attributes" : { }
-      }, {
-        "id" : "2fd6f7f3-d87a-4c1f-811b-e25c523a872c",
-        "name" : "view-users",
-        "description" : "${role_view-users}",
-        "composite" : true,
-        "composites" : {
-          "client" : {
-            "realm-management" : [ "query-users", "query-groups" ]
-          }
-        },
-        "clientRole" : true,
-        "containerId" : "caeb1678-f1f1-4530-8b50-eb53f6f7987b",
-        "attributes" : { }
-      }, {
-        "id" : "470a3d77-4acd-4e9f-8b24-ae480fcfa6a0",
+        "id" : "abe5ef56-41de-43e8-919c-b1fc7151e8da",
         "name" : "view-clients",
         "description" : "${role_view-clients}",
         "composite" : true,
@@ -226,23 +88,161 @@
           }
         },
         "clientRole" : true,
-        "containerId" : "caeb1678-f1f1-4530-8b50-eb53f6f7987b",
+        "containerId" : "27c3e781-f8ff-4959-b941-fe475f734fb4",
         "attributes" : { }
       }, {
-        "id" : "389a660c-66aa-4e9a-b9d7-98d7d5aea28b",
-        "name" : "view-realm",
-        "description" : "${role_view-realm}",
+        "id" : "d7e345c7-0b91-4984-8463-18656d218332",
+        "name" : "create-client",
+        "description" : "${role_create-client}",
         "composite" : false,
         "clientRole" : true,
-        "containerId" : "caeb1678-f1f1-4530-8b50-eb53f6f7987b",
+        "containerId" : "27c3e781-f8ff-4959-b941-fe475f734fb4",
         "attributes" : { }
       }, {
-        "id" : "70ef187c-8884-4820-ad04-d40e53a58444",
+        "id" : "2f26fe18-0691-4f7b-a950-74e267c20690",
+        "name" : "query-users",
+        "description" : "${role_query-users}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "27c3e781-f8ff-4959-b941-fe475f734fb4",
+        "attributes" : { }
+      }, {
+        "id" : "07bf505d-fb9a-47b9-93e9-fa76e46a6209",
+        "name" : "query-groups",
+        "description" : "${role_query-groups}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "27c3e781-f8ff-4959-b941-fe475f734fb4",
+        "attributes" : { }
+      }, {
+        "id" : "3a67bb49-cda9-4a2d-b252-3edc29749dfd",
         "name" : "manage-realm",
         "description" : "${role_manage-realm}",
         "composite" : false,
         "clientRole" : true,
-        "containerId" : "caeb1678-f1f1-4530-8b50-eb53f6f7987b",
+        "containerId" : "27c3e781-f8ff-4959-b941-fe475f734fb4",
+        "attributes" : { }
+      }, {
+        "id" : "2a23544a-9e85-4f80-bbe6-1830b240fdb9",
+        "name" : "manage-identity-providers",
+        "description" : "${role_manage-identity-providers}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "27c3e781-f8ff-4959-b941-fe475f734fb4",
+        "attributes" : { }
+      }, {
+        "id" : "e4b38a23-48e9-4b3e-b10f-c41390ec08a9",
+        "name" : "view-users",
+        "description" : "${role_view-users}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "query-users", "query-groups" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "27c3e781-f8ff-4959-b941-fe475f734fb4",
+        "attributes" : { }
+      }, {
+        "id" : "0349ff35-dbb4-40de-ac61-9d99bd64678a",
+        "name" : "view-events",
+        "description" : "${role_view-events}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "27c3e781-f8ff-4959-b941-fe475f734fb4",
+        "attributes" : { }
+      }, {
+        "id" : "e88beaa7-4d79-466a-a3c4-6e0c357d5407",
+        "name" : "realm-admin",
+        "description" : "${role_realm-admin}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "view-clients", "create-client", "query-users", "query-groups", "manage-realm", "view-users", "manage-identity-providers", "view-events", "query-realms", "view-identity-providers", "manage-authorization", "manage-users", "manage-clients", "view-realm", "view-authorization", "query-clients", "manage-events", "impersonation" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "27c3e781-f8ff-4959-b941-fe475f734fb4",
+        "attributes" : { }
+      }, {
+        "id" : "6e30cf47-c86c-43fc-8003-0ac4d8cda8a4",
+        "name" : "query-realms",
+        "description" : "${role_query-realms}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "27c3e781-f8ff-4959-b941-fe475f734fb4",
+        "attributes" : { }
+      }, {
+        "id" : "02abdba4-583e-4ed2-bd74-4899a2680c8f",
+        "name" : "view-identity-providers",
+        "description" : "${role_view-identity-providers}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "27c3e781-f8ff-4959-b941-fe475f734fb4",
+        "attributes" : { }
+      }, {
+        "id" : "636d812a-eb6f-4d51-9124-676a55fd6419",
+        "name" : "manage-authorization",
+        "description" : "${role_manage-authorization}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "27c3e781-f8ff-4959-b941-fe475f734fb4",
+        "attributes" : { }
+      }, {
+        "id" : "eea3cb32-a681-46df-9592-349dd2e837a0",
+        "name" : "manage-users",
+        "description" : "${role_manage-users}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "27c3e781-f8ff-4959-b941-fe475f734fb4",
+        "attributes" : { }
+      }, {
+        "id" : "93b3bbf1-4831-45d8-9c4f-0454c11dad44",
+        "name" : "manage-clients",
+        "description" : "${role_manage-clients}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "27c3e781-f8ff-4959-b941-fe475f734fb4",
+        "attributes" : { }
+      }, {
+        "id" : "801f027d-d924-4da2-b472-4d1a40224902",
+        "name" : "query-clients",
+        "description" : "${role_query-clients}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "27c3e781-f8ff-4959-b941-fe475f734fb4",
+        "attributes" : { }
+      }, {
+        "id" : "b3ee78ae-64e1-4dd6-9975-8d19253992ac",
+        "name" : "view-authorization",
+        "description" : "${role_view-authorization}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "27c3e781-f8ff-4959-b941-fe475f734fb4",
+        "attributes" : { }
+      }, {
+        "id" : "740f8a2f-a86d-4019-8085-bc112384d62f",
+        "name" : "view-realm",
+        "description" : "${role_view-realm}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "27c3e781-f8ff-4959-b941-fe475f734fb4",
+        "attributes" : { }
+      }, {
+        "id" : "7dc7038a-1a48-4370-8b03-3995232399de",
+        "name" : "impersonation",
+        "description" : "${role_impersonation}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "27c3e781-f8ff-4959-b941-fe475f734fb4",
+        "attributes" : { }
+      }, {
+        "id" : "4ea083cf-350d-468c-8204-9ed48cf8b984",
+        "name" : "manage-events",
+        "description" : "${role_manage-events}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "27c3e781-f8ff-4959-b941-fe475f734fb4",
         "attributes" : { }
       } ],
       "openproject" : [ ],
@@ -250,16 +250,32 @@
       "admin-cli" : [ ],
       "account-console" : [ ],
       "broker" : [ {
-        "id" : "552e6287-5e03-4131-a4a0-0c18349f7cb2",
+        "id" : "730d5ca0-3a76-4864-b45a-125907c089fa",
         "name" : "read-token",
         "description" : "${role_read-token}",
         "composite" : false,
         "clientRole" : true,
-        "containerId" : "07fe7fd4-0949-4a4d-8f16-136231ef7194",
+        "containerId" : "589c4ecc-e4d8-420b-bd6d-db1b5916cef4",
         "attributes" : { }
       } ],
       "account" : [ {
-        "id" : "61ace768-e1a3-4a22-b3a7-b3b374998636",
+        "id" : "6fbe71ec-1ced-4c8f-b61a-396a360ef509",
+        "name" : "delete-account",
+        "description" : "${role_delete-account}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "4f8a28f2-34a7-45c3-a6fd-02b632d8bdbd",
+        "attributes" : { }
+      }, {
+        "id" : "cc452a26-da7e-4b16-a5c8-ab1a89aefc68",
+        "name" : "view-applications",
+        "description" : "${role_view-applications}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "4f8a28f2-34a7-45c3-a6fd-02b632d8bdbd",
+        "attributes" : { }
+      }, {
+        "id" : "e3a069b0-3e02-4450-a4f8-a0332e5651e2",
         "name" : "manage-account",
         "description" : "${role_manage-account}",
         "composite" : true,
@@ -269,10 +285,26 @@
           }
         },
         "clientRole" : true,
-        "containerId" : "9cd66f6b-5c0a-4b37-9a0c-e222d8dcf4db",
+        "containerId" : "4f8a28f2-34a7-45c3-a6fd-02b632d8bdbd",
         "attributes" : { }
       }, {
-        "id" : "29b8f96d-5b9a-47b1-a9bd-4a422bd6cadf",
+        "id" : "932360ab-e010-4b13-b0ae-4e171b7e3485",
+        "name" : "manage-account-links",
+        "description" : "${role_manage-account-links}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "4f8a28f2-34a7-45c3-a6fd-02b632d8bdbd",
+        "attributes" : { }
+      }, {
+        "id" : "f26babcc-6ae3-4c28-b0bd-28bb5bd20b85",
+        "name" : "view-groups",
+        "description" : "${role_view-groups}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "4f8a28f2-34a7-45c3-a6fd-02b632d8bdbd",
+        "attributes" : { }
+      }, {
+        "id" : "05bfc7f1-f201-475b-b10e-6fdbf5878fb5",
         "name" : "manage-consent",
         "description" : "${role_manage-consent}",
         "composite" : true,
@@ -282,67 +314,35 @@
           }
         },
         "clientRole" : true,
-        "containerId" : "9cd66f6b-5c0a-4b37-9a0c-e222d8dcf4db",
+        "containerId" : "4f8a28f2-34a7-45c3-a6fd-02b632d8bdbd",
         "attributes" : { }
       }, {
-        "id" : "50480628-e5b0-47c6-b8a2-1b1ae50b07d9",
-        "name" : "view-profile",
-        "description" : "${role_view-profile}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "9cd66f6b-5c0a-4b37-9a0c-e222d8dcf4db",
-        "attributes" : { }
-      }, {
-        "id" : "17aba603-6b4f-48ec-ae6d-a6c542253caa",
-        "name" : "manage-account-links",
-        "description" : "${role_manage-account-links}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "9cd66f6b-5c0a-4b37-9a0c-e222d8dcf4db",
-        "attributes" : { }
-      }, {
-        "id" : "e8f7f5e4-5bc4-4625-8ec5-fce5dd150d01",
+        "id" : "ed6d1327-239d-41bb-a5d8-e0e49195d5ff",
         "name" : "view-consent",
         "description" : "${role_view-consent}",
         "composite" : false,
         "clientRole" : true,
-        "containerId" : "9cd66f6b-5c0a-4b37-9a0c-e222d8dcf4db",
+        "containerId" : "4f8a28f2-34a7-45c3-a6fd-02b632d8bdbd",
         "attributes" : { }
       }, {
-        "id" : "72a891c0-deb4-447d-9c04-c092de56109e",
-        "name" : "view-groups",
-        "description" : "${role_view-groups}",
+        "id" : "f53b8d24-f891-4a1e-bca4-fe2ba4466716",
+        "name" : "view-profile",
+        "description" : "${role_view-profile}",
         "composite" : false,
         "clientRole" : true,
-        "containerId" : "9cd66f6b-5c0a-4b37-9a0c-e222d8dcf4db",
-        "attributes" : { }
-      }, {
-        "id" : "ce410a42-bc9f-4c0d-af9d-fc7c30052077",
-        "name" : "delete-account",
-        "description" : "${role_delete-account}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "9cd66f6b-5c0a-4b37-9a0c-e222d8dcf4db",
-        "attributes" : { }
-      }, {
-        "id" : "bd56b5b3-633f-415e-baeb-7f5537fbafb0",
-        "name" : "view-applications",
-        "description" : "${role_view-applications}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "9cd66f6b-5c0a-4b37-9a0c-e222d8dcf4db",
+        "containerId" : "4f8a28f2-34a7-45c3-a6fd-02b632d8bdbd",
         "attributes" : { }
       } ]
     }
   },
   "groups" : [ ],
   "defaultRole" : {
-    "id" : "67292fc2-70b7-4bcc-ae54-a8230be99645",
+    "id" : "ffb4c044-77b2-408d-b954-10e3578afa51",
     "name" : "default-roles-opnc",
     "description" : "${role_default-roles}",
     "composite" : true,
     "clientRole" : false,
-    "containerId" : "2fba1b4c-3c7c-47d4-9148-0e04f61b5d89"
+    "containerId" : "b7fbca5e-5d61-474d-b405-d25ec3a2230d"
   },
   "requiredCredentials" : [ "password" ],
   "otpPolicyType" : "totp",
@@ -374,8 +374,8 @@
   "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister" : false,
   "webAuthnPolicyPasswordlessAcceptableAaguids" : [ ],
   "users" : [ {
-    "id" : "1076ebf3-ccc2-4091-b069-ceba72f004d3",
-    "createdTimestamp" : 1737352864431,
+    "id" : "27c234a3-8b47-4f97-8daf-3c33a0138f6b",
+    "createdTimestamp" : 1737367462648,
     "username" : "alice",
     "enabled" : true,
     "totp" : false,
@@ -384,11 +384,11 @@
     "lastName" : "Hansen",
     "email" : "alice@example.com",
     "credentials" : [ {
-      "id" : "c01deac1-4d97-43b9-8456-40593d230fe6",
+      "id" : "86934b42-21bc-4f83-80e6-8cdd4f1d035d",
       "type" : "password",
       "userLabel" : "My password",
-      "createdDate" : 1737352881517,
-      "secretData" : "{\"value\":\"8AXeIG4iLYAZPYgUNz7virM4LKnKjyirf4AZQNHKh7Q=\",\"salt\":\"zEyXllPP9MTU2ugff3dRag==\",\"additionalParameters\":{}}",
+      "createdDate" : 1737367476856,
+      "secretData" : "{\"value\":\"rK/7REBAqpGKxijbKhbSEyZugmH98mXh4aL3bj++6hg=\",\"salt\":\"vukiSCQjPwPbEqe10KU7cg==\",\"additionalParameters\":{}}",
       "credentialData" : "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\",\"additionalParameters\":{}}"
     } ],
     "disableableCredentialTypes" : [ ],
@@ -397,8 +397,8 @@
     "notBefore" : 0,
     "groups" : [ ]
   }, {
-    "id" : "9029d561-2961-4fad-a020-23a55dcbfc45",
-    "createdTimestamp" : 1737352905962,
+    "id" : "821ecfdb-7178-47ba-93a0-450d58ca2bc9",
+    "createdTimestamp" : 1737367498263,
     "username" : "brian",
     "enabled" : true,
     "totp" : false,
@@ -407,11 +407,11 @@
     "lastName" : "Murphy",
     "email" : "brian@example.com",
     "credentials" : [ {
-      "id" : "b785f6ac-6ef0-4810-9c08-d1e2088a2e32",
+      "id" : "92ee16b7-189d-4572-ab62-bc7db5483d2e",
       "type" : "password",
       "userLabel" : "My password",
-      "createdDate" : 1737352915050,
-      "secretData" : "{\"value\":\"+PuxOfqX7niBLLY0fYGO87UuBrbzmB/C9JgBfi3kJtY=\",\"salt\":\"m1Ych5sGSV0OszPryMXY3g==\",\"additionalParameters\":{}}",
+      "createdDate" : 1737367505702,
+      "secretData" : "{\"value\":\"ntGBBvh3YEcMDGW4WVoS7pi9zF/z/XFZ+A8A1zE8RhM=\",\"salt\":\"pWeVl+lgTHoP8WxpjB9mcw==\",\"additionalParameters\":{}}",
       "credentialData" : "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\",\"additionalParameters\":{}}"
     } ],
     "disableableCredentialTypes" : [ ],
@@ -431,7 +431,7 @@
     } ]
   },
   "clients" : [ {
-    "id" : "9cd66f6b-5c0a-4b37-9a0c-e222d8dcf4db",
+    "id" : "4f8a28f2-34a7-45c3-a6fd-02b632d8bdbd",
     "clientId" : "account",
     "name" : "${client_account}",
     "rootUrl" : "${authBaseUrl}",
@@ -458,10 +458,10 @@
     "authenticationFlowBindingOverrides" : { },
     "fullScopeAllowed" : false,
     "nodeReRegistrationTimeout" : 0,
-    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "email" ],
     "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
   }, {
-    "id" : "ece7e373-cefc-4908-b73f-3615a8503fdf",
+    "id" : "704b692b-8c45-4c50-adc7-e8d69a0a737a",
     "clientId" : "account-console",
     "name" : "${client_account-console}",
     "rootUrl" : "${authBaseUrl}",
@@ -490,17 +490,17 @@
     "fullScopeAllowed" : false,
     "nodeReRegistrationTimeout" : 0,
     "protocolMappers" : [ {
-      "id" : "08d83117-570e-49e4-8f6f-799b6156374c",
+      "id" : "2513a457-e201-4371-99c0-768ae36a7298",
       "name" : "audience resolve",
       "protocol" : "openid-connect",
       "protocolMapper" : "oidc-audience-resolve-mapper",
       "consentRequired" : false,
       "config" : { }
     } ],
-    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "email" ],
     "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
   }, {
-    "id" : "aafb9491-c20f-4287-9847-84d24f175e3b",
+    "id" : "c003fb66-7a59-4e65-a1e1-74b1fd281c00",
     "clientId" : "admin-cli",
     "name" : "${client_admin-cli}",
     "surrogateAuthRequired" : false,
@@ -523,10 +523,10 @@
     "authenticationFlowBindingOverrides" : { },
     "fullScopeAllowed" : false,
     "nodeReRegistrationTimeout" : 0,
-    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "email" ],
     "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
   }, {
-    "id" : "07fe7fd4-0949-4a4d-8f16-136231ef7194",
+    "id" : "589c4ecc-e4d8-420b-bd6d-db1b5916cef4",
     "clientId" : "broker",
     "name" : "${client_broker}",
     "surrogateAuthRequired" : false,
@@ -549,10 +549,10 @@
     "authenticationFlowBindingOverrides" : { },
     "fullScopeAllowed" : false,
     "nodeReRegistrationTimeout" : 0,
-    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "email" ],
     "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
   }, {
-    "id" : "79bb0619-22fd-46df-9bad-3b81753cd557",
+    "id" : "71c4769a-be41-4b12-ad52-e06189090511",
     "clientId" : "nextcloud",
     "name" : "",
     "description" : "",
@@ -563,7 +563,7 @@
     "enabled" : true,
     "alwaysDisplayInConsole" : false,
     "clientAuthenticatorType" : "client-secret",
-    "secret" : "GGACnANGMdlZqMzfmsbsoqURykF8oTm0",
+    "secret" : "WpI7bXhQHK67LMklXT3SAbCNAc5lwaZu",
     "redirectUris" : [ "https://nextcloud.local/*" ],
     "webOrigins" : [ "https://nextcloud.local" ],
     "notBefore" : 0,
@@ -579,17 +579,17 @@
     "attributes" : {
       "oidc.ciba.grant.enabled" : "false",
       "oauth2.device.authorization.grant.enabled" : "false",
-      "client.secret.creation.time" : "1737352683",
+      "client.secret.creation.time" : "1737367420",
       "backchannel.logout.session.required" : "true",
       "backchannel.logout.revoke.offline.tokens" : "false"
     },
     "authenticationFlowBindingOverrides" : { },
     "fullScopeAllowed" : true,
     "nodeReRegistrationTimeout" : -1,
-    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "email" ],
     "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
   }, {
-    "id" : "702bd1fc-0132-4863-a4db-5961d572c1c2",
+    "id" : "ab3ea1b7-645d-42d4-8179-60ebc2eee6c3",
     "clientId" : "openproject",
     "name" : "",
     "description" : "",
@@ -600,7 +600,7 @@
     "enabled" : true,
     "alwaysDisplayInConsole" : false,
     "clientAuthenticatorType" : "client-secret",
-    "secret" : "ntM20VjXl3sgBSrcD1V5LyNcxI7s23oN",
+    "secret" : "8XBgTNoCZIs6sQ3ziXQGJ4q5ttwEQaka",
     "redirectUris" : [ "https://openproject.local/*" ],
     "webOrigins" : [ "https://openproject.local" ],
     "notBefore" : 0,
@@ -616,17 +616,17 @@
     "attributes" : {
       "oidc.ciba.grant.enabled" : "false",
       "oauth2.device.authorization.grant.enabled" : "false",
-      "client.secret.creation.time" : "1737352699",
+      "client.secret.creation.time" : "1737367442",
       "backchannel.logout.session.required" : "true",
       "backchannel.logout.revoke.offline.tokens" : "false"
     },
     "authenticationFlowBindingOverrides" : { },
     "fullScopeAllowed" : true,
     "nodeReRegistrationTimeout" : -1,
-    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "email" ],
     "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
   }, {
-    "id" : "caeb1678-f1f1-4530-8b50-eb53f6f7987b",
+    "id" : "27c3e781-f8ff-4959-b941-fe475f734fb4",
     "clientId" : "realm-management",
     "name" : "${client_realm-management}",
     "surrogateAuthRequired" : false,
@@ -650,26 +650,48 @@
     "authenticationFlowBindingOverrides" : { },
     "fullScopeAllowed" : false,
     "nodeReRegistrationTimeout" : 0,
-    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "email" ],
     "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ],
     "authorizationSettings" : {
       "allowRemoteResourceManagement" : false,
       "policyEnforcementMode" : "ENFORCING",
       "resources" : [ {
-        "name" : "client.resource.79bb0619-22fd-46df-9bad-3b81753cd557",
+        "name" : "client.resource.71c4769a-be41-4b12-ad52-e06189090511",
         "type" : "Client",
         "ownerManagedAccess" : false,
         "attributes" : { },
-        "_id" : "11fdad89-038d-44f8-b795-376c87080dad",
+        "_id" : "903b63c8-8213-469a-9724-b15f4bc10643",
         "uris" : [ ],
         "scopes" : [ {
           "name" : "view"
         }, {
           "name" : "map-roles-client-scope"
         }, {
+          "name" : "configure"
+        }, {
           "name" : "map-roles"
         }, {
+          "name" : "manage"
+        }, {
+          "name" : "map-roles-composite"
+        }, {
+          "name" : "token-exchange"
+        } ]
+      }, {
+        "name" : "client.resource.ab3ea1b7-645d-42d4-8179-60ebc2eee6c3",
+        "type" : "Client",
+        "ownerManagedAccess" : false,
+        "attributes" : { },
+        "_id" : "cf4fa137-3540-4f67-b6e2-e35a07337f55",
+        "uris" : [ ],
+        "scopes" : [ {
+          "name" : "view"
+        }, {
+          "name" : "map-roles-client-scope"
+        }, {
           "name" : "configure"
+        }, {
+          "name" : "map-roles"
         }, {
           "name" : "manage"
         }, {
@@ -679,114 +701,186 @@
         } ]
       } ],
       "policies" : [ {
-        "id" : "04466f53-43cf-4cef-b39b-3756beef91ff",
+        "id" : "80b77402-5103-47ce-ad0e-7e964103f922",
         "name" : "opnc-policy",
         "description" : "",
         "type" : "client",
         "logic" : "POSITIVE",
         "decisionStrategy" : "UNANIMOUS",
         "config" : {
-          "clients" : "[\"openproject\",\"nextcloud\"]"
+          "clients" : "[\"nextcloud\",\"openproject\"]"
         }
       }, {
-        "id" : "4523f650-8566-4560-84a5-35c50de6b81c",
-        "name" : "manage.permission.client.79bb0619-22fd-46df-9bad-3b81753cd557",
+        "id" : "63ec99f5-6ceb-4140-bae2-15430115e484",
+        "name" : "manage.permission.client.71c4769a-be41-4b12-ad52-e06189090511",
         "type" : "scope",
         "logic" : "POSITIVE",
         "decisionStrategy" : "UNANIMOUS",
         "config" : {
-          "resources" : "[\"client.resource.79bb0619-22fd-46df-9bad-3b81753cd557\"]",
+          "resources" : "[\"client.resource.71c4769a-be41-4b12-ad52-e06189090511\"]",
           "scopes" : "[\"manage\"]"
         }
       }, {
-        "id" : "2470e0af-f622-4a18-9d79-c76f9892a58e",
-        "name" : "configure.permission.client.79bb0619-22fd-46df-9bad-3b81753cd557",
+        "id" : "5b00a7b3-0972-48ca-b1f6-bddcdfa33773",
+        "name" : "configure.permission.client.71c4769a-be41-4b12-ad52-e06189090511",
         "type" : "scope",
         "logic" : "POSITIVE",
         "decisionStrategy" : "UNANIMOUS",
         "config" : {
-          "resources" : "[\"client.resource.79bb0619-22fd-46df-9bad-3b81753cd557\"]",
+          "resources" : "[\"client.resource.71c4769a-be41-4b12-ad52-e06189090511\"]",
           "scopes" : "[\"configure\"]"
         }
       }, {
-        "id" : "10627712-4e80-4ca2-8986-449a7b564aa7",
-        "name" : "view.permission.client.79bb0619-22fd-46df-9bad-3b81753cd557",
+        "id" : "c41268fa-c2fc-40a2-bbeb-6643f5b7432a",
+        "name" : "view.permission.client.71c4769a-be41-4b12-ad52-e06189090511",
         "type" : "scope",
         "logic" : "POSITIVE",
         "decisionStrategy" : "UNANIMOUS",
         "config" : {
-          "resources" : "[\"client.resource.79bb0619-22fd-46df-9bad-3b81753cd557\"]",
+          "resources" : "[\"client.resource.71c4769a-be41-4b12-ad52-e06189090511\"]",
           "scopes" : "[\"view\"]"
         }
       }, {
-        "id" : "691f337f-c571-47d6-8b33-ad0af3fb423f",
-        "name" : "map-roles.permission.client.79bb0619-22fd-46df-9bad-3b81753cd557",
+        "id" : "1cb1bad5-f323-45ef-83f7-8be8b7690020",
+        "name" : "map-roles.permission.client.71c4769a-be41-4b12-ad52-e06189090511",
         "type" : "scope",
         "logic" : "POSITIVE",
         "decisionStrategy" : "UNANIMOUS",
         "config" : {
-          "resources" : "[\"client.resource.79bb0619-22fd-46df-9bad-3b81753cd557\"]",
+          "resources" : "[\"client.resource.71c4769a-be41-4b12-ad52-e06189090511\"]",
           "scopes" : "[\"map-roles\"]"
         }
       }, {
-        "id" : "d96c786d-e8c2-4d8f-b3b2-33653f2210bb",
-        "name" : "map-roles-client-scope.permission.client.79bb0619-22fd-46df-9bad-3b81753cd557",
+        "id" : "b9b28436-c7fc-4558-857e-3d31e43a37f5",
+        "name" : "map-roles-client-scope.permission.client.71c4769a-be41-4b12-ad52-e06189090511",
         "type" : "scope",
         "logic" : "POSITIVE",
         "decisionStrategy" : "UNANIMOUS",
         "config" : {
-          "resources" : "[\"client.resource.79bb0619-22fd-46df-9bad-3b81753cd557\"]",
+          "resources" : "[\"client.resource.71c4769a-be41-4b12-ad52-e06189090511\"]",
           "scopes" : "[\"map-roles-client-scope\"]"
         }
       }, {
-        "id" : "efb00f38-f84a-4984-a378-31a1bbf5895e",
-        "name" : "map-roles-composite.permission.client.79bb0619-22fd-46df-9bad-3b81753cd557",
+        "id" : "108a3932-08d2-40da-a33a-f2effceb075b",
+        "name" : "map-roles-composite.permission.client.71c4769a-be41-4b12-ad52-e06189090511",
         "type" : "scope",
         "logic" : "POSITIVE",
         "decisionStrategy" : "UNANIMOUS",
         "config" : {
-          "resources" : "[\"client.resource.79bb0619-22fd-46df-9bad-3b81753cd557\"]",
+          "resources" : "[\"client.resource.71c4769a-be41-4b12-ad52-e06189090511\"]",
           "scopes" : "[\"map-roles-composite\"]"
         }
       }, {
-        "id" : "09693ff7-9807-4958-964c-525f8383a785",
-        "name" : "token-exchange.permission.client.79bb0619-22fd-46df-9bad-3b81753cd557",
+        "id" : "ece64594-79f2-4df1-9daa-23aa86fb4206",
+        "name" : "token-exchange.permission.client.71c4769a-be41-4b12-ad52-e06189090511",
         "description" : "",
         "type" : "scope",
         "logic" : "POSITIVE",
         "decisionStrategy" : "UNANIMOUS",
         "config" : {
-          "resources" : "[\"client.resource.79bb0619-22fd-46df-9bad-3b81753cd557\"]",
+          "resources" : "[\"client.resource.71c4769a-be41-4b12-ad52-e06189090511\"]",
+          "scopes" : "[\"token-exchange\"]",
+          "applyPolicies" : "[\"opnc-policy\"]"
+        }
+      }, {
+        "id" : "d9048d47-4c83-454b-b47b-991afc78c774",
+        "name" : "manage.permission.client.ab3ea1b7-645d-42d4-8179-60ebc2eee6c3",
+        "type" : "scope",
+        "logic" : "POSITIVE",
+        "decisionStrategy" : "UNANIMOUS",
+        "config" : {
+          "resources" : "[\"client.resource.ab3ea1b7-645d-42d4-8179-60ebc2eee6c3\"]",
+          "scopes" : "[\"manage\"]"
+        }
+      }, {
+        "id" : "1876853d-5c69-4f1f-9922-86fedcd2ff9d",
+        "name" : "configure.permission.client.ab3ea1b7-645d-42d4-8179-60ebc2eee6c3",
+        "type" : "scope",
+        "logic" : "POSITIVE",
+        "decisionStrategy" : "UNANIMOUS",
+        "config" : {
+          "resources" : "[\"client.resource.ab3ea1b7-645d-42d4-8179-60ebc2eee6c3\"]",
+          "scopes" : "[\"configure\"]"
+        }
+      }, {
+        "id" : "a0c37fc4-1a00-4766-bdd3-698f44033781",
+        "name" : "view.permission.client.ab3ea1b7-645d-42d4-8179-60ebc2eee6c3",
+        "type" : "scope",
+        "logic" : "POSITIVE",
+        "decisionStrategy" : "UNANIMOUS",
+        "config" : {
+          "resources" : "[\"client.resource.ab3ea1b7-645d-42d4-8179-60ebc2eee6c3\"]",
+          "scopes" : "[\"view\"]"
+        }
+      }, {
+        "id" : "4ec4613e-81d7-44cf-b008-94bb18f082c8",
+        "name" : "map-roles.permission.client.ab3ea1b7-645d-42d4-8179-60ebc2eee6c3",
+        "type" : "scope",
+        "logic" : "POSITIVE",
+        "decisionStrategy" : "UNANIMOUS",
+        "config" : {
+          "resources" : "[\"client.resource.ab3ea1b7-645d-42d4-8179-60ebc2eee6c3\"]",
+          "scopes" : "[\"map-roles\"]"
+        }
+      }, {
+        "id" : "8cc8ecba-6d6f-4db0-8314-eb1d630a0d33",
+        "name" : "map-roles-client-scope.permission.client.ab3ea1b7-645d-42d4-8179-60ebc2eee6c3",
+        "type" : "scope",
+        "logic" : "POSITIVE",
+        "decisionStrategy" : "UNANIMOUS",
+        "config" : {
+          "resources" : "[\"client.resource.ab3ea1b7-645d-42d4-8179-60ebc2eee6c3\"]",
+          "scopes" : "[\"map-roles-client-scope\"]"
+        }
+      }, {
+        "id" : "1990bbab-5856-42a1-b6dd-b163e8cfa136",
+        "name" : "map-roles-composite.permission.client.ab3ea1b7-645d-42d4-8179-60ebc2eee6c3",
+        "type" : "scope",
+        "logic" : "POSITIVE",
+        "decisionStrategy" : "UNANIMOUS",
+        "config" : {
+          "resources" : "[\"client.resource.ab3ea1b7-645d-42d4-8179-60ebc2eee6c3\"]",
+          "scopes" : "[\"map-roles-composite\"]"
+        }
+      }, {
+        "id" : "2788c935-a402-44cb-98cc-40bf1a7206c6",
+        "name" : "token-exchange.permission.client.ab3ea1b7-645d-42d4-8179-60ebc2eee6c3",
+        "description" : "",
+        "type" : "scope",
+        "logic" : "POSITIVE",
+        "decisionStrategy" : "UNANIMOUS",
+        "config" : {
+          "resources" : "[\"client.resource.ab3ea1b7-645d-42d4-8179-60ebc2eee6c3\"]",
           "scopes" : "[\"token-exchange\"]",
           "applyPolicies" : "[\"opnc-policy\"]"
         }
       } ],
       "scopes" : [ {
-        "id" : "5565b754-d2c9-4e6f-80bf-057c71579e84",
+        "id" : "1e997c1d-8fd3-4086-b8a5-8fe3a92437e9",
         "name" : "manage"
       }, {
-        "id" : "16a52349-67f4-474a-92f8-cf3ee6e026a8",
+        "id" : "3bc88f08-a648-4889-92ba-b68e528bb072",
         "name" : "view"
       }, {
-        "id" : "d765dcde-2a80-47ae-a4ed-9cf1c9bf8ecc",
+        "id" : "499e12b6-a16d-444f-a062-2ac8a20ef594",
         "name" : "map-roles"
       }, {
-        "id" : "5a71772a-dbc6-4792-84c8-2601341e09b2",
+        "id" : "e3858ccb-bbcb-4337-9994-604add593acf",
         "name" : "map-roles-client-scope"
       }, {
-        "id" : "7642b189-2f54-4f10-835f-4d6db694d6d1",
+        "id" : "42b673a2-1bc4-4af5-8eb2-854abc1c59f7",
         "name" : "map-roles-composite"
       }, {
-        "id" : "d9a42fe8-5768-4412-8fcd-907a69069f13",
+        "id" : "dcbdd6bd-a9e6-469c-918b-5025324c195e",
         "name" : "configure"
       }, {
-        "id" : "c109d6e0-f138-4c67-856f-f9a47655c775",
+        "id" : "5e0c7177-1de8-4ebf-85e3-d7e1a436362d",
         "name" : "token-exchange"
       } ],
       "decisionStrategy" : "UNANIMOUS"
     }
   }, {
-    "id" : "e4adecda-f015-4f5e-92fc-4e6c9b996a33",
+    "id" : "8c3f8a56-87b9-490c-85cd-ba6aed42fbbc",
     "clientId" : "security-admin-console",
     "name" : "${client_security-admin-console}",
     "rootUrl" : "${authAdminUrl}",
@@ -815,7 +909,7 @@
     "fullScopeAllowed" : false,
     "nodeReRegistrationTimeout" : 0,
     "protocolMappers" : [ {
-      "id" : "56e21007-f216-46bf-8b32-38591bdda030",
+      "id" : "5e3fa4b2-f24e-459e-ab7c-ab74323ee72e",
       "name" : "locale",
       "protocol" : "openid-connect",
       "protocolMapper" : "oidc-usermodel-attribute-mapper",
@@ -829,11 +923,103 @@
         "jsonType.label" : "String"
       }
     } ],
-    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "email" ],
     "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
   } ],
   "clientScopes" : [ {
-    "id" : "836d01fa-c66e-4e91-8462-96462a4eb603",
+    "id" : "fd0f14d9-98ed-47c5-94c8-ef4af30b49c9",
+    "name" : "offline_access",
+    "description" : "OpenID Connect built-in scope: offline_access",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "consent.screen.text" : "${offlineAccessScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    }
+  }, {
+    "id" : "a1947ce4-6f65-4c31-b5dd-9329b0fc504b",
+    "name" : "role_list",
+    "description" : "SAML role list",
+    "protocol" : "saml",
+    "attributes" : {
+      "consent.screen.text" : "${samlRoleListScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "61d998d9-66c9-41f1-b192-f5e222f18fa2",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    } ]
+  }, {
+    "id" : "7bb389a4-5813-445c-894e-08d7155eee87",
+    "name" : "web-origins",
+    "description" : "OpenID Connect scope for add allowed web origins to the access token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "false",
+      "consent.screen.text" : ""
+    },
+    "protocolMappers" : [ {
+      "id" : "5adb4bcd-08b1-47b5-ad4a-e41dcb046f63",
+      "name" : "allowed web origins",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-allowed-origins-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    } ]
+  }, {
+    "id" : "7805d13d-0179-473c-b0df-2129b6928263",
+    "name" : "roles",
+    "description" : "OpenID Connect scope for add user roles to the access token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${rolesScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "ec5f26a6-db08-4711-ba3f-1a7f68592890",
+      "name" : "audience resolve",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-resolve-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    }, {
+      "id" : "1bc83cf6-4abc-4886-9be4-9cb751e69c93",
+      "name" : "realm roles",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-realm-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute" : "foo",
+        "access.token.claim" : "true",
+        "claim.name" : "realm_access.roles",
+        "jsonType.label" : "String",
+        "multivalued" : "true"
+      }
+    }, {
+      "id" : "d249aba9-22d0-4822-b159-3c111e914521",
+      "name" : "client roles",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-client-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute" : "foo",
+        "access.token.claim" : "true",
+        "claim.name" : "resource_access.${client_id}.roles",
+        "jsonType.label" : "String",
+        "multivalued" : "true"
+      }
+    } ]
+  }, {
+    "id" : "719036bd-5c8a-4ad5-998a-eaaa29620bab",
     "name" : "email",
     "description" : "OpenID Connect built-in scope: email",
     "protocol" : "openid-connect",
@@ -843,21 +1029,7 @@
       "consent.screen.text" : "${emailScopeConsentText}"
     },
     "protocolMappers" : [ {
-      "id" : "34efe1a7-36cf-4c2d-95f6-21ad02fefffd",
-      "name" : "email verified",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-property-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "emailVerified",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "email_verified",
-        "jsonType.label" : "boolean"
-      }
-    }, {
-      "id" : "1efae721-667f-4ede-95cc-0acbbda9afea",
+      "id" : "ea285b15-5a90-4a72-8d8e-95f5ff298312",
       "name" : "email",
       "protocol" : "openid-connect",
       "protocolMapper" : "oidc-usermodel-attribute-mapper",
@@ -870,9 +1042,23 @@
         "claim.name" : "email",
         "jsonType.label" : "String"
       }
+    }, {
+      "id" : "835d6656-da74-466e-81d9-36527e81dd48",
+      "name" : "email verified",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "emailVerified",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email_verified",
+        "jsonType.label" : "boolean"
+      }
     } ]
   }, {
-    "id" : "d395a999-614f-452a-b426-e842d99d9b73",
+    "id" : "5301e375-6a20-44e6-9b42-6d1b41107e7c",
     "name" : "microprofile-jwt",
     "description" : "Microprofile - JWT built-in scope",
     "protocol" : "openid-connect",
@@ -881,7 +1067,7 @@
       "display.on.consent.screen" : "false"
     },
     "protocolMappers" : [ {
-      "id" : "b760ad78-431c-4556-a2d9-ea67e90e7d7b",
+      "id" : "f5bc84e6-9284-4f34-9731-35968fec7750",
       "name" : "upn",
       "protocol" : "openid-connect",
       "protocolMapper" : "oidc-usermodel-attribute-mapper",
@@ -895,7 +1081,7 @@
         "jsonType.label" : "String"
       }
     }, {
-      "id" : "632428ab-d460-478b-a5a8-3f49db1a813b",
+      "id" : "a6584b74-44b3-48b8-b29b-d6d9884e1e2c",
       "name" : "groups",
       "protocol" : "openid-connect",
       "protocolMapper" : "oidc-usermodel-realm-role-mapper",
@@ -910,211 +1096,7 @@
       }
     } ]
   }, {
-    "id" : "570ac884-4a8f-4184-81c5-b2fb1e4c558a",
-    "name" : "profile",
-    "description" : "OpenID Connect built-in scope: profile",
-    "protocol" : "openid-connect",
-    "attributes" : {
-      "include.in.token.scope" : "true",
-      "display.on.consent.screen" : "true",
-      "consent.screen.text" : "${profileScopeConsentText}"
-    },
-    "protocolMappers" : [ {
-      "id" : "12cd562c-ff76-467f-a435-c60f60787951",
-      "name" : "locale",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-attribute-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "locale",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "locale",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "d4560f2a-0fbb-40a9-a996-53fa04b8704f",
-      "name" : "family name",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-attribute-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "lastName",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "family_name",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "c0354661-0edc-4690-878e-12f2ea4693f1",
-      "name" : "updated at",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-attribute-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "updatedAt",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "updated_at",
-        "jsonType.label" : "long"
-      }
-    }, {
-      "id" : "1892bc44-8e3c-44c4-92d3-1f017b77e12c",
-      "name" : "birthdate",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-attribute-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "birthdate",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "birthdate",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "bfe6e0e8-f7c4-440b-82b7-28373d621c30",
-      "name" : "given name",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-attribute-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "firstName",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "given_name",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "474a8a9b-e4df-409b-b31d-def76d383973",
-      "name" : "website",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-attribute-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "website",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "website",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "3a76edf8-04fb-4784-a29d-ae7866d9de68",
-      "name" : "zoneinfo",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-attribute-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "zoneinfo",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "zoneinfo",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "78fd2179-eddb-4531-ac45-a9d79cc14703",
-      "name" : "nickname",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-attribute-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "nickname",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "nickname",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "73cca7c4-5248-4fbd-9443-86ec45079f44",
-      "name" : "gender",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-attribute-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "gender",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "gender",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "cc7d8ba2-17d0-40e6-a603-f5b5397bcbe3",
-      "name" : "full name",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-full-name-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "userinfo.token.claim" : "true"
-      }
-    }, {
-      "id" : "ad2b7296-b187-45aa-a5b4-4ca5a667f4d8",
-      "name" : "picture",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-attribute-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "picture",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "picture",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "75d9d7d0-267b-4dd9-8178-081bf2c6b576",
-      "name" : "profile",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-attribute-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "profile",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "profile",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "5a3983e7-877a-4dc0-b59b-5a78b27b2aaa",
-      "name" : "middle name",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-attribute-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "middleName",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "middle_name",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "b4decea7-7b91-4892-ab90-0daeb4df2da5",
-      "name" : "username",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-attribute-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "username",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "preferred_username",
-        "jsonType.label" : "String"
-      }
-    } ]
-  }, {
-    "id" : "3693f287-35c7-47b0-b380-d322ecebe1a1",
+    "id" : "eb026795-d294-42bf-8fa5-06ea9ef82497",
     "name" : "acr",
     "description" : "OpenID Connect scope for add acr (authentication context class reference) to the token",
     "protocol" : "openid-connect",
@@ -1123,7 +1105,7 @@
       "display.on.consent.screen" : "false"
     },
     "protocolMappers" : [ {
-      "id" : "f61be5d9-e091-405e-900a-36da1d8d1b19",
+      "id" : "d1d221e7-74c6-429c-87d2-6a7604dc3cf9",
       "name" : "acr loa level",
       "protocol" : "openid-connect",
       "protocolMapper" : "oidc-acr-mapper",
@@ -1134,120 +1116,7 @@
       }
     } ]
   }, {
-    "id" : "e4c2f56b-40a4-497c-b7f0-7b37e1b41ae0",
-    "name" : "offline_access",
-    "description" : "OpenID Connect built-in scope: offline_access",
-    "protocol" : "openid-connect",
-    "attributes" : {
-      "consent.screen.text" : "${offlineAccessScopeConsentText}",
-      "display.on.consent.screen" : "true"
-    }
-  }, {
-    "id" : "8e270b8b-5ec5-4c4b-9198-d5be836a320f",
-    "name" : "phone",
-    "description" : "OpenID Connect built-in scope: phone",
-    "protocol" : "openid-connect",
-    "attributes" : {
-      "include.in.token.scope" : "true",
-      "display.on.consent.screen" : "true",
-      "consent.screen.text" : "${phoneScopeConsentText}"
-    },
-    "protocolMappers" : [ {
-      "id" : "4d29d213-993b-4f50-904f-49adaeb4fd67",
-      "name" : "phone number",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-attribute-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "phoneNumber",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "phone_number",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "ea0c6b35-8273-47c5-b023-337f47b4b927",
-      "name" : "phone number verified",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-attribute-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "phoneNumberVerified",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "phone_number_verified",
-        "jsonType.label" : "boolean"
-      }
-    } ]
-  }, {
-    "id" : "237f4c90-5c4c-4579-9091-b953bde627f5",
-    "name" : "role_list",
-    "description" : "SAML role list",
-    "protocol" : "saml",
-    "attributes" : {
-      "consent.screen.text" : "${samlRoleListScopeConsentText}",
-      "display.on.consent.screen" : "true"
-    },
-    "protocolMappers" : [ {
-      "id" : "0e196c05-169b-4688-a9f9-1920e33c32f1",
-      "name" : "role list",
-      "protocol" : "saml",
-      "protocolMapper" : "saml-role-list-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "single" : "false",
-        "attribute.nameformat" : "Basic",
-        "attribute.name" : "Role"
-      }
-    } ]
-  }, {
-    "id" : "a3d18233-07b5-4c39-9fda-7253dc84700d",
-    "name" : "roles",
-    "description" : "OpenID Connect scope for add user roles to the access token",
-    "protocol" : "openid-connect",
-    "attributes" : {
-      "include.in.token.scope" : "false",
-      "display.on.consent.screen" : "true",
-      "consent.screen.text" : "${rolesScopeConsentText}"
-    },
-    "protocolMappers" : [ {
-      "id" : "ed5480f7-7908-4a44-8d1f-49b17c0f8489",
-      "name" : "realm roles",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-realm-role-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "user.attribute" : "foo",
-        "access.token.claim" : "true",
-        "claim.name" : "realm_access.roles",
-        "jsonType.label" : "String",
-        "multivalued" : "true"
-      }
-    }, {
-      "id" : "909c9260-75a5-4867-b2d2-e643faacdc5e",
-      "name" : "audience resolve",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-audience-resolve-mapper",
-      "consentRequired" : false,
-      "config" : { }
-    }, {
-      "id" : "d0fd48fb-f7d8-4161-ba5e-47df53319fba",
-      "name" : "client roles",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-client-role-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "user.attribute" : "foo",
-        "access.token.claim" : "true",
-        "claim.name" : "resource_access.${client_id}.roles",
-        "jsonType.label" : "String",
-        "multivalued" : "true"
-      }
-    } ]
-  }, {
-    "id" : "57906f2f-662b-41b3-b4a2-e16d72bb77c4",
+    "id" : "c963317d-e4b8-405e-b2c0-18df261f2992",
     "name" : "address",
     "description" : "OpenID Connect built-in scope: address",
     "protocol" : "openid-connect",
@@ -1257,7 +1126,7 @@
       "consent.screen.text" : "${addressScopeConsentText}"
     },
     "protocolMappers" : [ {
-      "id" : "f516175e-4afa-4d78-9353-40f5eef91076",
+      "id" : "1f6bd3a2-e74c-4585-9263-652557a1804a",
       "name" : "address",
       "protocol" : "openid-connect",
       "protocolMapper" : "oidc-address-mapper",
@@ -1275,22 +1144,247 @@
       }
     } ]
   }, {
-    "id" : "3ce4a601-8680-4aa6-acb2-a52db1c4d8f6",
-    "name" : "web-origins",
-    "description" : "OpenID Connect scope for add allowed web origins to the access token",
+    "id" : "b683890a-77f0-44f9-80c6-dd21fd1ae91f",
+    "name" : "phone",
+    "description" : "OpenID Connect built-in scope: phone",
     "protocol" : "openid-connect",
     "attributes" : {
-      "include.in.token.scope" : "false",
-      "display.on.consent.screen" : "false",
-      "consent.screen.text" : ""
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${phoneScopeConsentText}"
     },
     "protocolMappers" : [ {
-      "id" : "eb7c9661-bdc3-4a68-96b3-6a6a8a1b28b5",
-      "name" : "allowed web origins",
+      "id" : "d1a60ead-51e2-4d96-86b7-dd7baa9a20e7",
+      "name" : "phone number verified",
       "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-allowed-origins-mapper",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
       "consentRequired" : false,
-      "config" : { }
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "phoneNumberVerified",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "phone_number_verified",
+        "jsonType.label" : "boolean"
+      }
+    }, {
+      "id" : "5d2e2ba9-c987-4039-8a22-9311065b54ca",
+      "name" : "phone number",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "phoneNumber",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "phone_number",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "8c3e13f9-380c-4ef5-9737-e84c4860ce0c",
+    "name" : "profile",
+    "description" : "OpenID Connect built-in scope: profile",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${profileScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "c5c09429-8c50-4e7f-b5bc-3be5d5bb574b",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "59e0be34-3b27-4b40-996b-49d62addd5ec",
+      "name" : "picture",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "picture",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "picture",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "c56ca0f6-b084-4134-a502-b1d5b8988774",
+      "name" : "birthdate",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "birthdate",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "birthdate",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "1f4dc8ce-5e14-4b26-b685-a4ced80aa2f1",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "6b50cc62-1919-44c6-9c8f-09addcc3f088",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "userinfo.token.claim" : "true"
+      }
+    }, {
+      "id" : "ee574792-b966-4f67-9fc6-b765fa796c64",
+      "name" : "zoneinfo",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "zoneinfo",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "zoneinfo",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "ccbf2b88-5494-4d3b-81b1-1e0ccdccfe94",
+      "name" : "locale",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "locale",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "locale",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "a300e95a-3324-40f8-939c-2553b506a1e9",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "ba83486a-c98f-40d2-af08-9bea9f7e7c23",
+      "name" : "middle name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "middleName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "middle_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "ae03893f-ac0d-4241-8b35-acdc9cb8e7f9",
+      "name" : "updated at",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "updatedAt",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "updated_at",
+        "jsonType.label" : "long"
+      }
+    }, {
+      "id" : "528e15ce-9dc1-4979-8001-ed8a29a625e8",
+      "name" : "nickname",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "nickname",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "nickname",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "11a9edb4-9d29-4d95-8637-91be93bcbedc",
+      "name" : "profile",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "profile",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "profile",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "b7de35c2-5693-4751-8a5c-d9bb1a391e75",
+      "name" : "gender",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "gender",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "gender",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "76015594-b5c2-42ca-9763-d2357e018966",
+      "name" : "website",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "website",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "website",
+        "jsonType.label" : "String"
+      }
     } ]
   } ],
   "defaultDefaultClientScopes" : [ "role_list", "profile", "email", "roles", "web-origins", "acr" ],
@@ -1314,16 +1408,7 @@
   "identityProviderMappers" : [ ],
   "components" : {
     "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy" : [ {
-      "id" : "6cc33d6b-6880-4994-b327-f105b51c1f4b",
-      "name" : "Allowed Protocol Mapper Types",
-      "providerId" : "allowed-protocol-mappers",
-      "subType" : "authenticated",
-      "subComponents" : { },
-      "config" : {
-        "allowed-protocol-mapper-types" : [ "oidc-sha256-pairwise-sub-mapper", "oidc-full-name-mapper", "saml-user-property-mapper", "oidc-usermodel-attribute-mapper", "oidc-address-mapper", "saml-user-attribute-mapper", "oidc-usermodel-property-mapper", "saml-role-list-mapper" ]
-      }
-    }, {
-      "id" : "a36caeaa-5e2d-45cb-ba42-81f1ec56dd83",
+      "id" : "d08e6917-d297-441f-a067-4735f7dbd45b",
       "name" : "Trusted Hosts",
       "providerId" : "trusted-hosts",
       "subType" : "anonymous",
@@ -1333,7 +1418,16 @@
         "client-uris-must-match" : [ "true" ]
       }
     }, {
-      "id" : "4f391901-3a13-4df9-82a1-f8980ba30021",
+      "id" : "5e774f76-19b1-4e36-85d7-76173dfdaac6",
+      "name" : "Allowed Client Scopes",
+      "providerId" : "allowed-client-templates",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "allow-default-scopes" : [ "true" ]
+      }
+    }, {
+      "id" : "7f6a72ec-17ff-4c0d-b660-5e7440642958",
       "name" : "Max Clients Limit",
       "providerId" : "max-clients",
       "subType" : "anonymous",
@@ -1342,25 +1436,23 @@
         "max-clients" : [ "200" ]
       }
     }, {
-      "id" : "cee04451-a2a5-4ca9-a942-39da816ff0f1",
-      "name" : "Allowed Client Scopes",
-      "providerId" : "allowed-client-templates",
+      "id" : "ced4b446-2682-4092-a796-04b085f8ce71",
+      "name" : "Consent Required",
+      "providerId" : "consent-required",
       "subType" : "anonymous",
       "subComponents" : { },
-      "config" : {
-        "allow-default-scopes" : [ "true" ]
-      }
+      "config" : { }
     }, {
-      "id" : "625c7bb5-49af-4946-b9e2-8d566838feb8",
+      "id" : "f87d0154-08b5-4671-a0e1-59a927be3fbc",
       "name" : "Allowed Protocol Mapper Types",
       "providerId" : "allowed-protocol-mappers",
       "subType" : "anonymous",
       "subComponents" : { },
       "config" : {
-        "allowed-protocol-mapper-types" : [ "oidc-usermodel-attribute-mapper", "oidc-address-mapper", "saml-role-list-mapper", "oidc-usermodel-property-mapper", "saml-user-attribute-mapper", "saml-user-property-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-full-name-mapper" ]
+        "allowed-protocol-mapper-types" : [ "oidc-full-name-mapper", "saml-user-attribute-mapper", "oidc-usermodel-property-mapper", "saml-user-property-mapper", "oidc-address-mapper", "oidc-usermodel-attribute-mapper", "oidc-sha256-pairwise-sub-mapper", "saml-role-list-mapper" ]
       }
     }, {
-      "id" : "22679df7-c92d-4a96-ac79-17d10e72c473",
+      "id" : "ac7de5d6-d660-477d-a7db-f5b04e3c3ff1",
       "name" : "Allowed Client Scopes",
       "providerId" : "allowed-client-templates",
       "subType" : "authenticated",
@@ -1369,14 +1461,16 @@
         "allow-default-scopes" : [ "true" ]
       }
     }, {
-      "id" : "8e736fd3-96a0-452e-810d-263d79772f1f",
-      "name" : "Consent Required",
-      "providerId" : "consent-required",
-      "subType" : "anonymous",
+      "id" : "ed51cc92-16d2-45d8-a1bb-c86fcfaf66ca",
+      "name" : "Allowed Protocol Mapper Types",
+      "providerId" : "allowed-protocol-mappers",
+      "subType" : "authenticated",
       "subComponents" : { },
-      "config" : { }
+      "config" : {
+        "allowed-protocol-mapper-types" : [ "saml-user-attribute-mapper", "saml-role-list-mapper", "oidc-usermodel-property-mapper", "oidc-address-mapper", "oidc-sha256-pairwise-sub-mapper", "saml-user-property-mapper", "oidc-full-name-mapper", "oidc-usermodel-attribute-mapper" ]
+      }
     }, {
-      "id" : "303355db-376e-426f-a74f-4a93d4d2910c",
+      "id" : "f09139e4-ef8e-496c-8d68-69ae8c648d13",
       "name" : "Full Scope Disabled",
       "providerId" : "scope",
       "subType" : "anonymous",
@@ -1384,47 +1478,47 @@
       "config" : { }
     } ],
     "org.keycloak.keys.KeyProvider" : [ {
-      "id" : "578cb54a-05fc-47c9-b70c-573aa41d30b3",
-      "name" : "rsa-enc-generated",
-      "providerId" : "rsa-enc-generated",
-      "subComponents" : { },
-      "config" : {
-        "privateKey" : [ "MIIEpQIBAAKCAQEAzsEJpswGyxttxLz/Ogh1ZZgN5mthyZ+uO4WhYv0Ai3mfFCViGvscAis804wa7zWl5kszbpEhIl6fleTZke7N9VIjnwM6QzhsiqBq3hS3jAvZzkOFcm3L545mFLWz5yKV+RfS4TZBdkQHbP5Sb4xV4KcI0Q6aJGvL5uVfwiImhLsIUdMR9g+gT6f1np/dPhU9mV/gX6hYPOaFZK7jjtnZwlGkA4JPwQT4Je7VzJKEIrXVewFGGsM0b21OX+O53uakTNrFMJODWb17ABYCdfVgUaSfXTmYTmguP0uX6f/93wuJe8WZtvm0+IA6HRziyUKANQ8W/70YRAcOOzh0+5GsewIDAQABAoIBAGT1EuLtNpX//0I1rYUnczfYH1V38uiSve/XqT4eX6E7kqeyN20IWB1hApMkE1TiQ++noeYoHN9dCB0YAfuF+fEEGlu/pjgDudCZU4W85QGQGdtj0ipVnd8khAkxzrabB1N6RCFvrlhzEJMyvos0ogyQU7hNoowNTSQitfckWN2vW5rhkWgU1u/HjtxUuVFjhW3eARtN2MBibv5gskVKJjCb6LtnbsHLQR1OCMEvKHO4dsF5u1JcVs13K05LvtpnrTsHaQM/dCvads2Rt8zUv8P8D42AX8DvTMNgAJisMSus0E5vafV3pZi4gPNhEdvqMdn2+qsIpCCOuKKJKPOztPkCgYEA76JldETn5IkKETeu4FUamYWRrkHVSnqvuxLuPIqXFB2G2txSv3sljDG2sPjL7gz7+eoXDCKPRXa8ttIB1Ktyqn1SCa7kHsuWED5r8oSG2HEVtwe7Nqn5CrX9GvFORsetMB1KRWB4DpR9Fq+wGwRBbETQ6p7YiF/lxD23DKyQk6kCgYEA3N/I12ZtwhEMoDnoI5+UbVtYvMuoGnK9gkvV1pYmj8CO25sPHaT+AEEqoMWNl4OGiUlSiQFOHnNmeSr9mc+yjUMag2Zi/TCOqbWToulsemRWYsquRvHyMfE5PcwJuW2g7hyy9rQIgM0uuhr164YkicBsJm9GD2pijGWnfWF3VYMCgYEAoeXQr2XiWZdwUsORBYTZzMDd9KILrR8IXNZkWEi122Q7eOADk9RqQLZRnGzqsjDZiDXsTkmHDEI1Kzrk+769YIv8gghDnL6k6uKRYa7Bv7dfGWJCzKK3W9IqZyqCXPWIf4o6ZHbRheAyRsJ5szcD0FcJ4olg93n6rMOZSRnJL8kCgYEAwfn3FNTsB8eZYw34BXEclX3nzMa+95tVO50GS9LKQu1FiTAAcnR4bhjNKyzUUQA9o0w1pAT1amDG2hsbZX22vcD1A/ljbiC66eiBpE2D62k7RL/jloLdxWaoctFCqQrSjsu9kFREM3n/U4ph91pztFa9pHOM//TaX5rXIZH7j6kCgYEA5ObFgXGAh7WoJg4Yz8vfdovKhW7CwAwjUAUXgdDYxQotgz9DvHUwQm5H0lH3tWcZNQ3qgyxnDhrxs4vNDWJVj0TicaNxGbpwmJIFc/acAy+U/ipbcKsYe5ByYb8xi/5bB7Q0YH+g6sIE1kDIT6rnXoRa0AKIPwUo6uTGafKUwiQ=" ],
-        "keyUse" : [ "ENC" ],
-        "certificate" : [ "MIIClzCCAX8CBgGUgknmoTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDDARvcG5jMB4XDTI1MDEyMDA1NTYwOFoXDTM1MDEyMDA1NTc0OFowDzENMAsGA1UEAwwEb3BuYzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAM7BCabMBssbbcS8/zoIdWWYDeZrYcmfrjuFoWL9AIt5nxQlYhr7HAIrPNOMGu81peZLM26RISJen5Xk2ZHuzfVSI58DOkM4bIqgat4Ut4wL2c5DhXJty+eOZhS1s+cilfkX0uE2QXZEB2z+Um+MVeCnCNEOmiRry+blX8IiJoS7CFHTEfYPoE+n9Z6f3T4VPZlf4F+oWDzmhWSu447Z2cJRpAOCT8EE+CXu1cyShCK11XsBRhrDNG9tTl/jud7mpEzaxTCTg1m9ewAWAnX1YFGkn105mE5oLj9Ll+n//d8LiXvFmbb5tPiAOh0c4slCgDUPFv+9GEQHDjs4dPuRrHsCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEATkOkUvCCcI7Tcy2MBBJnfrLkEBlkBdnjeTBgshYdLEEUSEwnaU/XlUwg1EhPwmLm1AWWj023JMK1oa9noDjIU6M/ZYFzDI1T4JuE3Kzbs0xMVu4drbbN2VUWVpXY+r2LeqUbxVH8odPCv+exQ/3R+0TESmFp9NkiIbcsC/YLsyBUQvbOC7vd/eoVQh208i0OC6mkg8UDFAmAMCJ+mP4fDCpq0Ys4QYkd6xY7+YJl8C165jHBs0T9uwa1Hl9vFMj3hEFQkN+wJNYjIG5rQSApVnxYMXRw8oMAru57I8nc8CDIyU9YQOqCW+sa1CPQ6L1+Hm+b75YeK1fpjopxtLMtbw==" ],
-        "priority" : [ "100" ],
-        "algorithm" : [ "RSA-OAEP" ]
-      }
-    }, {
-      "id" : "a12ce523-09aa-49b3-8dbd-daa24319a44e",
+      "id" : "0563aa17-33f1-46a4-8a6f-4c02d33bc1c1",
       "name" : "hmac-generated",
       "providerId" : "hmac-generated",
       "subComponents" : { },
       "config" : {
-        "kid" : [ "55e0ca86-e5a9-46d0-85b1-a2f9f00adca2" ],
-        "secret" : [ "uFeCYxY_fJS_7LFYsv1coFU90FFkfz29Rq94PuxznOa7PivJ4zDipfGpG2ZAEvKnjm8AV2P-n3IcZjcBIkc33A" ],
+        "kid" : [ "3f6f8a07-bce2-45e9-901c-6ffa96b9817c" ],
+        "secret" : [ "Ot2mS9T7wEks7bI9ReMUvkhZvdn9k726S2_8hic2HquZNvFiF3dEbML7BzXpgVJtZ5btHfjT6GW9EOwVHoEqzA" ],
         "priority" : [ "100" ],
         "algorithm" : [ "HS256" ]
       }
     }, {
-      "id" : "0614e4cb-cfda-452a-9920-339a993d39eb",
-      "name" : "rsa-generated",
-      "providerId" : "rsa-generated",
+      "id" : "4fd46b9f-a3b0-40c4-80f1-e48e59092a55",
+      "name" : "rsa-enc-generated",
+      "providerId" : "rsa-enc-generated",
       "subComponents" : { },
       "config" : {
-        "privateKey" : [ "MIIEowIBAAKCAQEAqlZK90gmoGtKUMTJTxpWi6n4jl25s3kkkvP6E+OaJkMEo6z2dT/YegiVZtBF21PDGJ/std6OZcSaPAtOrxv5EHDxvVNExqKo5K6R+NEc/bkRkgEo+WUzYTPoGn00bAyHgjbEuNfWHOgT2k/mI1Ou5j5OpjIVmgcAsEfaU6xPhKNRJ2z5pQOri/NXkauXzCWSTK0oi4k9WZ72XiaAY5P8FjJWghVjrndqFiLHFqa3MKOFsqA51uaLd88JZeCvZ+O84ESCC/LDiJIWZpi9Q/7CaTV0S9TT1CnSr/Hf/aVQ3cx2JVWt1ujMG/4GwJjip7XUj4lxVQ0ZJkxcwGgtjR1rpwIDAQABAoIBAEacvzcDkf+ueoBBE7LXGEmNjJx3/iOIdMD2oxTbpWt3HNU9Pm4cqYDtTgHxFQR3FMmAgoBiYmWNuuJpTZUJ45YNPClf+4Lcq2chdyHOjlYgAkikcnfwm/wPqIhSnwirqQEx8xstXnVdP92ggabjaf3IlpIO8SWJAaASKU/GfrBc1bgyoiUxzQE0ngSAkeeAXBKOyLv2UMmGd8pWUCHiDKFpB/Zx9rXFTnpY4EYn5W5Kunsmvkc8rjHbiLwYSKIyaxDttrJW+vM49ZUq8akmX4RRJN4kL84rhiP7bSPP6d4X8unqHj3Joj3jjLwzC2vMrfC1oFQ0/cUZlHnpAW9aGgECgYEA5ebgxgmwhT8VtOG2iwdgiOtCmq7qNZHsGow2LhD5gYTSWP0LG+6eNpoaZZeHIKkJlhcWNsDP6QhdgS/q8Bjs7gYbQ8aX/KM7sFNJ3l3KgptvmNhU/lHAqb2mmgqOWQhlqugKk1qcOUB2m+SIBFKYe8pdVTb9Bp2JbwneqHlWHr8CgYEAvaxqyPESwIFRIRf/saFRhDodaBGzHOOFndkK6I8KNclBcoTLvUYRPvIp5shRiHM/F6fj7iYd+IlIkyUQif1Ltv/rqLX/ltszCV9J+1r4xBNFBFC86dcvYEg3NfnATLvBF8+QYPgnfCv7tVcXu12hxye9SY5VQVPGASEAXfNBVRkCgYEAsciw2XR0xRXbu10wxKKXzEnh36yUAYkug/kZjNYjnD0STS6hgKAuSRsyfo2HOYJ+n0qLKxw/q32EkXp0u+cKkaa3Pto8fmncpqZB4Wu2Rvncet4QG/ssehbm1wiCu+b6eAeo5fqUBNIM5tD7PhyBPnlnY5Z6ZLs+pFeFj9ME/hECgYA1YepoBZl+fqbjxopbZwi3S1fta1Xa4po/k8+DJob8HlmCLqfc7HR8H9H1NxnjanQuZz06UJYM1i6L41mlTJnbtmmQATEfNzBFCgGbcb4kCTxae5K/yaV21rxbP6CEuC8fUXbUI+ORChv8rLdsL20RzTh0FFAgY8CNnskoqAcSOQKBgEh2uTyjAnm0e2kCRxANkMvgDrug30gvE+fEHIyrVUlnTY4xnpJnMJ88SJ1PfPmmoEtifH8cOoqbG5eGFojcTjLRTyw3/sNjkCW3b2ENvqc+HMLvaCqwywssb4Cf/4X0S7YonrbOmjBYx0Vita6zywTmYVemnbtCK0sVmEnOYJxX" ],
-        "keyUse" : [ "SIG" ],
-        "certificate" : [ "MIIClzCCAX8CBgGUgknmKDANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDDARvcG5jMB4XDTI1MDEyMDA1NTYwOFoXDTM1MDEyMDA1NTc0OFowDzENMAsGA1UEAwwEb3BuYzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKpWSvdIJqBrSlDEyU8aVoup+I5dubN5JJLz+hPjmiZDBKOs9nU/2HoIlWbQRdtTwxif7LXejmXEmjwLTq8b+RBw8b1TRMaiqOSukfjRHP25EZIBKPllM2Ez6Bp9NGwMh4I2xLjX1hzoE9pP5iNTruY+TqYyFZoHALBH2lOsT4SjUSds+aUDq4vzV5Grl8wlkkytKIuJPVme9l4mgGOT/BYyVoIVY653ahYixxamtzCjhbKgOdbmi3fPCWXgr2fjvOBEggvyw4iSFmaYvUP+wmk1dEvU09Qp0q/x3/2lUN3MdiVVrdbozBv+BsCY4qe11I+JcVUNGSZMXMBoLY0da6cCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAoJ7Sb2rHghm/fw9mAo0G2cAD/nQmFRoPyKv8ZDntiXDV+aSXfN/vinpzvGE/EHESUGXUcZ/jH5/L23il2Vmrqt6PFT8r+QvbBhWW3rzqtMZIRMaD2AOQqwlaJJqvbnZ6JxXANigTkqPgtrPp+5gUP8491FSfqO2eip9EbU2WCQrfbb5PStsUZlsftkhdhXLHg/EMWIuDKtwk9mjM4iCQoucVefCPAT7XKR1mjfQ7Wh4Wm2jq7XYNgp7mO2D+uWlrbPNYzdeAvSAICvYsAIaDckADrnNoJJZxSSYnasmHp2hsk3DvmIHeo4hY9gTbupAiKOI7BC7kWBCxMTYSGyGbTw==" ],
-        "priority" : [ "100" ]
+        "privateKey" : [ "MIIEogIBAAKCAQEAkIBUj9ZZzhvo5FP3o0nJXI/GJuFpqyd6NAfi0Vr/WV6WvuTkBBA6+NCk/CRG08Q6DG3ywOCF+P1c9iqHrYxU/6wxIHInXFmtJhAxqS2MFWSAOlKe4LiDIXEcL9SDORpHZxSLOw55wiC/PATkYI1sIUJwYr/zwdghgt/OVQRAdZ3RvkgKnyD7wif+G/esZvNNgCcaKftwbQHlrW88icV2p+kB6RHTDxttlyjbG4dj/fMfQR04WAXxYl9DFHBLTKQqwKq8OF4nSLZH/nPfRTA/q6xyyrRsP8nmPOTyJOlzZfE6yVhif1Uzj5jO1g40MgsNY17eYI10zvBMtXYEWS4PnwIDAQABAoIBADdOXs80t+eaqA8oEiqVtbOvNaSw9swyzmN2tznw7bXLbb//hEQH4EJWPSdiTReFTcBvHo/y/2P2uStgyNBEW04GHkFwX59JlWtxnEhHrguMDUYFVFjnVg0pKSQnXtgutjB+XPHMDw8dkIQMzUolJsMuFiy9kjLZoa3hMiw49eDt5NMKL+bfaAc3+cvbX8KkWOyJ2eJ5DM91NasnfAxXNr1tNzEoWqM+ogoLGJGrBCCHXc+8YIlkBCAZvPZ/ChWJPj/fXdFBjJHxdHe640H/aDKYV4Y+REXXH0mJAJezTsnrx4NenBtqAPePZvDxnnCMtKmJ90qJKpQ8kcpPGVJHWqECgYEAxJek3hiI6cqMlegZe+w4f1LSBBOhmf6xUGxlvprN9Eow4mLJ9Znnmexb9Rr6QBs6FLj/xSCb8Us66Zr0zUQdgNMGQcFJmh0nZ1d6U1NIzcQ3SELg8o96ce4JlVIJSe3N4lsiJMHGwQw4g3jEopWd6hj/P9uzG3luK8aUbUco+T8CgYEAvCrtyjoWXT/2OrOFkKzRuNpdnoRCUf+5KrSp1HDIinKfE52TQ2nz6M6TaZl/CvUNfdjl5DLCdwygTgVnyfrWKOoHRleh0s4fa3DIal+uqt5QEk+ia6Ohbpih6YaFZ/FEKHn8/cjsuHVw+ddVi+9RN6i15tfXvXxR499VaRv78aECgYAN1CTywoMO/wJ4oQT55JnsyuSfCMp7TKEoaReXGsiWAIoDwrM2JYdXGns1eJpV3BRv1LuZIDwX8xTHzfCeZ8Yzg6STB4en4Zkd+ddO+TLL1puU569vIIyaawYdjNG+c43h+EskjsTuW2+2P86FKUUcbHm4AjpNGnOXfLaAIVtOfQKBgG87XUffIJtNFSxMNRd54ZvJkfADtQSuC3KgS4hmh1W4PislSgle1612eBPDhiMfCzOqhPNpwiUH1LdqYJk4a2LSPSyq3uEzscUcbYzcNO+S7Xh1lMjWeLZdCdF3EOOJ7sWSnygSn0THP9qhHVPUS4mAdM8aJtE/bVUsD1xMC5ohAoGAZmt/VPnI9+uJXODZybZILxfrEzOWm6wfen71GEdbhzbw9TvG7ZjF8OMCDy0UqKD3w3q+3pibr7alFG0MrEg2/sHNMg8rwDeAcS9wKIzK/2lgbRkuAPhGioJmQcS4BrrXDCRK6i4PWtHW+iSKNTIvr2jLyEEI05S+xJbhhUMHXO4=" ],
+        "keyUse" : [ "ENC" ],
+        "certificate" : [ "MIIClzCCAX8CBgGUgyrMijANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDDARvcG5jMB4XDTI1MDEyMDEwMDE0N1oXDTM1MDEyMDEwMDMyN1owDzENMAsGA1UEAwwEb3BuYzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJCAVI/WWc4b6ORT96NJyVyPxibhaasnejQH4tFa/1lelr7k5AQQOvjQpPwkRtPEOgxt8sDghfj9XPYqh62MVP+sMSByJ1xZrSYQMaktjBVkgDpSnuC4gyFxHC/UgzkaR2cUizsOecIgvzwE5GCNbCFCcGK/88HYIYLfzlUEQHWd0b5ICp8g+8In/hv3rGbzTYAnGin7cG0B5a1vPInFdqfpAekR0w8bbZco2xuHY/3zH0EdOFgF8WJfQxRwS0ykKsCqvDheJ0i2R/5z30UwP6uscsq0bD/J5jzk8iTpc2XxOslYYn9VM4+YztYONDILDWNe3mCNdM7wTLV2BFkuD58CAwEAATANBgkqhkiG9w0BAQsFAAOCAQEADn1iFM2uUVMu3s2EFWWkaaxRVd06pyqzHbjwlgsgLsmpOGGn1imU89Fk5GdaNFrkb2vjAuLJ9h+//OB9uW6SB58g4aZc5FQSax0gpt2jqcrXfs8yWTQ/D8g9W37sFPJ6vV2PC4WY+5ZnYFMRzgjG1didPlnTma6+NSROTa+FpoMzX9BOvOIWGSYQHJ8393jvQUGTWtVCYrZfTveGfYGYCVpNNg/+iRl5OT5RT+aevAvoZIu2Uw97PaEv2BcsRcgq4f18n+2hGfbwkev1gMDnd4Pltp3IzWGooD0DATAc4BV8ukFXc9Vw9ebpuxxmOkWhVT+FYziU5SoG7jR8v6na4w==" ],
+        "priority" : [ "100" ],
+        "algorithm" : [ "RSA-OAEP" ]
       }
     }, {
-      "id" : "842afda1-2c36-463f-b8da-1534d0bb3b83",
+      "id" : "2fd5f760-de8d-4de3-bb97-09cf71ac6e1e",
       "name" : "aes-generated",
       "providerId" : "aes-generated",
       "subComponents" : { },
       "config" : {
-        "kid" : [ "dca9b20e-b993-4f63-9bf7-01a627c5f760" ],
-        "secret" : [ "lpgsre26xwuVQp94RCVzuw" ],
+        "kid" : [ "2351e22d-4799-43dd-b7a2-a33450a4ec0d" ],
+        "secret" : [ "t5D44lGA42qBugs-SndSpA" ],
+        "priority" : [ "100" ]
+      }
+    }, {
+      "id" : "27f531ca-2cb5-4043-a777-7e2a38094410",
+      "name" : "rsa-generated",
+      "providerId" : "rsa-generated",
+      "subComponents" : { },
+      "config" : {
+        "privateKey" : [ "MIIEpQIBAAKCAQEAtEVaxEFOLJOBDqMIhPvaPGiRtZz0v3KF0gfkJpc9qlOo8brTL1deXI0bQU9elS6uo7LtWK0wacRL/gsJqsTtrvvPmC37nfOZ3i66a4N2gBnd/QSFpC5gBHNU5DgggK9hH/Y/ZsmE4j9NbY03MaV1s62mRSCSLFqt8e9gUaSFOe6P0wCUQjeEHpfFrZnDGPzCqvvDr69xzUY++ji9aSKI9fq3/r3fRdUEZl4s1ElTy1iOrI9QUyDQWgkrKrIZ9jewU3tT/ZcwuLVSj/vsbSHM3uoRo62A78BM2c9C0WlkY5dy3DFcZX5SdI5iPBvctVYXGTR/vCxsrAVWP75m/aq/8wIDAQABAoIBAAGFkv2bL2sz6fyYJQy2wpzJWzIqT6KA8M4ZKucRpzIp0K9rL6rVTIez9ErQjv+ogHZvQF+D+X9BY6sm8c5/2Eof1oiAQqlEgDNPS9TjaJvCYuDmuqJlhD6rRJJtJ5r7IAc3i0lQWFfamHlj7wZfByytahfh4A8R2MpuVxCTehj2Ug8FZLd0JEPXNAko2IfIValPofGvgzL34ii+RiuXLW45hC5WDsyXQ5QzrfBLPCQPxE5RwtyC2mwH0LN56UyykwnmJnxgWvCq/MYY8BkMQ472sUvubR/SWkOW+YOPyNq5/dKmWTlAtquj2RbwefhU7gxfaIwTnykPlM4+QoGCgQ0CgYEA9u6uuRVLWW4iIB80OpYWDv0yN7ee8I7ZZy6q0HOdfQyXbJBHPZ7AS42kWc4kFimvC9Tp84QLCe/5gx22/Rrb7W/o2LqvrnKC8uvN7Uwwfbqa7fL5SwcLEZODgCyzOZqcCApcQ5Gs95yC8w+r64hm54kiRAmIBW1GKuPQuc5ZdocCgYEAuuQDXKcWma4QK8A7RqJt6x1mn5XTxRqP1GygwUTsmnQu4RJRbbWRHkLsyBCS80+nwgzwRyQ86CNMs+9HDkE61adwc3GE1lKBP16DgvPqJgMCob1G99MnJUK6KLUiZlzY68JGpX/irpGRJ58m4ngTuVdPKwviJCyWoe+hlotomjUCgYEAqfG67kZphTL26YSQPYHtzIMVfKMzD/xAQ3MqvCvVx6pSzLS/Uvle/qCM7AGjdF1by5jNKntF3aD65/IbbjZ+BftvFTnmjvjghq8jGp3FAcLbvcfrKme+hmovppcdAhgWKrJ2rUok8IUW2pF+kKtfpxoKKykkJBgAoqQHktkhWSECgYEAsSNPAHGqnSz7TMyeIlvwPSoXy+ix2R9M9jWjxKv0aoz2pgO7xHWUv48FaLc04YM9aVLkJzn0tL5IhD+mJJ+1CS70CaeuFYoL0SlfEy7nXvH5e52wd1LexpVRZyYQHd+hBwyT82ecToPQhjJ2I69WWpSjiBRyWoEcoQ5FJTCri4UCgYEAkqc3tr5cV1bDpqlqvl2CWxNb2WEmAgd1sZ2mWyd9WohcfLfCKsFpihKb7a2ulxdEP5PNZq5bcWlIYZq7HcGRvK7eyVA6gtoC90yU1l40ClAm9gRNJIa3Uxtlmbl8Zo0u5AR4s6qw766t3RMb1FejrNN3jtXw6D47nXuOFQ2/KTg=" ],
+        "keyUse" : [ "SIG" ],
+        "certificate" : [ "MIIClzCCAX8CBgGUgyrMazANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDDARvcG5jMB4XDTI1MDEyMDEwMDE0N1oXDTM1MDEyMDEwMDMyN1owDzENMAsGA1UEAwwEb3BuYzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALRFWsRBTiyTgQ6jCIT72jxokbWc9L9yhdIH5CaXPapTqPG60y9XXlyNG0FPXpUurqOy7VitMGnES/4LCarE7a77z5gt+53zmd4uumuDdoAZ3f0EhaQuYARzVOQ4IICvYR/2P2bJhOI/TW2NNzGldbOtpkUgkixarfHvYFGkhTnuj9MAlEI3hB6Xxa2Zwxj8wqr7w6+vcc1GPvo4vWkiiPX6t/6930XVBGZeLNRJU8tYjqyPUFMg0FoJKyqyGfY3sFN7U/2XMLi1Uo/77G0hzN7qEaOtgO/ATNnPQtFpZGOXctwxXGV+UnSOYjwb3LVWFxk0f7wsbKwFVj++Zv2qv/MCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAoahD2BNYru5/3gZth/V6deSDVzeodAbmtxlbrJm4fd1Ck+HAQs11fSxP7Bq3ZlfalftNoAYrCp6pKGph3IBmoZic5zD8w7YZjXpEv7suTCGw/5FYufFtZGjs8qF87ogqAbs/Gqk+l3bdzbmO+MAON79J3QIafLr96jhOiuTj+SLd3J0mrYCESxLD0dlZCPFHiKxecdCtohFu1UVt3K8B1TpnkIQDroWs3JO0v6hthIW7PMkT1uS5TXhH/vQMSW4flyqcayde+JP1fyI0v372FWPsMc2wITfqC1Que2Imf5hcxWsEVJxgCZ3ZIkOgStM83Cds0tHeVuZSUZTK8m6NIw==" ],
         "priority" : [ "100" ]
       }
     } ]
@@ -1432,7 +1526,7 @@
   "internationalizationEnabled" : false,
   "supportedLocales" : [ ],
   "authenticationFlows" : [ {
-    "id" : "a7b0ce87-a65b-440d-9f8f-a995e0ee7071",
+    "id" : "703cbf04-6afc-4ee5-a346-47ec012e9092",
     "alias" : "Account verification options",
     "description" : "Method with which to verity the existing account",
     "providerId" : "basic-flow",
@@ -1454,7 +1548,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "9a131341-d657-4a47-8381-1ea6912c88a1",
+    "id" : "d8231de8-169e-40e8-b132-8a0bcd258c0b",
     "alias" : "Authentication Options",
     "description" : "Authentication options.",
     "providerId" : "basic-flow",
@@ -1483,7 +1577,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "b07078a0-0df4-4f85-aff6-b068c8c5f394",
+    "id" : "e4a9b202-03e6-427d-8e9b-1a6ef722c54b",
     "alias" : "Browser - Conditional OTP",
     "description" : "Flow to determine if the OTP is required for the authentication",
     "providerId" : "basic-flow",
@@ -1505,7 +1599,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "0aa5586d-0950-457b-b813-82a7a2742554",
+    "id" : "c92f3863-bfd5-4e47-8109-703dfd9196c6",
     "alias" : "Direct Grant - Conditional OTP",
     "description" : "Flow to determine if the OTP is required for the authentication",
     "providerId" : "basic-flow",
@@ -1527,7 +1621,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "968b9a71-2ebe-4ebc-a67c-e0407aa19bbc",
+    "id" : "33e724cf-b302-4737-b272-cc7a04d6bbc6",
     "alias" : "First broker login - Conditional OTP",
     "description" : "Flow to determine if the OTP is required for the authentication",
     "providerId" : "basic-flow",
@@ -1549,7 +1643,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "bd03b55a-41bb-441e-95d3-550c81a9780b",
+    "id" : "f7de583c-db66-40f7-b991-a39262e922d2",
     "alias" : "Handle Existing Account",
     "description" : "Handle what to do if there is existing account with same email/username like authenticated identity provider",
     "providerId" : "basic-flow",
@@ -1571,7 +1665,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "a4750f56-052e-4535-8c3d-4a28790059af",
+    "id" : "4f81017a-d14d-4b0e-8db4-476fbe36a1b9",
     "alias" : "Reset - Conditional OTP",
     "description" : "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
     "providerId" : "basic-flow",
@@ -1593,7 +1687,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "9501892b-e5a0-4795-b886-ce9073970336",
+    "id" : "598a597d-6cf0-49da-8d8f-044dcd310760",
     "alias" : "User creation or linking",
     "description" : "Flow for the existing/non-existing user alternatives",
     "providerId" : "basic-flow",
@@ -1616,7 +1710,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "94d53f20-d89a-440b-be3b-4300c9dc8dae",
+    "id" : "04dddc0b-b291-4771-9d0d-d64abf54334d",
     "alias" : "Verify Existing Account by Re-authentication",
     "description" : "Reauthentication of existing account",
     "providerId" : "basic-flow",
@@ -1638,7 +1732,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "f5940a28-8792-419f-ae59-062df295f701",
+    "id" : "29272268-81a7-4166-961d-52519198be6e",
     "alias" : "browser",
     "description" : "browser based authentication",
     "providerId" : "basic-flow",
@@ -1674,7 +1768,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "c603913c-4462-4b12-b6ab-4d049a2befa6",
+    "id" : "b5ed63b0-cee1-412c-bcb8-666f6c235ecb",
     "alias" : "clients",
     "description" : "Base authentication for clients",
     "providerId" : "client-flow",
@@ -1710,7 +1804,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "9cf72091-1a8c-4be8-aecb-75bbc460e1ff",
+    "id" : "6a5c5a94-232c-4d39-b675-bb4f63de4b36",
     "alias" : "direct grant",
     "description" : "OpenID Connect Resource Owner Grant",
     "providerId" : "basic-flow",
@@ -1739,7 +1833,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "d4b30090-4656-4724-a76a-cc38e9c94932",
+    "id" : "fa4b6b99-f1ae-4137-b831-c2cc8367c00c",
     "alias" : "docker auth",
     "description" : "Used by Docker clients to authenticate against the IDP",
     "providerId" : "basic-flow",
@@ -1754,7 +1848,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "3bbe783d-2a09-4624-a160-5733e9cc26d3",
+    "id" : "4e7dfca7-66fd-4369-a960-863908b1269e",
     "alias" : "first broker login",
     "description" : "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
     "providerId" : "basic-flow",
@@ -1777,7 +1871,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "1830f487-41d3-4c65-ad1a-0496fab73023",
+    "id" : "e35c991d-87fc-4933-91df-2ca5244b8c4a",
     "alias" : "forms",
     "description" : "Username, password, otp and other auth forms.",
     "providerId" : "basic-flow",
@@ -1799,7 +1893,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "017b7fcf-dce2-4d85-a540-d78ba1b74542",
+    "id" : "4d91d590-2810-4eef-8716-5181eae60f52",
     "alias" : "http challenge",
     "description" : "An authentication flow based on challenge-response HTTP Authentication Schemes",
     "providerId" : "basic-flow",
@@ -1821,7 +1915,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "73b3a53a-5502-4b34-9ca3-1edbfe6f85ca",
+    "id" : "53226039-3364-4528-9a64-9e24113e67fc",
     "alias" : "registration",
     "description" : "registration flow",
     "providerId" : "basic-flow",
@@ -1837,7 +1931,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "5cf01140-9868-4133-a1c3-e043d46d06af",
+    "id" : "5ea0780d-b138-41e9-93c8-3da19c72392d",
     "alias" : "registration form",
     "description" : "registration form",
     "providerId" : "form-flow",
@@ -1873,7 +1967,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "aa18f410-0040-4132-b43f-51d97ba64f14",
+    "id" : "3690a435-c9fe-4319-a74b-7da2897053cf",
     "alias" : "reset credentials",
     "description" : "Reset credentials for a user if they forgot their password or something",
     "providerId" : "basic-flow",
@@ -1909,7 +2003,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "3aa09d0c-7005-4629-a5ad-15f7d18eb610",
+    "id" : "e54b5cc6-4ad0-4a06-9cf0-647c88ad9b38",
     "alias" : "saml ecp",
     "description" : "SAML ECP Profile Authentication Flow",
     "providerId" : "basic-flow",
@@ -1925,13 +2019,13 @@
     } ]
   } ],
   "authenticatorConfig" : [ {
-    "id" : "43121cc6-c53f-47ee-ac64-d911c908d173",
+    "id" : "381e51cb-c82a-44e5-844b-890c4c22d560",
     "alias" : "create unique user config",
     "config" : {
       "require.password.update.after.registration" : "false"
     }
   }, {
-    "id" : "71b2b979-b339-4c25-b44f-288cc7d42628",
+    "id" : "14a0f30e-8e94-40ff-9d41-01c5146814e1",
     "alias" : "review profile config",
     "config" : {
       "update.profile.on.first.login" : "missing"

--- a/docs/setup_nc_op__full.md
+++ b/docs/setup_nc_op__full.md
@@ -1,6 +1,13 @@
 # Nextcloud-OpenProject Full Setup
 
-**Pre-requisites:**
+## Table of Contents
+
+1. [Pre-requisites](#pre-requisites)
+2. [Run the Setup](#run-the-setup)
+3. [Installing Extra Apps](#installing-extra-apps)
+4. [Keycloak Realm Configuration](#keycloak-realm-configuration)
+
+### Pre-requisites
 
 - Docker
 - Docker Compose
@@ -81,3 +88,19 @@ If permission issues occur, you can run the following command:
 
 docker compose exec nextcloud chown www-data -R custom_apps/<app>
 ```
+
+### Keycloak Realm Configuration
+
+When the setup is run with Keycloak, new realm will be initialized with necessary clients, permissions, and some demo users. The following are the details:
+
+|         |                                                                    |
+| ------- | ------------------------------------------------------------------ |
+| Realm   | `opnc`                                                             |
+| Clients | `nextcloud` and `openproject` (token-exchange has been configured) |
+
+And the following are the demo users:
+
+| Displayname      | Username | Password |
+| ---------------- | -------- | -------- |
+| **Alice Hansen** | `alice`  | `1234`   |
+| **Brian Murphy** | `brian`  | `1234`   |


### PR DESCRIPTION
## Description
Setup keycloak test realm, clients, policies and demo users upon starting the keycloak service. This should reduce the efforts required to set up keycloak for the OIDC method.
Pre-configured in Keycloak:
- realm: `opnc`
- clients: `nextcloud` and `openproject`
- token-exchange policy between above clients has been added
- demo users: `alice` and `brian` (password: `1234` for both)


## Related Issue or Workpackage


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
