### PR TITLE
ci: bump nextcloud version to 32

### DIFF
--- a/.github/workflows/shared_workflow.yml
+++ b/.github/workflows/shared_workflow.yml
@@ -11,7 +11,7 @@ jobs:
     name: unit tests and linting
     strategy:
       matrix:
-        nextcloudVersion: [ stable30, master ]
+        nextcloudVersion: [ stable31 ]
         phpVersion: [ 8.1, 8.2, 8.3 ]
         # This condition is temporary and can be removed once Nextcloud 31 support is added in the integration app for the release/2.7 branch
         isReleaseBranch:
@@ -23,15 +23,11 @@ jobs:
             phpVersion: 8.1
           - nextcloudVersion: stable29
             phpVersion: 8.1
-        exclude:
-          - isReleaseBranch: true
-            nextcloudVersion: master
-          - isReleaseBranch: false
-            nextcloudVersion: master
-            phpVersion: 8.1
-          - isReleaseBranch: false
-            nextcloudVersion: master
+          - nextcloudVersion: stable30
             phpVersion: 8.2
+          - nextcloudVersion: master
+            phpVersion: 8.3
+            isReleaseBranch: false
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout for nightly CI
@@ -189,7 +185,7 @@ jobs:
     name: API tests
     strategy:
       matrix:
-        nextcloudVersion: [ stable30, master ]
+        nextcloudVersion: [ stable31 ]
         phpVersionMajor: [ 8 ]
         phpVersionMinor: [ 1, 2, 3 ]
         database: [ mysql ]
@@ -198,7 +194,7 @@ jobs:
           - ${{ inputs.branch == 'release/2.7'}}
         include:
           # Each database once on the newest Server with preinstalled PHP version
-          - nextcloudVersion: stable30
+          - nextcloudVersion: stable31
             phpVersionMajor: 8
             phpVersionMinor: 1
             database: pgsql
@@ -214,19 +210,15 @@ jobs:
             phpVersionMajor: 8
             phpVersionMinor: 1
             database: mysql
-        exclude:
-          - isReleaseBranch: true
-            nextcloudVersion: master
-          - isReleaseBranch: false
-            nextcloudVersion: master
-            phpVersionMajor: 8
-            phpVersionMinor: 1
-            database: mysql
-          - isReleaseBranch: false
-            nextcloudVersion: master
+          - nextcloudVersion: stable30
             phpVersionMajor: 8
             phpVersionMinor: 2
             database: mysql
+          - nextcloudVersion: master
+            phpVersionMajor: 8
+            phpVersionMinor: 3
+            database: mysql
+            isReleaseBranch: false
 
     runs-on: ubuntu-20.04
     container:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Add application's support for Nextcloud 31
 - Add support for OIDC-based connection between Nextcloud and OpenProject
+- Support Nextcloud 32 [#758](https://github.com/nextcloud/integration_openproject/pull/758)
 
 ## 2.7.2 - 2024-12-16
 ### Fixed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -3,7 +3,8 @@
 	<id>integration_openproject</id>
 	<name>OpenProject Integration</name>
 	<summary>Link Nextcloud files to OpenProject work packages</summary>
-	<description><![CDATA[This application enables seamless integration with open source project management and collaboration software OpenProject.
+	<description>
+		<![CDATA[This application enables seamless integration with open source project management and collaboration software OpenProject.
 
 On the Nextcloud end, it allows users to:
 
@@ -24,7 +25,8 @@ On the OpenProject end, users are able to:
 * Let OpenProject create shared folders per project
 
 For more information on how to set up and use the OpenProject application, please refer to [integration setup guide](https://www.openproject.org/docs/system-admin-guide/integrations/nextcloud/) for administrators and [the user guide](https://www.openproject.org/docs/user-guide/nextcloud-integration/).
-	]]></description>
+	]]>
+	</description>
 	<version>2.7.2</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
@@ -41,7 +43,7 @@ For more information on how to set up and use the OpenProject application, pleas
 	<screenshot>https://github.com/nextcloud/integration_openproject/raw/master/img/screenshot1.png</screenshot>
 	<screenshot>https://github.com/nextcloud/integration_openproject/raw/master/img/screenshot2.png</screenshot>
 	<dependencies>
-		<nextcloud min-version="27" max-version="31" />
+		<nextcloud min-version="27" max-version="32" />
 	</dependencies>
 	<background-jobs>
 		<job>OCA\OpenProject\BackgroundJob\RemoveExpiredDirectUploadTokens</job>


### PR DESCRIPTION
## Description
bump nextcloud version to 32 (required to run tests against the nextcloud master branch)

new CI jobs:
- [unit tests and linting (stable30, 8.2)](https://github.com/nextcloud/integration_openproject/actions/runs/12946925756/job/36112429152#logs)
- [API tests (stable30, 8, 2, mysql)](https://github.com/nextcloud/integration_openproject/actions/runs/12946925756/job/36112430402#logs)
- 3.0 matrixes replaced by current latest 3.1

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
