### PR TITLE
[WP #60683]display error if oidc apps not supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Show errors when user_oidc app is not available [#753](https://github.com/nextcloud/integration_openproject/pull/753)
 - Show proper error message in the dashboard based on auth method [#770](https://github.com/nextcloud/integration_openproject/pull/770)
 - Drop application's support for Nextcloud 27 [#779](https://github.com/nextcloud/integration_openproject/pull/779)
+- Show error when the user_oidc app not supported [#768](https://github.com/nextcloud/integration_openproject/pull/768)
 
 ### Fixed
 - choose correct base URL for OCS requests [#780](https://github.com/nextcloud/integration_openproject/pull/780)

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -66,6 +66,7 @@ define('CACHE_TTL', 3600);
 class OpenProjectAPIService {
 	public const AUTH_METHOD_OAUTH = 'oauth2';
 	public const AUTH_METHOD_OIDC = 'oidc';
+	public const MIN_SUPPORTED_OIDC_APP_VERSION = '6.2.0';
 	/**
 	 * @var string
 	 */
@@ -1676,13 +1677,18 @@ class OpenProjectAPIService {
 	}
 
 	public function isUserOIDCAppInstalledAndEnabled(): bool {
+		return $this->appManager->isInstalled('user_oidc');
+	}
+
+	public function isUserOIDCAppSupported(): bool {
+		$userOidcVersion = $this->appManager->getAppVersion('user_oidc');
 		return (
+			$this->isUserOIDCAppInstalledAndEnabled() &&
 			class_exists('\OCA\UserOIDC\Db\ProviderMapper') &&
 			class_exists('\OCA\UserOIDC\Event\ExchangedTokenRequestedEvent') &&
 			class_exists('\OCA\UserOIDC\Exception\TokenExchangeFailedException') &&
-			$this->appManager->isInstalled(
-				'user_oidc',
-			)
+			class_exists('\OCA\UserOIDC\User\Backend') &&
+			version_compare($userOidcVersion, self::MIN_SUPPORTED_OIDC_APP_VERSION) >= 0
 		);
 	}
 

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -66,7 +66,7 @@ define('CACHE_TTL', 3600);
 class OpenProjectAPIService {
 	public const AUTH_METHOD_OAUTH = 'oauth2';
 	public const AUTH_METHOD_OIDC = 'oidc';
-	public const MIN_SUPPORTED_OIDC_APP_VERSION = '6.2.0';
+	public const MIN_SUPPORTED_USER_OIDC_APP_VERSION = '6.2.0';
 	/**
 	 * @var string
 	 */
@@ -1688,7 +1688,7 @@ class OpenProjectAPIService {
 			class_exists('\OCA\UserOIDC\Event\ExchangedTokenRequestedEvent') &&
 			class_exists('\OCA\UserOIDC\Exception\TokenExchangeFailedException') &&
 			class_exists('\OCA\UserOIDC\User\Backend') &&
-			version_compare($userOidcVersion, self::MIN_SUPPORTED_OIDC_APP_VERSION) >= 0
+			version_compare($userOidcVersion, self::MIN_SUPPORTED_USER_OIDC_APP_VERSION) >= 0
 		);
 	}
 

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -91,7 +91,9 @@ class Admin implements ISettings {
 				'encryption_enabled_for_groupfolders' => $this->config->getAppValue('groupfolders', 'enable_encryption', '') === 'true'
 			],
 			'oidc_provider' => $this->openProjectAPIService->getRegisteredOidcProviders(),
-			'user_oidc_enabled' => $this->openProjectAPIService->isUserOIDCAppInstalledAndEnabled()
+			'user_oidc_enabled' => $this->openProjectAPIService->isUserOIDCAppInstalledAndEnabled(),
+			'user_oidc_supported' => $this->openProjectAPIService->isUserOIDCAppSupported(),
+			'user_oidc_minimum_version' => OpenProjectAPIService::MIN_SUPPORTED_OIDC_APP_VERSION,
 		];
 
 		$this->initialStateService->provideInitialState('admin-settings-config', $adminConfig);

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -93,7 +93,7 @@ class Admin implements ISettings {
 			'oidc_provider' => $this->openProjectAPIService->getRegisteredOidcProviders(),
 			'user_oidc_enabled' => $this->openProjectAPIService->isUserOIDCAppInstalledAndEnabled(),
 			'user_oidc_supported' => $this->openProjectAPIService->isUserOIDCAppSupported(),
-			'user_oidc_minimum_version' => OpenProjectAPIService::MIN_SUPPORTED_OIDC_APP_VERSION,
+			'user_oidc_minimum_version' => OpenProjectAPIService::MIN_SUPPORTED_USER_OIDC_APP_VERSION,
 		];
 
 		$this->initialStateService->provideInitialState('admin-settings-config', $adminConfig);

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -86,14 +86,14 @@
 						<NcCheckboxRadioSwitch class="radio-check"
 							:checked.sync="authorizationMethod.authorizationMethodSet"
 							:value="authMethods.OIDC"
-							:disabled="!isOIDCAppInstalledAndEnabled || !state.user_oidc_supported"
+							:disabled="!isOIDCAppInstalledAndEnabled || !isOIDCAppSupported"
 							type="radio">
 							{{ authMethodsLabel.OIDC }}
 						</NcCheckboxRadioSwitch>
 						<p v-if="!isOIDCAppInstalledAndEnabled" class="oidc-app-check-description" v-html="getOIDCAppNotInstalledHintText" /> <!-- eslint-disable-line vue/no-v-html -->
 						<ErrorLabel
-							v-if="isOIDCAppInstalledAndEnabled && !state.user_oidc_supported"
-							:error="`${messagesFmt.appNotSupported('User_Oidc')} ${messagesFmt.minimumVersionRequired(state.user_oidc_minimum_version)}`"
+							v-if="isOIDCAppInstalledAndEnabled && !isOIDCAppSupported"
+							:error="`${messagesFmt.appNotSupported('user_oidc')}. ${messagesFmt.minimumVersionRequired(getUserOidcMinimumVersion)}`"
 							type="error" />
 					</div>
 				</div>
@@ -137,7 +137,7 @@
 				:is-complete="isAuthorizationSettingFormComplete"
 				:is-disabled="isAuthorizationSettingFormInDisabledMode"
 				:is-dark-theme="isDarkTheme"
-				:has-error="!isOIDCAppInstalledAndEnabled || !state.user_oidc_supported" />
+				:has-error="!isOIDCAppInstalledAndEnabled || !isOIDCAppSupported" />
 			<ErrorNote
 				v-if="!isOIDCAppInstalledAndEnabled"
 				:error-title="messagesFmt.appNotInstalled('user_oidc')"
@@ -145,9 +145,9 @@
 				:error-link="appLinks.user_oidc.installLink"
 				:error-link-label="messages.downloadAndEnableApp" />
 			<ErrorNote
-				v-if="isOIDCAppInstalledAndEnabled && !state.user_oidc_supported"
+				v-if="isOIDCAppInstalledAndEnabled && !isOIDCAppSupported"
 				:error-title="messagesFmt.appNotSupported('user_oidc')"
-				:error-message="messagesFmt.minimumVersionRequired(state.user_oidc_minimum_version)"
+				:error-message="messagesFmt.minimumVersionRequired(getUserOidcMinimumVersion)"
 				:error-link="appLinks.user_oidc.installLink"
 				:error-link-label="messages.downloadAndEnableApp" />
 			<div class="authorization-settings--content">
@@ -163,7 +163,7 @@
 					<div id="select">
 						<NcSelect
 							input-id="provider-search-input"
-							:disabled="!isOIDCAppInstalledAndEnabled || !state.user_oidc_supported"
+							:disabled="!isOIDCAppInstalledAndEnabled || !isOIDCAppSupported"
 							:placeholder="t('integration_openproject', 'Select an OIDC provider')"
 							:options="registeredOidcProviders"
 							:value="getCurrentSelectedOIDCProvider"
@@ -188,7 +188,7 @@
 						v-model="state.authorization_settings.targeted_audience_client_id"
 						class="py-1"
 						is-required
-						:disabled="!isOIDCAppInstalledAndEnabled || !state.user_oidc_supported"
+						:disabled="!isOIDCAppInstalledAndEnabled || !isOIDCAppSupported"
 						:place-holder="messages.opClientId"
 						:label="messages.opClientId"
 						hint-text="You can get this value from Keycloak when you set-up define the client" />
@@ -196,7 +196,7 @@
 			</div>
 			<div class="form-actions">
 				<NcButton v-if="isAuthorizationSettingsInViewMode"
-					:disabled="!isOIDCAppInstalledAndEnabled"
+					:disabled="!isOIDCAppInstalledAndEnabled || !isOIDCAppSupported"
 					data-test-id="reset-auth-settings-btn"
 					@click="setAuthorizationSettingInEditMode">
 					<template #icon>
@@ -806,6 +806,9 @@ export default {
 			const htmlLink = `<a class="link" href="" target="_blank" title="${linkText}">${linkText}</a>`
 			return t('integration_openproject', 'You can configure OIDC providers in the {htmlLink}.', { htmlLink }, null, { escape: false, sanitize: false })
 		},
+		getUserOidcMinimumVersion() {
+			return this.state.user_oidc_minimum_version
+		},
 		isIntegrationCompleteWithOauth2() {
 			return (this.isServerHostFormComplete
 				&& this.isAuthorizationMethodFormComplete
@@ -865,6 +868,9 @@ export default {
 		},
 		isOIDCAppInstalledAndEnabled() {
 			return this.state.user_oidc_enabled
+		},
+		isOIDCAppSupported() {
+			return this.state.user_oidc_supported
 		},
 	},
 	created() {

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -137,7 +137,7 @@
 				:is-complete="isAuthorizationSettingFormComplete"
 				:is-disabled="isAuthorizationSettingFormInDisabledMode"
 				:is-dark-theme="isDarkTheme"
-				:has-error="!isOIDCAppInstalledAndEnabled" />
+				:has-error="!isOIDCAppInstalledAndEnabled || !state.user_oidc_supported" />
 			<ErrorNote
 				v-if="!isOIDCAppInstalledAndEnabled"
 				:error-title="messagesFmt.appNotInstalled('user_oidc')"
@@ -147,7 +147,9 @@
 			<ErrorNote
 				v-if="isOIDCAppInstalledAndEnabled && !state.user_oidc_supported"
 				:error-title="messagesFmt.appNotSupported('user_oidc')"
-				:error-message="messagesFmt.minimumVersionRequired(state.user_oidc_minimum_version)" />
+				:error-message="messagesFmt.minimumVersionRequired(state.user_oidc_minimum_version)"
+				:error-link="appLinks.user_oidc.installLink"
+				:error-link-label="messages.downloadAndEnableApp" />
 			<div class="authorization-settings--content">
 				<FieldValue v-if="isAuthorizationSettingsInViewMode"
 					is-required

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -91,7 +91,10 @@
 							{{ authMethodsLabel.OIDC }}
 						</NcCheckboxRadioSwitch>
 						<p v-if="!isOIDCAppInstalledAndEnabled" class="oidc-app-check-description" v-html="getOIDCAppNotInstalledHintText" /> <!-- eslint-disable-line vue/no-v-html -->
-						<ErrorLabel v-if="isOIDCAppInstalledAndEnabled && !state.user_oidc_supported" :error="messagesFmt.appNotSupported('User_Oidc', state.user_oidc_minimum_version)" type="error" />
+						<ErrorLabel
+							v-if="isOIDCAppInstalledAndEnabled && !state.user_oidc_supported"
+							:error="`${messagesFmt.appNotSupported('User_Oidc')} ${messagesFmt.minimumVersionRequired(state.user_oidc_minimum_version)}`"
+							type="error" />
 					</div>
 				</div>
 				<div v-else>
@@ -143,7 +146,8 @@
 				:error-link-label="messages.downloadAndEnableApp" />
 			<ErrorNote
 				v-if="isOIDCAppInstalledAndEnabled && !state.user_oidc_supported"
-				:error-title="messagesFmt.appNotSupported('user_oidc', state.user_oidc_minimum_version)" />
+				:error-title="messagesFmt.appNotSupported('user_oidc')"
+				:error-message="messagesFmt.minimumVersionRequired(state.user_oidc_minimum_version)" />
 			<div class="authorization-settings--content">
 				<FieldValue v-if="isAuthorizationSettingsInViewMode"
 					is-required

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -86,11 +86,12 @@
 						<NcCheckboxRadioSwitch class="radio-check"
 							:checked.sync="authorizationMethod.authorizationMethodSet"
 							:value="authMethods.OIDC"
-							:disabled="!isOIDCAppInstalledAndEnabled"
+							:disabled="!isOIDCAppInstalledAndEnabled || !state.user_oidc_supported"
 							type="radio">
 							{{ authMethodsLabel.OIDC }}
 						</NcCheckboxRadioSwitch>
 						<p v-if="!isOIDCAppInstalledAndEnabled" class="oidc-app-check-description" v-html="getOIDCAppNotInstalledHintText" /> <!-- eslint-disable-line vue/no-v-html -->
+						<ErrorLabel v-if="isOIDCAppInstalledAndEnabled && !state.user_oidc_supported" :error="messagesFmt.appNotSupported('User_Oidc', state.user_oidc_minimum_version)" type="error" />
 					</div>
 				</div>
 				<div v-else>
@@ -140,6 +141,9 @@
 				:error-message="messages.appRequiredForOIDCMethod"
 				:error-link="appLinks.user_oidc.installLink"
 				:error-link-label="messages.downloadAndEnableApp" />
+			<ErrorNote
+				v-if="isOIDCAppInstalledAndEnabled && !state.user_oidc_supported"
+				:error-title="messagesFmt.appNotSupported('user_oidc', state.user_oidc_minimum_version)" />
 			<div class="authorization-settings--content">
 				<FieldValue v-if="isAuthorizationSettingsInViewMode"
 					is-required
@@ -153,7 +157,7 @@
 					<div id="select">
 						<NcSelect
 							input-id="provider-search-input"
-							:disabled="!isOIDCAppInstalledAndEnabled"
+							:disabled="!isOIDCAppInstalledAndEnabled || !state.user_oidc_supported"
 							:placeholder="t('integration_openproject', 'Select an OIDC provider')"
 							:options="registeredOidcProviders"
 							:value="getCurrentSelectedOIDCProvider"
@@ -178,7 +182,7 @@
 						v-model="state.authorization_settings.targeted_audience_client_id"
 						class="py-1"
 						is-required
-						:disabled="!isOIDCAppInstalledAndEnabled"
+						:disabled="!isOIDCAppInstalledAndEnabled || !state.user_oidc_supported"
 						:place-holder="messages.opClientId"
 						:label="messages.opClientId"
 						hint-text="You can get this value from Keycloak when you set-up define the client" />
@@ -548,10 +552,12 @@ import TermsOfServiceUnsigned from './admin/TermsOfServiceUnsigned.vue'
 import dompurify from 'dompurify'
 import { messages, messagesFmt } from '../constants/messages.js'
 import { appLinks } from '../constants/links.js'
+import ErrorLabel from './ErrorLabel.vue'
 
 export default {
 	name: 'AdminSettings',
 	components: {
+		ErrorLabel,
 		NcSelect,
 		NcButton,
 		FieldValue,

--- a/src/constants/messages.js
+++ b/src/constants/messages.js
@@ -16,4 +16,5 @@ export const messages = {
 
 export const messagesFmt = {
 	appNotInstalled: (app) => t(APP_ID, 'The "{app}" app is not installed', { app }),
+	appNotSupported: (app, userOidcMinimumVersion) => t(APP_ID, '"{app}" app not supported. Minimum required version: "{userOidcMinimumVersion}"', { app, userOidcMinimumVersion }),
 }

--- a/src/constants/messages.js
+++ b/src/constants/messages.js
@@ -16,5 +16,6 @@ export const messages = {
 
 export const messagesFmt = {
 	appNotInstalled: (app) => t(APP_ID, 'The "{app}" app is not installed', { app }),
-	appNotSupported: (app, userOidcMinimumVersion) => t(APP_ID, '"{app}" app not supported. Minimum required version: "{userOidcMinimumVersion}"', { app, userOidcMinimumVersion }),
+	appNotSupported: (app) => t(APP_ID, '"{app}" app not supported.', { app }),
+	minimumVersionRequired: (minimumAppVersion) => t(APP_ID, 'This app requires a minimum version of "{minimumAppVersion}" for support', { minimumAppVersion }),
 }

--- a/src/constants/messages.js
+++ b/src/constants/messages.js
@@ -16,6 +16,6 @@ export const messages = {
 
 export const messagesFmt = {
 	appNotInstalled: (app) => t(APP_ID, 'The "{app}" app is not installed', { app }),
-	appNotSupported: (app) => t(APP_ID, 'The "{app}" app is not supported.', { app }),
-	minimumVersionRequired: (minimumAppVersion) => t(APP_ID, 'This app requires a minimum version of "{minimumAppVersion}" for support', { minimumAppVersion }),
+	appNotSupported: (app) => t(APP_ID, 'The "{app}" app is not supported', { app }),
+	minimumVersionRequired: (minimumAppVersion) => t(APP_ID, 'Requires app version "{minimumAppVersion}" or later', { minimumAppVersion }),
 }

--- a/src/constants/messages.js
+++ b/src/constants/messages.js
@@ -16,6 +16,6 @@ export const messages = {
 
 export const messagesFmt = {
 	appNotInstalled: (app) => t(APP_ID, 'The "{app}" app is not installed', { app }),
-	appNotSupported: (app) => t(APP_ID, '"{app}" app not supported.', { app }),
+	appNotSupported: (app) => t(APP_ID, 'The "{app}" app is not supported.', { app }),
 	minimumVersionRequired: (minimumAppVersion) => t(APP_ID, 'This app requires a minimum version of "{minimumAppVersion}" for support', { minimumAppVersion }),
 }

--- a/tests/jest/components/AdminSettings.spec.js
+++ b/tests/jest/components/AdminSettings.spec.js
@@ -880,7 +880,7 @@ describe('AdminSettings.vue', () => {
 				axios.put.mockReset()
 				jest.clearAllMocks()
 			})
-			it('should disable "OpenID identity provider" radio button for user_oidc app not installed', async () => {
+			it('should disable "OpenID identity provider" radio button when an user_oidc app is not installed', async () => {
 				await wrapper.setData({
 					state: {
 						user_oidc_enabled: false,
@@ -890,7 +890,7 @@ describe('AdminSettings.vue', () => {
 				expect(openIDProviderDisabled.isVisible()).toBe(true)
 			})
 
-			it('should disable "OpenID identity provider" radio button for unsupported user_oidc app installed', async () => {
+			it('should disable "OpenID identity provider" radio button when an  unsupported user_oidc app is installed', async () => {
 				await wrapper.setData({
 					state: {
 						user_oidc_enabled: true,
@@ -1196,7 +1196,7 @@ describe('AdminSettings.vue', () => {
 				})
 			})
 
-			describe('Unsupported user_oidc app enabled', () => {
+			describe('unsupported user_oidc app enabled', () => {
 				beforeEach(async () => {
 					wrapper = getWrapper({ state: { ...state, ...authorizationSettingsState, user_oidc_enabled: true, user_oidc_supported: false } })
 				})
@@ -1207,7 +1207,7 @@ describe('AdminSettings.vue', () => {
 				})
 				it('should disable reset button', () => {
 					const resetButton = wrapper.find(selectors.authorizationSettingsResetButton)
-					expect(resetButton.attributes().disabled).toBe(undefined)
+					expect(resetButton.attributes().disabled).toBe('true')
 				})
 				it('should show app not supported error messages', () => {
 					const formHeader = wrapper.find(formHeaderSelector)
@@ -1448,12 +1448,12 @@ describe('AdminSettings.vue', () => {
 				})
 			})
 
-			describe('Unsupported user_oidc app is enable', () => {
+			describe('unsupported user_oidc app is enable', () => {
 				beforeEach(async () => {
 					wrapper = getWrapper({ state: { ...state, user_oidc_enabled: true, user_oidc_supported: false } })
 				})
 
-				it('should show app unsupported error messages', () => {
+				it('should show app not supported error messages', () => {
 					const formHeaderError = wrapper.find(formHeaderSelector)
 					const errorNote = wrapper.find(errorNoteSelector)
 

--- a/tests/jest/components/AdminSettings.spec.js
+++ b/tests/jest/components/AdminSettings.spec.js
@@ -1209,15 +1209,16 @@ describe('AdminSettings.vue', () => {
 					const resetButton = wrapper.find(selectors.authorizationSettingsResetButton)
 					expect(resetButton.attributes().disabled).toBe(undefined)
 				})
-				it('should show app unsupported error messages', () => {
+				it('should show app not supported error messages', () => {
 					const formHeader = wrapper.find(formHeaderSelector)
 					const errorNote = wrapper.find(errorNoteSelector)
 
 					expect(formHeader.exists()).toBe(true)
-					// expect(formHeader.attributes().haserror).toBe(undefined)
+					expect(formHeader.attributes().haserror).toBe('true')
 					expect(errorNote.exists()).toBe(true)
 					expect(errorNote.attributes().errortitle).toBe(messagesFmt.appNotSupported())
 					expect(errorNote.attributes().errormessage).toBe(messagesFmt.minimumVersionRequired())
+					expect(errorNote.attributes().errorlink).toBe(appLinks.user_oidc.installLink)
 				})
 			})
 
@@ -1457,10 +1458,11 @@ describe('AdminSettings.vue', () => {
 					const errorNote = wrapper.find(errorNoteSelector)
 
 					expect(formHeaderError.exists()).toBe(true)
-					// expect(formHeaderError.attributes().haserror).toBe(undefined)
+					expect(formHeaderError.attributes().haserror).toBe('true')
 					expect(errorNote.exists()).toBe(true)
 					expect(errorNote.attributes().errortitle).toBe(messagesFmt.appNotSupported())
 					expect(errorNote.attributes().errormessage).toBe(messagesFmt.minimumVersionRequired())
+					expect(errorNote.attributes().errorlink).toBe(appLinks.user_oidc.installLink)
 				})
 				it('should disable form elements', () => {
 					const authorizationSettingsForm = wrapper.find(selectors.authorizationSettings)

--- a/tests/jest/components/__snapshots__/AdminSettings.spec.js.snap
+++ b/tests/jest/components/__snapshots__/AdminSettings.spec.js.snap
@@ -24,7 +24,65 @@ Wrapper {
 }
 `;
 
-exports[`AdminSettings.vue OIDC authorization settings view mode form complete user_oidc app disabled should show field values and hide authorization settings form 1`] = `
+exports[`AdminSettings.vue OIDC authorization settings view mode form complete Unsupported user_oidc app enabled should show field values and hide authorization settings form 1`] = `
+<div
+  class="authorization-settings"
+>
+  <formheading-stub
+    index="3"
+    iscomplete="true"
+    title="Authorization settings"
+  />
+   
+  <!---->
+   
+  <errornote-stub
+    errorlink=""
+    errorlinklabel=""
+    errormessage="This app requires a minimum version of "{minimumAppVersion}" for support"
+    errortitle=""{app}" app not supported."
+  />
+   
+  <div
+    class="authorization-settings--content"
+  >
+    <fieldvalue-stub
+      class="pb-1"
+      isrequired="true"
+      title="OIDC Provider"
+      value="some-oidc-provider"
+    />
+     
+    <fieldvalue-stub
+      class="pb-1"
+      isrequired="true"
+      title="OpenProject client ID"
+      value="some-target-aud-client-id"
+    />
+  </div>
+   
+  <div
+    class="form-actions"
+  >
+    <ncbutton-stub
+      alignment="center"
+      data-test-id="reset-auth-settings-btn"
+      nativetype="button"
+      type="secondary"
+    >
+      
+				Edit authorization settings
+			
+    </ncbutton-stub>
+     
+    <!---->
+     
+    <!---->
+  </div>
+</div>
+`;
+
+exports[`AdminSettings.vue OIDC authorization settings view mode form complete supported user_oidc app disabled should show field values and hide authorization settings form 1`] = `
 <div
   class="authorization-settings"
 >
@@ -41,6 +99,8 @@ exports[`AdminSettings.vue OIDC authorization settings view mode form complete u
     errormessage="This app is required to use the OIDC authorization method"
     errortitle="The "{app}" app is not installed"
   />
+   
+  <!---->
    
   <div
     class="authorization-settings--content"
@@ -82,7 +142,7 @@ exports[`AdminSettings.vue OIDC authorization settings view mode form complete u
 </div>
 `;
 
-exports[`AdminSettings.vue OIDC authorization settings view mode form complete user_oidc app enabled should show configured OIDC authorization 1`] = `
+exports[`AdminSettings.vue OIDC authorization settings view mode form complete supported user_oidc app enabled should show configured OIDC authorization 1`] = `
 <div
   class="authorization-settings"
 >
@@ -91,6 +151,8 @@ exports[`AdminSettings.vue OIDC authorization settings view mode form complete u
     iscomplete="true"
     title="Authorization settings"
   />
+   
+  <!---->
    
   <!---->
    

--- a/tests/jest/components/__snapshots__/AdminSettings.spec.js.snap
+++ b/tests/jest/components/__snapshots__/AdminSettings.spec.js.snap
@@ -29,6 +29,7 @@ exports[`AdminSettings.vue OIDC authorization settings view mode form complete U
   class="authorization-settings"
 >
   <formheading-stub
+    haserror="true"
     index="3"
     iscomplete="true"
     title="Authorization settings"
@@ -37,10 +38,10 @@ exports[`AdminSettings.vue OIDC authorization settings view mode form complete U
   <!---->
    
   <errornote-stub
-    errorlink=""
-    errorlinklabel=""
+    errorlink="http://localhost/settings/apps/files/user_oidc"
+    errorlinklabel="Download and enable it"
     errormessage="This app requires a minimum version of "{minimumAppVersion}" for support"
-    errortitle=""{app}" app not supported."
+    errortitle="The "{app}" app is not supported."
   />
    
   <div

--- a/tests/jest/components/__snapshots__/AdminSettings.spec.js.snap
+++ b/tests/jest/components/__snapshots__/AdminSettings.spec.js.snap
@@ -24,65 +24,6 @@ Wrapper {
 }
 `;
 
-exports[`AdminSettings.vue OIDC authorization settings view mode form complete Unsupported user_oidc app enabled should show field values and hide authorization settings form 1`] = `
-<div
-  class="authorization-settings"
->
-  <formheading-stub
-    haserror="true"
-    index="3"
-    iscomplete="true"
-    title="Authorization settings"
-  />
-   
-  <!---->
-   
-  <errornote-stub
-    errorlink="http://localhost/settings/apps/files/user_oidc"
-    errorlinklabel="Download and enable it"
-    errormessage="This app requires a minimum version of "{minimumAppVersion}" for support"
-    errortitle="The "{app}" app is not supported."
-  />
-   
-  <div
-    class="authorization-settings--content"
-  >
-    <fieldvalue-stub
-      class="pb-1"
-      isrequired="true"
-      title="OIDC Provider"
-      value="some-oidc-provider"
-    />
-     
-    <fieldvalue-stub
-      class="pb-1"
-      isrequired="true"
-      title="OpenProject client ID"
-      value="some-target-aud-client-id"
-    />
-  </div>
-   
-  <div
-    class="form-actions"
-  >
-    <ncbutton-stub
-      alignment="center"
-      data-test-id="reset-auth-settings-btn"
-      nativetype="button"
-      type="secondary"
-    >
-      
-				Edit authorization settings
-			
-    </ncbutton-stub>
-     
-    <!---->
-     
-    <!---->
-  </div>
-</div>
-`;
-
 exports[`AdminSettings.vue OIDC authorization settings view mode form complete supported user_oidc app disabled should show field values and hide authorization settings form 1`] = `
 <div
   class="authorization-settings"
@@ -181,6 +122,66 @@ exports[`AdminSettings.vue OIDC authorization settings view mode form complete s
     <ncbutton-stub
       alignment="center"
       data-test-id="reset-auth-settings-btn"
+      nativetype="button"
+      type="secondary"
+    >
+      
+				Edit authorization settings
+			
+    </ncbutton-stub>
+     
+    <!---->
+     
+    <!---->
+  </div>
+</div>
+`;
+
+exports[`AdminSettings.vue OIDC authorization settings view mode form complete unsupported user_oidc app enabled should show field values and hide authorization settings form 1`] = `
+<div
+  class="authorization-settings"
+>
+  <formheading-stub
+    haserror="true"
+    index="3"
+    iscomplete="true"
+    title="Authorization settings"
+  />
+   
+  <!---->
+   
+  <errornote-stub
+    errorlink="http://localhost/settings/apps/files/user_oidc"
+    errorlinklabel="Download and enable it"
+    errormessage="Requires app version "{minimumAppVersion}" or later"
+    errortitle="The "{app}" app is not supported"
+  />
+   
+  <div
+    class="authorization-settings--content"
+  >
+    <fieldvalue-stub
+      class="pb-1"
+      isrequired="true"
+      title="OIDC Provider"
+      value="some-oidc-provider"
+    />
+     
+    <fieldvalue-stub
+      class="pb-1"
+      isrequired="true"
+      title="OpenProject client ID"
+      value="some-target-aud-client-id"
+    />
+  </div>
+   
+  <div
+    class="form-actions"
+  >
+    <ncbutton-stub
+      alignment="center"
+      data-test-id="reset-auth-settings-btn"
+      disabled="true"
       nativetype="button"
       type="secondary"
     >

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -4320,4 +4320,57 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$result = $service->isOIDCUser();
 		$this->assertEquals($expected, $result);
 	}
+
+	/**
+	 * Data provider for testIsUserOIDCAppSupported
+	 */
+	public function dataProviderForIsUserOIDCAppSupported(): array {
+		return [
+			'has installed supported OIDC apps and all classes exist' => [
+				'isInstalledAndEnabled' => true,
+				'isClassesExist' => true,
+				'version' => '6.2.0',
+				'expected' => true,
+			],
+			'has installed OIDC apps but one of the class does not exist' => [
+				'isInstalledAndEnabled' => true,
+				'isClassesExist' => false,
+				'version' => '6.2.0',
+				'expected' => false,
+			],
+			'has OIDC apps not installed' => [
+				'isInstalledAndEnabled' => false,
+				'isClassesExist' => true,
+				'version' => '6.2.0',
+				'expected' => false,
+			],
+			'has installed unsupported OIDC apps version' => [
+				'isInstalledAndEnabled' => false,
+				'isClassesExist' => true,
+				'version' => '6.1.2',
+				'expected' => false,
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider dataProviderForIsUserOIDCAppSupported
+	 */
+	public function testIsUserOIDCAppSupported($isInstalledAndEnabled, $isClassesExist, $version, $expected): void {
+		$mock = $this->getFunctionMock(__NAMESPACE__, "class_exists");
+		$mock->expects($this->any())->willReturn($isClassesExist);
+
+		$iAppManagerMock = $this->getMockBuilder(IAppManager::class)->getMock();
+		$iAppManagerMock->method('getAppVersion')->with('user_oidc')->willReturn($version);
+
+		$service = $this->getOpenProjectAPIServiceMock(
+			['isUserOIDCAppInstalledAndEnabled'],
+			[
+				'appManager' => $iAppManagerMock,
+			],
+		);
+		$service->method('isUserOIDCAppInstalledAndEnabled')->willReturn($isInstalledAndEnabled);
+		$actualResult = $service->isUserOIDCAppSupported();
+		$this->assertEquals($expected, $actualResult);
+	}
 }

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -4326,28 +4326,40 @@ class OpenProjectAPIServiceTest extends TestCase {
 	 */
 	public function dataProviderForIsUserOIDCAppSupported(): array {
 		return [
-			'has installed supported OIDC apps and all classes exist' => [
-				'isInstalledAndEnabled' => true,
-				'isClassesExist' => true,
+			'has installed supported user_oidc apps and all classes exist' => [
+				'appInstalledAndEnabled' => true,
+				'classesExist' => true,
 				'version' => '6.2.0',
 				'expected' => true,
 			],
-			'has installed OIDC apps but one of the class does not exist' => [
-				'isInstalledAndEnabled' => true,
-				'isClassesExist' => false,
+			'has installed user_oidc apps but one of the class does not exist' => [
+				'appInstalledAndEnabled' => true,
+				'classesExist' => false,
 				'version' => '6.2.0',
 				'expected' => false,
 			],
-			'has OIDC apps not installed' => [
-				'isInstalledAndEnabled' => false,
-				'isClassesExist' => true,
+			'has user_oidc apps not installed' => [
+				'appInstalledAndEnabled' => false,
+				'classesExist' => true,
 				'version' => '6.2.0',
 				'expected' => false,
 			],
-			'has installed unsupported OIDC apps version' => [
-				'isInstalledAndEnabled' => false,
-				'isClassesExist' => true,
+			'has installed unsupported user_oidc apps version' => [
+				'appInstalledAndEnabled' => true,
+				'classesExist' => true,
 				'version' => '6.1.2',
+				'expected' => false,
+			],
+			'has installed user_oidc apps higher version and all classes exist' => [
+				'appInstalledAndEnabled' => true,
+				'classesExist' => true,
+				'version' => '6.3.1',
+				'expected' => true,
+			],
+			'has no user_oidc apps' => [
+				'appInstalledAndEnabled' => true,
+				'classesExist' => true,
+				'version' => '0',
 				'expected' => false,
 			],
 		];
@@ -4356,9 +4368,9 @@ class OpenProjectAPIServiceTest extends TestCase {
 	/**
 	 * @dataProvider dataProviderForIsUserOIDCAppSupported
 	 */
-	public function testIsUserOIDCAppSupported($isInstalledAndEnabled, $isClassesExist, $version, $expected): void {
+	public function testIsUserOIDCAppSupported($appInstalledAndEnabled, $classesExist, $version, $expected): void {
 		$mock = $this->getFunctionMock(__NAMESPACE__, "class_exists");
-		$mock->expects($this->any())->willReturn($isClassesExist);
+		$mock->expects($this->any())->willReturn($classesExist);
 
 		$iAppManagerMock = $this->getMockBuilder(IAppManager::class)->getMock();
 		$iAppManagerMock->method('getAppVersion')->with('user_oidc')->willReturn($version);
@@ -4369,7 +4381,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 				'appManager' => $iAppManagerMock,
 			],
 		);
-		$service->method('isUserOIDCAppInstalledAndEnabled')->willReturn($isInstalledAndEnabled);
+		$service->method('isUserOIDCAppInstalledAndEnabled')->willReturn($appInstalledAndEnabled);
 		$actualResult = $service->isUserOIDCAppSupported();
 		$this->assertEquals($expected, $actualResult);
 	}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
In this PR, an error message is added which will display if the `user_OIDC` app is not supported with the integration OpenProject.


## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://community.openproject.org/projects/nextcloud-integration/work_packages/60683

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->
![image](https://github.com/user-attachments/assets/06414bb3-37c7-4e51-a3e9-e45f204f652f)
![image](https://github.com/user-attachments/assets/eeb6e1d6-d281-4f54-a4d7-958cd61ea043)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
