### PR TITLE
chore: add linting make targets

### DIFF
--- a/.github/workflows/shared_workflow.yml
+++ b/.github/workflows/shared_workflow.yml
@@ -92,7 +92,7 @@ jobs:
           cd server && git submodule update --init
           ./occ maintenance:install --admin-pass=admin
 
-      - name: PHP code analysis
+      - name: PHP code analysis and linting
         run: |
           # The following if block can be removed once Nextcloud no longer supports PHP 8.0
           if [ "${{matrix.phpVersion}}" -eq 8 ]; then
@@ -100,18 +100,13 @@ jobs:
             sed -i '/<ignoreFiles>/a \ <file name="tests/lib/Service/OpenProjectAPIServiceTest.php"/>' psalm.xml
           fi
           make psalm
-
-      - name: PHP code style
-        run: composer run cs:check || ( echo 'Please run `composer run cs:fix` to format your code' && exit 1 )
+          make phpcs || ( echo 'Please run `make phpcs-fix` to format your code' && exit 1 )
 
       - name: Install NPM Dependencies
         run: npm install
 
       - name: JS Lint
-        run: npm run lint
-
-      - name: Style Lint
-        run: npm run stylelint
+        run: make lint-js || ( echo 'Please run `make lint-js-fix` to format your code' && exit 1 )
 
       - name: PHP & Vue Unit Tests
         run: |

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -4,7 +4,9 @@ define('PHPUNIT_RUN', 1);
 use Composer\Autoload\ClassLoader;
 
 include_once __DIR__.'/vendor/autoload.php';
-if (file_exists(__DIR__ . '/server')) {
+if (getenv('SERVER_PATH')) {
+	$serverPath = getenv('SERVER_PATH');
+} elseif (file_exists(__DIR__ . '/server')) {
 	$serverPath = __DIR__ . '/server';
 } else {
 	$serverPath = __DIR__ . '/../..';

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,10 @@
 	},
 	"scripts": {
 		"cs:fix": "php-cs-fixer fix",
-		"cs:check": "php-cs-fixer fix --dry-run --diff"
+		"cs:check": "php-cs-fixer fix --dry-run --diff",
+		"psalm": "psalm",
+		"test:unit": "phpunit",
+		"test:api": "behat -c tests/acceptance/config/behat.yml"
 	},
 	"config": {
 		"allow-plugins": {

--- a/makefile
+++ b/makefile
@@ -65,19 +65,19 @@ npm-dev:
 psalm:
 	composer run psalm
 
-.PHONY: csfixer
-csfixer:
+.PHONY: phpcs
+phpcs:
 	composer run cs:check
 
-.PHONY: csfixer-fix
-csfixer-fix:
+.PHONY: phpcs-fix
+phpcs-fix:
 	composer run cs:fix
 
 .PHONY: lint-php
-lint-php: psalm csfixer
+lint-php: psalm phpcs
 
-.PHONY: lint-php
-lint-php-fix: psalm csfixer-fix
+.PHONY: lint-php-fix
+lint-php-fix: psalm phpcs-fix
 
 .PHONY: lint-js
 lint-js:
@@ -88,6 +88,12 @@ lint-js:
 lint-js-fix:
 	npm run lint:fix
 	npm run stylelint:fix
+
+.PHONY: lint
+lint: lint-php lint-js
+
+.PHONY: lint-fix
+lint-fix: lint-php-fix lint-js-fix
 
 .PHONY: phpunit
 phpunit:

--- a/makefile
+++ b/makefile
@@ -63,16 +63,40 @@ npm-dev:
 
 .PHONY: psalm
 psalm:
-	vendor/bin/psalm
+	composer run psalm
+
+.PHONY: csfixer
+csfixer:
+	composer run cs:check
+
+.PHONY: csfixer-fix
+csfixer-fix:
+	composer run cs:fix
+
+.PHONY: lint-php
+lint-php: psalm csfixer
+
+.PHONY: lint-php
+lint-php-fix: psalm csfixer-fix
+
+.PHONY: lint-js
+lint-js:
+	npm run lint
+	npm run stylelint
+
+.PHONY: lint-js-fix
+lint-js-fix:
+	npm run lint:fix
+	npm run stylelint:fix
 
 .PHONY: phpunit
 phpunit:
-	vendor/phpunit/phpunit/phpunit
+	composer run test:unit
 
 # The following make block can be removed once Nextcloud no longer supports PHP 8.0
 .PHONY: phpunitforphp8.0
 phpunitforphp8.0:
-	vendor/phpunit/phpunit/phpunit --exclude-group ignoreWithPHP8.0
+	composer run test:unit -- --exclude-group ignoreWithPHP8.0
 
 .PHONY: jsunit
 jsunit:
@@ -80,10 +104,10 @@ jsunit:
 
 .PHONY: api-test
 api-test:
-	vendor/bin/behat -c tests/acceptance/config/behat.yml --tags '${FILTER_TAGS}' ${FEATURE_PATH}
+	composer run test:api -- --tags '${FILTER_TAGS}' ${FEATURE_PATH}
 
 .PHONY: test
-test: phpunit  jsunit api-test
+test: phpunit jsunit api-test
 
 clean:
 	sudo rm -rf $(build_dir)


### PR DESCRIPTION
## Description
Added make targets for linting php and js code, and combined targets.
Also, added use of `SERVER_PATH` env to provide server root path. This is helpful when using integration_openproject repo outside of server apps directory.

## Related Issue or Workpackage

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
