### PR TITLE
Group the API endpoints that contact OP in an OCS controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Correct encoding of the avatar url [#767](https://github.com/nextcloud/integration_openproject/pull/767)
 - Show errors when user_oidc app is not available [#753](https://github.com/nextcloud/integration_openproject/pull/753)
 - Show proper error message in the dashboard based on auth method [#770](https://github.com/nextcloud/integration_openproject/pull/770)
+- Expose OpenProject API endpoints as OCS endpoints [#769](https://github.com/nextcloud/integration_openproject/pull/769)
 
 ## 2.7.2 - 2024-12-16
 ### Fixed

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -6,6 +6,10 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+$requirements = [
+	'apiVersion' => '(v1)',
+];
+
 return [
 	'routes' => [
 		['name' => 'config#oauthRedirect', 'url' => '/oauth-redirect', 'verb' => 'GET'],
@@ -26,27 +30,28 @@ return [
 		['name' => 'config#resetIntegration', 'url' => '/setup', 'verb' => 'DELETE'],
 		['name' => 'config#updateIntegration', 'url' => '/setup', 'verb' => 'PATCH'],
 
-		['name' => 'openProjectAPI#getNotifications', 'url' => '/notifications', 'verb' => 'GET'],
-		['name' => 'openProjectAPI#markNotificationAsRead', 'url' => '/work-packages/{workpackageId}/notifications', 'verb' => 'DELETE'],
-		['name' => 'openProjectAPI#getOpenProjectUrl', 'url' => '/url', 'verb' => 'GET'],
-		['name' => 'openProjectAPI#getOpenProjectAvatar', 'url' => '/avatar', 'verb' => 'GET'],
-		['name' => 'openProjectAPI#getSearchedWorkPackages', 'url' => '/work-packages', 'verb' => 'GET'],
-		['name' => 'openProjectAPI#linkWorkPackageToFile', 'url' => '/work-packages', 'verb' => 'POST'],
-		['name' => 'openProjectAPI#getWorkPackageFileLinks', 'url' => '/work-packages/{id}/file-links', 'verb' => 'GET'],
-		['name' => 'openProjectAPI#getOpenProjectWorkPackageStatus', 'url' => '/statuses/{id}', 'verb' => 'GET'],
-		['name' => 'openProjectAPI#getOpenProjectWorkPackageType', 'url' => '/types/{id}', 'verb' => 'GET'],
-		['name' => 'openProjectAPI#deleteFileLink', 'url' => '/file-links/{id}', 'verb' => 'DELETE'],
-		['name' => 'openProjectAPI#isValidOpenProjectInstance', 'url' => '/is-valid-op-instance', 'verb' => 'POST'],
-		['name' => 'openProjectAPI#getOpenProjectOauthURLWithStateAndPKCE', 'url' => '/op-oauth-url', 'verb' => 'GET'],
-		['name' => 'openProjectAPI#getProjectFolderSetupStatus', 'url' => '/project-folder-status', 'verb' => 'GET'],
-		['name' => 'openProjectAPI#getAvailableOpenProjectProjects', 'url' => '/projects','verb' => 'GET'],
-		['name' => 'openProjectAPI#getOpenProjectWorkPackageForm', 'url' => '/projects/{projectId}/work-packages/form','verb' => 'POST'],
-		['name' => 'openProjectAPI#getAvailableAssigneesOfAProject', 'url' => '/projects/{projectId}/available-assignees','verb' => 'GET'],
-		['name' => 'openProjectAPI#createWorkPackage', 'url' => '/create/work-packages','verb' => 'POST'],
-		['name' => 'openProjectAPI#getOpenProjectConfiguration', 'url' => '/configuration', 'verb' => 'GET'],
+		['name' => 'openProject#isValidOpenProjectInstance', 'url' => '/is-valid-op-instance', 'verb' => 'POST'],
+		['name' => 'openProject#getOpenProjectOauthURLWithStateAndPKCE', 'url' => '/op-oauth-url', 'verb' => 'GET'],
+		['name' => 'openProject#getProjectFolderSetupStatus', 'url' => '/project-folder-status', 'verb' => 'GET'],
 	],
 	'ocs' => [
 		['name' => 'files#getFileInfo', 'url' => '/fileinfo/{fileId}', 'verb' => 'GET'],
 		['name' => 'files#getFilesInfo', 'url' => '/filesinfo', 'verb' => 'POST'],
+
+		['name' => 'openProjectAPI#getNotifications', 'url' => '/api/{apiVersion}/notifications', 'verb' => 'GET', 'requirements' => $requirements],
+		['name' => 'openProjectAPI#markNotificationAsRead', 'url' => '/api/{apiVersion}/work-packages/{workpackageId}/notifications', 'verb' => 'DELETE', 'requirements' => $requirements],
+		['name' => 'openProjectAPI#getOpenProjectUrl', 'url' => '/api/{apiVersion}/url', 'verb' => 'GET', 'requirements' => $requirements],
+		['name' => 'openProjectAPI#getOpenProjectAvatar', 'url' => '/api/{apiVersion}/avatar', 'verb' => 'GET', 'requirements' => $requirements],
+		['name' => 'openProjectAPI#getSearchedWorkPackages', 'url' => '/api/{apiVersion}/work-packages', 'verb' => 'GET', 'requirements' => $requirements],
+		['name' => 'openProjectAPI#linkWorkPackageToFile', 'url' => '/api/{apiVersion}/work-packages', 'verb' => 'POST', 'requirements' => $requirements],
+		['name' => 'openProjectAPI#getWorkPackageFileLinks', 'url' => '/api/{apiVersion}/work-packages/{id}/file-links', 'verb' => 'GET', 'requirements' => $requirements],
+		['name' => 'openProjectAPI#getOpenProjectWorkPackageStatus', 'url' => '/api/{apiVersion}/statuses/{id}', 'verb' => 'GET', 'requirements' => $requirements],
+		['name' => 'openProjectAPI#getOpenProjectWorkPackageType', 'url' => '/api/{apiVersion}/types/{id}', 'verb' => 'GET', 'requirements' => $requirements],
+		['name' => 'openProjectAPI#deleteFileLink', 'url' => '/api/{apiVersion}/file-links/{id}', 'verb' => 'DELETE', 'requirements' => $requirements],
+		['name' => 'openProjectAPI#getAvailableOpenProjectProjects', 'url' => '/api/{apiVersion}/projects','verb' => 'GET', 'requirements' => $requirements],
+		['name' => 'openProjectAPI#getOpenProjectWorkPackageForm', 'url' => '/api/{apiVersion}/projects/{projectId}/work-packages/form','verb' => 'POST', 'requirements' => $requirements],
+		['name' => 'openProjectAPI#getAvailableAssigneesOfAProject', 'url' => '/api/{apiVersion}/projects/{projectId}/available-assignees','verb' => 'GET', 'requirements' => $requirements],
+		['name' => 'openProjectAPI#createWorkPackage', 'url' => '/api/{apiVersion}/create/work-packages','verb' => 'POST', 'requirements' => $requirements],
+		['name' => 'openProjectAPI#getOpenProjectConfiguration', 'url' => '/api/{apiVersion}/configuration', 'verb' => 'GET', 'requirements' => $requirements],
 	]
 ];

--- a/lib/Controller/OpenProjectController.php
+++ b/lib/Controller/OpenProjectController.php
@@ -1,13 +1,9 @@
 <?php
 
 /**
- * Nextcloud - openproject
- *
- * This file is licensed under the Affero General Public License version 3 or
- * later. See the COPYING file.
- *
- * @author Julien Veyssier <eneiluj@posteo.net>
- * @copyright Julien Veyssier 2020
+ * SPDX-FileCopyrightText: 2021-2025 Jankari Tech Pvt. Ltd.
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 namespace OCA\OpenProject\Controller;

--- a/lib/Controller/OpenProjectController.php
+++ b/lib/Controller/OpenProjectController.php
@@ -1,0 +1,251 @@
+<?php
+
+/**
+ * Nextcloud - openproject
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Julien Veyssier <eneiluj@posteo.net>
+ * @copyright Julien Veyssier 2020
+ */
+
+namespace OCA\OpenProject\Controller;
+
+use Exception;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\ServerException;
+use OCA\OpenProject\AppInfo\Application;
+use OCA\OpenProject\Service\OpenProjectAPIService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\Http\Client\LocalServerException;
+
+use OCP\IConfig;
+use OCP\IRequest;
+use OCP\IURLGenerator;
+use Psr\Log\LoggerInterface;
+
+class OpenProjectController extends Controller {
+
+	public function __construct(string $appName,
+		IRequest $request,
+		private IConfig $config,
+		private OpenProjectAPIService $openprojectAPIService,
+		private IURLGenerator $urlGenerator,
+		private LoggerInterface $logger,
+		private ?string $userId,
+	) {
+		parent::__construct($appName, $request);
+	}
+
+	/**
+	 * check if there is a OpenProject behind a certain URL
+	 *
+	 * @param string $url
+	 *
+	 * @return DataResponse
+	 */
+	#[NoAdminRequired]
+	public function isValidOpenProjectInstance(string $url): DataResponse {
+		if ($this->openprojectAPIService::validateURL($url) !== true) {
+			$this->logger->error(
+				"The OpenProject URL '$url' is invalid",
+				['app' => $this->appName]
+			);
+			return new DataResponse(['result' => 'invalid']);
+		}
+		try {
+			$response = $this->openprojectAPIService->rawRequest(
+				'', $url, '', [], 'GET',
+				['allow_redirects' => false]
+			);
+			$statusCode = $response->getStatusCode();
+			if ($statusCode >= 300 && $statusCode <= 399) {
+				$newLocation = $response->getHeader('Location');
+				if ($newLocation !== '') {
+					return new DataResponse(
+						[
+							'result' => 'redirected',
+							'details' => str_replace('api/v3/', '', $newLocation)
+						]
+					);
+				}
+				$this->logger->error(
+					"Could not connect to the URL '$url'",
+					[
+						'app' => $this->appName,
+					]
+				);
+				return new DataResponse(
+					[
+						'result' => 'unexpected_error',
+						'details' => 'received a redirect status code (' . $statusCode . ') but no "Location" header'
+					]
+				);
+			}
+			$body = (string) $response->getBody();
+			$decodedBody = json_decode($body, true);
+			if (
+				$decodedBody &&
+				isset($decodedBody['_type']) &&
+				isset($decodedBody['instanceName']) &&
+				$decodedBody['_type'] === 'Root' &&
+				$decodedBody['instanceName'] !== ''
+			) {
+				return new DataResponse(['result' => true]);
+			}
+		} catch (ClientException $e) {
+			$response = $e->getResponse();
+			$body = (string) $response->getBody();
+			$decodedBody = json_decode($body, true);
+			if (
+				$decodedBody &&
+				isset($decodedBody['_type']) &&
+				isset($decodedBody['errorIdentifier']) &&
+				$decodedBody['_type'] === 'Error' &&
+				$decodedBody['errorIdentifier'] !== ''
+			) {
+				return new DataResponse(['result' => true]);
+			}
+			$this->logger->error(
+				"Could not connect to the OpenProject. " .
+				"There is no valid OpenProject instance at '$url'",
+				['app' => $this->appName, 'exception' => $e]
+			);
+			return new DataResponse(
+				[
+					'result' => 'client_exception',
+					'details' => $response->getStatusCode() . " " . $response->getReasonPhrase()
+				]
+			);
+		} catch (ServerException $e) {
+			$response = $e->getResponse();
+			$this->logger->error(
+				"Could not connect to the OpenProject URL '$url', " .
+				"The server replied with " . $response->getStatusCode() . " " . $response->getReasonPhrase(),
+				['app' => $this->appName, 'exception' => $e]
+			);
+			return new DataResponse(
+				[
+					'result' => 'server_exception',
+					'details' => $response->getStatusCode() . " " . $response->getReasonPhrase()
+				]
+			);
+		} catch (RequestException $e) {
+			$this->logger->error(
+				"Could not connect to the URL '$url'",
+				['app' => $this->appName, 'exception' => $e]
+			);
+			return new DataResponse(
+				[
+					'result' => 'request_exception',
+					'details' => $e->getMessage()
+				]
+			);
+		} catch (LocalServerException $e) {
+			$this->logger->error(
+				'Accessing OpenProject servers with local addresses is not allowed. ' .
+				'To be able to use an OpenProject server with a local address, ' .
+				'enable the `allow_local_remote_servers` setting.',
+				['app' => $this->appName, 'exception' => $e]
+			);
+			return new DataResponse(
+				[
+					'result' => 'local_remote_servers_not_allowed'
+				]
+			);
+		} catch (ConnectException $e) {
+			$this->logger->error(
+				"A network error occurred while trying to connect to the OpenProject URL '$url'",
+				['app' => $this->appName, 'exception' => $e]
+			);
+			return new DataResponse(
+				[
+					'result' => 'network_error',
+					'details' => $e->getMessage()
+				]
+			);
+		} catch (Exception $e) {
+			$this->logger->error(
+				"Could not connect to the URL '$url'",
+				['app' => $this->appName, 'exception' => $e]
+			);
+			return new DataResponse(
+				[
+					'result' => 'unexpected_error',
+					'details' => $e->getMessage()
+				]
+			);
+		}
+		$this->logger->error(
+			"Could not connect to the OpenProject. " .
+			"There is no valid OpenProject instance at '$url'",
+			['app' => $this->appName, 'data' => $body]
+		);
+		return new DataResponse(
+			[
+				'result' => 'not_valid_body',
+				'details' => $body
+			]
+		);
+	}
+
+	/**
+	 * @return DataResponse
+	 */
+	#[NoAdminRequired]
+	public function getOpenProjectOauthURLWithStateAndPKCE(): DataResponse {
+		$url = $this->openprojectAPIService::getOpenProjectOauthURL(
+			$this->config, $this->urlGenerator
+		);
+		$oauthState = bin2hex(random_bytes(5));
+		$this->config->setUserValue(
+			$this->userId,
+			Application::APP_ID,
+			'oauth_state',
+			$oauthState
+		);
+		// this results in a random string of 192 char and after packing and encoding a 128 char verifier
+		$randomString = bin2hex(random_bytes(96));
+		$codeVerifier = $this->base64UrlEncode(pack('H*', $randomString));
+		$this->config->setUserValue(
+			$this->userId,
+			Application::APP_ID,
+			'code_verifier',
+			$codeVerifier
+		);
+		$hash = hash('sha256', $codeVerifier);
+		$codeChallenge = $this->base64UrlEncode(pack('H*', $hash));
+		$url = $url . '&state=' .$oauthState .
+				 '&code_challenge=' . $codeChallenge .
+				'&code_challenge_method=S256';
+
+		return new DataResponse($url);
+	}
+
+	private function base64UrlEncode(string $plainText): string {
+		$base64 = base64_encode($plainText);
+		$base64 = trim($base64, "=");
+		$base64url = strtr($base64, '+/', '-_');
+		return ($base64url);
+	}
+
+	/**
+	 * check if the project folder set up is already setup or not
+	 *
+	 * @return DataResponse
+	 */
+	#[NoCSRFRequired]
+	public function getProjectFolderSetupStatus(): DataResponse {
+		return new DataResponse(
+			[
+				'result' => $this->openprojectAPIService->isProjectFoldersSetupComplete()
+			]
+		);
+	}
+}

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -1444,15 +1444,13 @@ class OpenProjectAPIService {
 			? $entry['_links']['assignee']['title']
 			: '';
 		$userId = preg_replace('/.*\//', "", $userIdURL);
-		return $this->urlGenerator->getAbsoluteURL(
-			'ocs/v1.php/apps/integration_openproject/api/v1/avatar?' .
-			"userId" .
-			'=' .
-			$userId .
-			'&' .
-			"userName" .
-			'=' .
-			$userName
+		return $this->urlGenerator->linkToOCSRouteAbsolute(
+			Application::APP_ID . '.openProjectAPI.getOpenProjectAvatar',
+			[
+				'apiVersion' => 'v1',
+				'userId' => $userId,
+				'userName' => $userName,
+			]
 		);
 	}
 

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -1445,7 +1445,7 @@ class OpenProjectAPIService {
 			: '';
 		$userId = preg_replace('/.*\//', "", $userIdURL);
 		return $this->urlGenerator->getAbsoluteURL(
-			'index.php/apps/integration_openproject/avatar?' .
+			'ocs/v1.php/apps/integration_openproject/api/v1/avatar?' .
 			"userId" .
 			'=' .
 			$userId .

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -94,7 +94,7 @@ class Admin implements ISettings {
 			'user_oidc_enabled' => $this->openProjectAPIService->isUserOIDCAppInstalledAndEnabled()
 		];
 
-		$this->initialStateService->provideInitialState('admin-config', $adminConfig);
+		$this->initialStateService->provideInitialState('admin-settings-config', $adminConfig);
 		$this->initialStateService->provideInitialState(
 			'admin-config-status', OpenProjectAPIService::isAdminConfigOk($this->config)
 		);

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -598,7 +598,7 @@ export default {
 			isOpenProjectInstanceValid: null,
 			openProjectNotReachableErrorMessage: null,
 			openProjectNotReachableErrorMessageDetails: null,
-			state: loadState('integration_openproject', 'admin-config'),
+			state: loadState('integration_openproject', 'admin-settings-config'),
 			isAdminConfigOk: loadState('integration_openproject', 'admin-config-status'),
 			serverHostUrlForEdit: null,
 			isServerHostUrlReadOnly: true,

--- a/src/components/tab/SearchInput.vue
+++ b/src/components/tab/SearchInput.vue
@@ -60,7 +60,7 @@
 import { loadState } from '@nextcloud/initial-state'
 import debounce from 'lodash/debounce.js'
 import axios from '@nextcloud/axios'
-import { generateUrl } from '@nextcloud/router'
+import { generateOcsUrl } from '@nextcloud/router'
 import { NcSelect, NcButton } from '@nextcloud/vue'
 import WorkPackage from './WorkPackage.vue'
 import { showError, showSuccess } from '@nextcloud/dialogs'
@@ -255,7 +255,7 @@ export default {
 		},
 		async makeSearchRequest(search, fileId) {
 			this.state = STATE.LOADING
-			const url = generateUrl('/apps/integration_openproject/work-packages')
+			const url = generateOcsUrl('/apps/integration_openproject/api/v1/work-packages')
 			const isSmartPicker = this.isSmartPicker
 			const req = {}
 			req.params = {
@@ -270,7 +270,7 @@ export default {
 			}
 			this.checkForErrorCode(response.status)
 			if (response.status === 200) {
-				await this.processWorkPackages(response.data, fileId)
+				await this.processWorkPackages(response.data.ocs.data, fileId)
 			}
 			if (this.isStateLoading) {
 				this.state = STATE.OK

--- a/src/utils/workpackageHelper.js
+++ b/src/utils/workpackageHelper.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { generateUrl } from '@nextcloud/router'
+import { generateOcsUrl } from '@nextcloud/router'
 import axios from '@nextcloud/axios'
 import { showError, showSuccess } from '@nextcloud/dialogs'
 
@@ -16,15 +16,15 @@ export const workpackageHelper = {
 		cachedTypeColors = {}
 	},
 	async getColorAttributes(path, id) {
-		const url = generateUrl(path + id)
+		const url = generateOcsUrl(path + id)
 		let response
 		try {
 			response = await axios.get(url)
 		} catch (e) {
 			response = e.response
 		}
-		return (response.status === 200 && response.data?.color)
-			? response.data.color
+		return (response.status === 200 && response.data?.ocs?.data?.color)
+			? response.data.ocs.data.color
 			: ''
 	},
 	replaceHrefToGetId(href) {
@@ -60,12 +60,12 @@ export const workpackageHelper = {
 		const userId = this.replaceHrefToGetId(workPackage._links.assignee.href)
 		const projectId = this.replaceHrefToGetId(workPackage._links.project.href)
 		const userName = workPackage._links.assignee.title
-		const avatarUrl = generateUrl('/apps/integration_openproject/avatar?')
+		const avatarUrl = generateOcsUrl('/apps/integration_openproject/api/v1/avatar?')
 			+ 'userId=' + encodeURIComponent(userId)
 			+ '&userName=' + encodeURIComponent(userName)
 		let statusColor
 		if (cachedStatusColors[statusId] === undefined) {
-			statusColor = await this.getColorAttributes('/apps/integration_openproject/statuses/', statusId)
+			statusColor = await this.getColorAttributes('/apps/integration_openproject/api/v1/statuses/', statusId)
 			cachedStatusColors[statusId] = statusColor
 		} else {
 			statusColor = cachedStatusColors[statusId]
@@ -73,7 +73,7 @@ export const workpackageHelper = {
 
 		let typeColor
 		if (cachedTypeColors[typeId] === undefined) {
-			typeColor = await this.getColorAttributes('/apps/integration_openproject/types/', typeId)
+			typeColor = await this.getColorAttributes('/apps/integration_openproject/api/v1/types/', typeId)
 			cachedTypeColors[typeId] = typeColor
 		} else {
 			typeColor = cachedTypeColors[typeId]
@@ -168,7 +168,7 @@ export const workpackageHelper = {
 				'Content-Type': 'application/json',
 			},
 		}
-		const url = generateUrl('/apps/integration_openproject/work-packages')
+		const url = generateOcsUrl('/apps/integration_openproject/api/v1/work-packages')
 		const body = {
 			values: {
 				workpackageId: selectedWorkpackage.id,

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -26,7 +26,7 @@
 
 <script>
 import axios from '@nextcloud/axios'
-import { generateUrl } from '@nextcloud/router'
+import { generateUrl, generateOcsUrl } from '@nextcloud/router'
 import { NcDashboardWidget } from '@nextcloud/vue'
 import { showError, showSuccess } from '@nextcloud/dialogs'
 import { loadState } from '@nextcloud/initial-state'
@@ -153,8 +153,8 @@ export default {
 			}
 			// get openproject URL first
 			try {
-				const response = await axios.get(generateUrl('/apps/integration_openproject/url'))
-				this.openprojectUrl = response.data.replace(/\/+$/, '')
+				const response = await axios.get(generateOcsUrl('/apps/integration_openproject/api/v1/url'))
+				this.openprojectUrl = response.data.ocs.data.replace(/\/+$/, '')
 			} catch (error) {
 				console.debug(error)
 			}
@@ -163,12 +163,13 @@ export default {
 			this.loop = setInterval(() => this.fetchNotifications(), 60000)
 		},
 		fetchNotifications() {
-			const notificationsUrl = generateUrl('/apps/integration_openproject/notifications')
+			const notificationsUrl = generateOcsUrl('/apps/integration_openproject/api/v1/notifications')
 			axios.get(notificationsUrl).then((response) => {
 				const notifications = {}
-				if (Array.isArray(response.data)) {
-					for (let i = 0; i < response.data.length; i++) {
-						const n = response.data[i]
+				const responseData = response.data.ocs.data
+				if (Array.isArray(responseData)) {
+					for (let i = 0; i < responseData.length; i++) {
+						const n = responseData[i]
 						const wpId = n._links.resource.href.replace(/.*\//, '')
 						if (notifications[wpId] === undefined) {
 							notifications[wpId] = {
@@ -240,7 +241,7 @@ export default {
 				: undefined
 		},
 		getAuthorAvatarUrl(n) {
-			const url = generateUrl('/apps/integration_openproject/avatar?')
+			const url = generateOcsUrl('/apps/integration_openproject/api/v1/avatar?')
 			return n.mostRecentActor?.id
 				? url + 'userId=' + encodeURIComponent(n.mostRecentActor.id) + '&userName=' + encodeURIComponent(n.mostRecentActor.title)
 				: url + 'userName='
@@ -278,8 +279,8 @@ export default {
 			return '(' + n.count + ') ' + n.resourceTitle
 		},
 		onMarkAsRead(item) {
-			const url = generateUrl(
-				'/apps/integration_openproject/work-packages/' + item.id + '/notifications',
+			const url = generateOcsUrl(
+				'/apps/integration_openproject/api/v1/work-packages/' + item.id + '/notifications',
 			)
 			axios.delete(url).then(() => {
 				showSuccess(

--- a/src/views/LinkMultipleFilesModal.vue
+++ b/src/views/LinkMultipleFilesModal.vue
@@ -74,7 +74,7 @@
 import { NcModal, NcLoadingIcon, NcButton, NcProgressBar } from '@nextcloud/vue'
 import SearchInput from '../components/tab/SearchInput.vue'
 import EmptyContent from '../components/tab/EmptyContent.vue'
-import { generateUrl } from '@nextcloud/router'
+import { generateOcsUrl } from '@nextcloud/router'
 import axios from '@nextcloud/axios'
 import { loadState } from '@nextcloud/initial-state'
 import AlertCircleOutline from 'vue-material-design-icons/AlertCircleOutline.vue'
@@ -193,14 +193,15 @@ export default {
 		async fetchWorkpackagesForSingleFileSelected(fileId) {
 			this.state = STATE.LOADING
 			const req = {}
-			const url = generateUrl('/apps/integration_openproject/work-packages?fileId=' + fileId)
+			const url = generateOcsUrl('/apps/integration_openproject/api/v1/work-packages?fileId=' + fileId)
 			try {
 				const response = await axios.get(url, req)
-				if (!Array.isArray(response.data)) {
+				const responseData = response.data.ocs.data
+				if (!Array.isArray(responseData)) {
 					this.state = STATE.FAILED_FETCHING_WORKPACKAGES
 				} else {
-					if (this.fileInfos.length === 1 && response.data.length > 0) {
-						for (let workPackage of response.data) {
+					if (this.fileInfos.length === 1 && responseData.length > 0) {
+						for (let workPackage of responseData) {
 							workPackage.fileId = fileId
 							workPackage = await workpackageHelper.getAdditionalMetaData(workPackage, true)
 							this.alreadyLinkedWorkPackage.push(workPackage)

--- a/src/views/ProjectsTab.vue
+++ b/src/views/ProjectsTab.vue
@@ -55,7 +55,7 @@ import LinkOffIcon from 'vue-material-design-icons/LinkOff.vue'
 
 import axios from '@nextcloud/axios'
 
-import { generateUrl } from '@nextcloud/router'
+import { generateOcsUrl } from '@nextcloud/router'
 import { showSuccess, showError } from '@nextcloud/dialogs'
 import { translate as t } from '@nextcloud/l10n'
 import { loadState } from '@nextcloud/initial-state'
@@ -190,13 +190,13 @@ export default {
 		async unlinkWorkPackage(workpackageId, fileId) {
 			let response
 			try {
-				response = await axios.get(generateUrl(`/apps/integration_openproject/work-packages/${workpackageId}/file-links`))
+				response = await axios.get(generateOcsUrl(`/apps/integration_openproject/api/v1/work-packages/${workpackageId}/file-links`))
 			} catch (e) {
 				response = e.response
 			}
 			if (response.status === 200) {
-				const id = this.processLink(response.data, fileId)
-				const url = generateUrl('/apps/integration_openproject/file-links/' + id)
+				const id = this.processLink(response.data.ocs.data, fileId)
+				const url = generateOcsUrl('/apps/integration_openproject/api/v1/file-links/' + id)
 				response = await axios.delete(url)
 			} else {
 				this.checkForErrorCode(response.status)
@@ -221,15 +221,16 @@ export default {
 		},
 		async fetchWorkpackages(fileId) {
 			const req = {}
-			const url = generateUrl('/apps/integration_openproject/work-packages?fileId=' + fileId)
+			const url = generateOcsUrl('/apps/integration_openproject/api/v1/work-packages?fileId=' + fileId)
 			try {
 				const response = await axios.get(url, req)
-				if (!Array.isArray(response.data)) {
+				const responseData = response.data.ocs.data
+				if (!Array.isArray(responseData)) {
 					this.state = STATE.FAILED_FETCHING_WORKPACKAGES
 				} else {
 					// empty data means there are no workpackages linked
-					if (response.data.length > 0) {
-						for (let workPackage of response.data) {
+					if (responseData.length > 0) {
+						for (let workPackage of responseData) {
 							if (fileId !== this.fileInfo.id) {
 								break
 							}

--- a/src/views/WorkPackagePickerElement.vue
+++ b/src/views/WorkPackagePickerElement.vue
@@ -32,7 +32,7 @@ import SearchInput from '../components/tab/SearchInput.vue'
 import EmptyContent from '../components/tab/EmptyContent.vue'
 import { AUTH_METHOD, STATE } from '../utils.js'
 import { loadState } from '@nextcloud/initial-state'
-import { generateUrl } from '@nextcloud/router'
+import { generateOcsUrl } from '@nextcloud/router'
 import axios from '@nextcloud/axios'
 import { NcLoadingIcon } from '@nextcloud/vue'
 
@@ -92,12 +92,12 @@ export default {
 				this.state = STATE.ERROR
 				return
 			}
-			const configurationUrl = generateUrl('/apps/integration_openproject/configuration')
+			const configurationUrl = generateOcsUrl('/apps/integration_openproject/api/v1/configuration')
 			let response = null
 			try {
 				// send an axios request to fetch configuration to see if the connection is there
 				response = await axios.get(configurationUrl)
-				if (response.data) {
+				if (response.data.ocs.data) {
 					this.state = STATE.OK
 					if (this.$refs.linkPicker?.$refs?.workPackageSelect) {
 						this.$nextTick(() => {

--- a/tests/jest/components/tab/__snapshots__/SearchInput.spec.js.snap
+++ b/tests/jest/components/tab/__snapshots__/SearchInput.spec.js.snap
@@ -52,7 +52,7 @@ exports[`SearchInput.vue work packages select search list should only use the op
     "assignee": "some assignee",
     "fileId": 111,
     "id": 1,
-    "picture": "http://localhost/apps/integration_openproject/avatar?userId=&userName=some%20assignee",
+    "picture": "http://nc.local/apps/integration_openproject/api/v1/avatar?userId=&userName=some%20assignee",
     "project": "some project",
     "projectId": "",
     "statusCol": "",

--- a/tests/jest/views/CreateWorkpackageModal.spec.js
+++ b/tests/jest/views/CreateWorkpackageModal.spec.js
@@ -6,8 +6,9 @@
  */
 
 import { createLocalVue, mount } from '@vue/test-utils'
-import CreateWorkPackageModal from '../../../src/views/CreateWorkPackageModal.vue'
+import util from 'util'
 import axios from '@nextcloud/axios'
+import { generateOcsUrl } from '@nextcloud/router'
 import availableProjectsResponse from '../fixtures/openprojectAvailableProjectResponse.json'
 import availableProjectsResponseAfterSearch from '../fixtures/openprojectAvailableProjectResponseAfterSearch.json'
 import availableProjectsOption from '../fixtures/availableProjectOptions.json'
@@ -16,6 +17,7 @@ import workpackageFormValidationTypeChanged from '../fixtures/workpackageFormVal
 import availableProjectAssignees from '../fixtures/availableProjectAssigneesResponse.json'
 import workpackageCreatedResponse from '../fixtures/workPackageSuccessfulCreationResponse.json'
 import requiredTypeResponse from '../fixtures/formValidationResponseRequiredType.json'
+import CreateWorkPackageModal from '../../../src/views/CreateWorkPackageModal.vue'
 
 const localVue = createLocalVue()
 
@@ -32,6 +34,17 @@ jest.mock('@nextcloud/initial-state', () => {
 		}),
 	}
 })
+jest.mock('@nextcloud/router', () => ({
+	generateUrl: (path) => `http://nc.local${path}`,
+	generateOcsUrl: (path) => `http://nc.local${path}`,
+	imagePath: (path) => `http://nc.local${path}`,
+}))
+
+// url
+const projectsUrl = generateOcsUrl('/apps/integration_openproject/api/v1/projects')
+const workPackageFormUrl = generateOcsUrl('/apps/integration_openproject/api/v1/projects/%s/work-packages/form')
+const availableAssigneesUrl = generateOcsUrl('/apps/integration_openproject/api/v1/projects/%s/available-assignees')
+const createWorkPackageUrl = generateOcsUrl('/apps/integration_openproject/api/v1/create/work-packages')
 
 describe('CreateWorkPackageModal.vue', () => {
 	const createWorkPackageSelector = '.create-workpackage-modal'
@@ -66,13 +79,10 @@ describe('CreateWorkPackageModal.vue', () => {
 	describe('workpackage creation form', () => {
 		it('should display available projects in the project dropdown', async () => {
 			const axiosSpy = jest.spyOn(axios, 'get')
-				.mockImplementationOnce(() => Promise.resolve({
-					status: 200,
-					data: availableProjectsResponse,
-				}))
+				.mockImplementationOnce(() => sendOCSResponse(availableProjectsResponse))
 			wrapper = mountWrapper(true)
 			expect(wrapper.find(createWorkPackageSelector).isVisible()).toBe(true)
-			expect(axiosSpy).toHaveBeenCalledWith('http://localhost/apps/integration_openproject/projects', {})
+			expect(axiosSpy).toHaveBeenCalledWith(projectsUrl, {})
 			await wrapper.find(projectInputField).setValue(' ')
 			expect(wrapper.find(projectSelectSelector)).toMatchSnapshot()
 			axiosSpy.mockRestore()
@@ -83,13 +93,10 @@ describe('CreateWorkPackageModal.vue', () => {
 			let axiosSpy, inputField
 			beforeEach(async () => {
 				axiosSpy = jest.spyOn(axios, 'get')
-					.mockImplementationOnce(() => Promise.resolve({
-						status: 200,
-						data: availableProjectsResponse,
-					}))
+					.mockImplementationOnce(() => sendOCSResponse(availableProjectsResponse))
 				wrapper = mountWrapper(true)
 				expect(wrapper.find(createWorkPackageSelector).isVisible()).toBe(true)
-				expect(axiosSpy).toHaveBeenCalledWith('http://localhost/apps/integration_openproject/projects', {})
+				expect(axiosSpy).toHaveBeenCalledWith(projectsUrl, {})
 				inputField = wrapper.find(projectInputField)
 				await inputField.setValue('Sc')
 			})
@@ -97,7 +104,7 @@ describe('CreateWorkPackageModal.vue', () => {
 				await inputField.setValue('Scw')
 				// for a search debounce request, minimum 500 ms wait is required
 				await new Promise(resolve => setTimeout(resolve, 500))
-				expect(axiosSpy).toHaveBeenCalledWith('http://localhost/apps/integration_openproject/projects',
+				expect(axiosSpy).toHaveBeenCalledWith(projectsUrl,
 					{
 						params: {
 							searchQuery: 'Scw',
@@ -108,15 +115,12 @@ describe('CreateWorkPackageModal.vue', () => {
 
 			it('should show "No matching work projects found!" when the searched project is not found', async () => {
 				const axiosSpyWithSearchQuery = jest.spyOn(axios, 'get')
-					.mockImplementationOnce(() => Promise.resolve({
-						status: 200,
-						data: [],
-					}))
+					.mockImplementationOnce(() => sendOCSResponse({}))
 				await inputField.setValue('Scw')
 				expect(wrapper.vm.isFetchingProjectsFromOpenProjectWithQuery).toBe(true)
 				// for a search debounce request, minimum 500 ms wait is required
 				await new Promise(resolve => setTimeout(resolve, 500))
-				expect(axiosSpyWithSearchQuery).toHaveBeenCalledWith('http://localhost/apps/integration_openproject/projects',
+				expect(axiosSpyWithSearchQuery).toHaveBeenCalledWith(projectsUrl,
 					{
 						params: {
 							searchQuery: 'Scw',
@@ -129,15 +133,12 @@ describe('CreateWorkPackageModal.vue', () => {
 
 			it('should fetch projects when not found in initial available projects', async () => {
 				const axiosSpyWithSearchQuery = jest.spyOn(axios, 'get')
-					.mockImplementationOnce(() => Promise.resolve({
-						status: 200,
-						data: availableProjectsResponseAfterSearch,
-					}))
+					.mockImplementationOnce(() => sendOCSResponse(availableProjectsResponseAfterSearch))
 				const inputField = wrapper.find(projectInputField)
 				await inputField.setValue('se')
 				// for a search debounce request, minimum 500 ms wait is required
 				await new Promise(resolve => setTimeout(resolve, 500))
-				expect(axiosSpyWithSearchQuery).toHaveBeenCalledWith('http://localhost/apps/integration_openproject/projects',
+				expect(axiosSpyWithSearchQuery).toHaveBeenCalledWith(projectsUrl,
 					{
 						params: {
 							searchQuery: 'se',
@@ -182,20 +183,11 @@ describe('CreateWorkPackageModal.vue', () => {
 			}
 
 			jest.spyOn(axios, 'get')
-				.mockImplementationOnce(() => Promise.resolve({
-					status: 200,
-					data: availableProjectsResponse,
-				}))
+				.mockImplementationOnce(() => sendOCSResponse(availableProjectsResponse))
 			const axiosSpy = jest.spyOn(axios, 'post')
-				.mockImplementationOnce(() => Promise.resolve({
-					status: 200,
-					data: workpackageFormValidationProjectSelected,
-				}))
+				.mockImplementationOnce(() => sendOCSResponse(workpackageFormValidationProjectSelected))
 			const assigneeAxiosSpy = jest.spyOn(axios, 'get')
-				.mockImplementationOnce(() => Promise.resolve({
-					status: 200,
-					data: availableProjectAssignees,
-				}))
+				.mockImplementationOnce(() => sendOCSResponse(availableProjectAssignees))
 			wrapper = mountWrapper(true, {
 				noDropAvailableProjectDropDown: false,
 			})
@@ -207,8 +199,8 @@ describe('CreateWorkPackageModal.vue', () => {
 			await wrapper.find(projectOptionsSelector).trigger('click')
 			await wrapper.vm.$nextTick()
 			await wrapper.vm.$nextTick()
-			expect(axiosSpy).toHaveBeenCalledWith('http://localhost/apps/integration_openproject/projects/2/work-packages/form', formValidationBody)
-			expect(assigneeAxiosSpy).toHaveBeenCalledWith('http://localhost/apps/integration_openproject/projects/2/available-assignees')
+			expect(axiosSpy).toHaveBeenCalledWith(util.format(workPackageFormUrl, 2), formValidationBody)
+			expect(assigneeAxiosSpy).toHaveBeenCalledWith(util.format(availableAssigneesUrl, 2))
 			await wrapper.vm.$nextTick()
 			await wrapper.find(typeInputFieldSelector).setValue(' ')
 			await wrapper.vm.$nextTick()
@@ -330,10 +322,7 @@ describe('CreateWorkPackageModal.vue', () => {
 				},
 			]
 			const axiosSpy = jest.spyOn(axios, 'post')
-				.mockImplementationOnce(() => Promise.resolve({
-					status: 200,
-					data: workpackageFormValidationTypeChanged,
-				}))
+				.mockImplementationOnce(() => sendOCSResponse(workpackageFormValidationTypeChanged))
 			wrapper = mountWrapper(true, {
 				allowedStatues: availableStatusBefore,
 				allowedTypes,
@@ -353,7 +342,7 @@ describe('CreateWorkPackageModal.vue', () => {
 			await wrapper.find(typeInputFieldSelector).setValue('Milest')
 			await wrapper.find(typeOptionsSelector).trigger('click')
 			await wrapper.vm.$nextTick()
-			expect(axiosSpy).toHaveBeenCalledWith('http://localhost/apps/integration_openproject/projects/2/work-packages/form', formValidationBody)
+			expect(axiosSpy).toHaveBeenCalledWith(util.format(workPackageFormUrl, 2), formValidationBody)
 			// one thing to note is the statues in snapshot should not match the statuses defined in variable availableStatusBefore
 			await wrapper.find(statusInputFieldSelector).setValue(' ')
 			expect(wrapper.find(statusSelectSelector)).toMatchSnapshot()
@@ -417,15 +406,9 @@ describe('CreateWorkPackageModal.vue', () => {
 				},
 			}
 			jest.spyOn(axios, 'get')
-				.mockImplementationOnce(() => Promise.resolve({
-					status: 200,
-					data: availableProjectsResponse,
-				}))
+				.mockImplementationOnce(() => sendOCSResponse(availableProjectsResponse))
 			const axiosSpy = jest.spyOn(axios, 'post')
-				.mockImplementationOnce(() => Promise.resolve({
-					status: 422,
-					data: expectedErrorDetails.data,
-				}))
+				.mockImplementationOnce(() => sendOCSResponse(expectedErrorDetails.data, 422))
 			wrapper = mountWrapper(true, {
 				status: {
 					label: 'New',
@@ -436,7 +419,7 @@ describe('CreateWorkPackageModal.vue', () => {
 			})
 			await wrapper.find(createWorkpackageButtonSelector).trigger('click')
 			await wrapper.vm.$nextTick()
-			expect(axiosSpy).toHaveBeenCalledWith('http://localhost/apps/integration_openproject/create/work-packages', createWorkpackageBody)
+			expect(axiosSpy).toHaveBeenCalledWith(createWorkPackageUrl, createWorkpackageBody)
 			const error = wrapper.find(validationErrorSelector)
 			expect(error.isVisible()).toBe(true)
 			expect(error.text()).toBe(expectedErrorDetails.errorMessage)
@@ -472,15 +455,9 @@ describe('CreateWorkPackageModal.vue', () => {
 				},
 			}
 			jest.spyOn(axios, 'get')
-				.mockImplementationOnce(() => Promise.resolve({
-					status: 200,
-					data: availableProjectsResponse,
-				}))
+				.mockImplementationOnce(() => sendOCSResponse(availableProjectsResponse))
 			const axiosSpy = jest.spyOn(axios, 'post')
-				.mockImplementationOnce(() => Promise.resolve({
-					status: 422,
-					data: "{\"_type\":\"Error\",\"errorIdentifier\":\"urn:openproject-org:api:v3:errors:MultipleErrors\",\"message\":\"Multiple field constraints have been violated.\",\"_embedded\":{\"errors\":[{\"_type\":\"Error\",\"errorIdentifier\":\"urn:openproject-org:api:v3:errors:PropertyConstraintViolation\",\"message\":\"Subject can't be blank.\",\"_embedded\":{\"details\":{\"attribute\":\"subject\"}}},{\"_type\":\"Error\",\"errorIdentifier\":\"urn:openproject-org:api:v3:errors:PropertyConstraintViolation\",\"message\":\"Project can't be blank.\",\"_embedded\":{\"details\":{\"attribute\":\"project\"}}}]}}",
-				}))
+				.mockImplementationOnce(() => sendOCSResponse("{\"_type\":\"Error\",\"errorIdentifier\":\"urn:openproject-org:api:v3:errors:MultipleErrors\",\"message\":\"Multiple field constraints have been violated.\",\"_embedded\":{\"errors\":[{\"_type\":\"Error\",\"errorIdentifier\":\"urn:openproject-org:api:v3:errors:PropertyConstraintViolation\",\"message\":\"Subject can't be blank.\",\"_embedded\":{\"details\":{\"attribute\":\"subject\"}}},{\"_type\":\"Error\",\"errorIdentifier\":\"urn:openproject-org:api:v3:errors:PropertyConstraintViolation\",\"message\":\"Project can't be blank.\",\"_embedded\":{\"details\":{\"attribute\":\"project\"}}}]}}", 422))
 			wrapper = mountWrapper(true, {
 				status: {
 					label: 'New',
@@ -488,7 +465,7 @@ describe('CreateWorkPackageModal.vue', () => {
 			})
 			await wrapper.find(createWorkpackageButtonSelector).trigger('click')
 			await wrapper.vm.$nextTick()
-			expect(axiosSpy).toHaveBeenCalledWith('http://localhost/apps/integration_openproject/create/work-packages', createWorkpackageBody)
+			expect(axiosSpy).toHaveBeenCalledWith(createWorkPackageUrl, createWorkpackageBody)
 			const projectError = wrapper.find(validationErrorProjectSelector)
 			expect(projectError.isVisible()).toBe(true)
 			expect(projectError.text()).toBe("Project can't be blank.")
@@ -499,20 +476,11 @@ describe('CreateWorkPackageModal.vue', () => {
 
 		it('should not change description template once edited (changed)', async () => {
 			jest.spyOn(axios, 'get')
-				.mockImplementationOnce(() => Promise.resolve({
-					status: 200,
-					data: availableProjectsResponse,
-				}))
+				.mockImplementationOnce(() => sendOCSResponse(availableProjectsResponse))
 			const axiosSpyWorkPackageValidationForm = jest.spyOn(axios, 'post')
-				.mockImplementationOnce(() => Promise.resolve({
-					status: 200,
-					data: workpackageFormValidationProjectSelected,
-				}))
+				.mockImplementationOnce(() => sendOCSResponse(workpackageFormValidationProjectSelected))
 			const assigneeAxiosSpy = jest.spyOn(axios, 'get')
-				.mockImplementationOnce(() => Promise.resolve({
-					status: 200,
-					data: availableProjectAssignees,
-				}))
+				.mockImplementationOnce(() => sendOCSResponse(availableProjectAssignees))
 
 			wrapper = mountWrapper(true, {
 				project: {
@@ -563,20 +531,11 @@ describe('CreateWorkPackageModal.vue', () => {
 
 		it('should change description when template is not edited or (changed)', async () => {
 			jest.spyOn(axios, 'get')
-				.mockImplementationOnce(() => Promise.resolve({
-					status: 200,
-					data: availableProjectsResponse,
-				}))
+				.mockImplementationOnce(() => sendOCSResponse(availableProjectsResponse))
 			const axiosSpyWorkPackageValidationForm = jest.spyOn(axios, 'post')
-				.mockImplementationOnce(() => Promise.resolve({
-					status: 200,
-					data: workpackageFormValidationProjectSelected,
-				}))
+				.mockImplementationOnce(() => sendOCSResponse(workpackageFormValidationProjectSelected))
 			const assigneeAxiosSpy = jest.spyOn(axios, 'get')
-				.mockImplementationOnce(() => Promise.resolve({
-					status: 200,
-					data: availableProjectAssignees,
-				}))
+				.mockImplementationOnce(() => sendOCSResponse(availableProjectAssignees))
 
 			wrapper = mountWrapper(true, {
 				project: {
@@ -619,20 +578,11 @@ describe('CreateWorkPackageModal.vue', () => {
 
 		it('should empty the type if that type is not available for the selected project', async () => {
 			jest.spyOn(axios, 'get')
-				.mockImplementationOnce(() => Promise.resolve({
-					status: 200,
-					data: availableProjectsResponse,
-				}))
+				.mockImplementationOnce(() => sendOCSResponse(availableProjectsResponse))
 			const axiosSpyWorkPackageValidationForm = jest.spyOn(axios, 'post')
-				.mockImplementationOnce(() => Promise.resolve({
-					status: 200,
-					data: workpackageFormValidationProjectSelected,
-				}))
+				.mockImplementationOnce(() => sendOCSResponse(workpackageFormValidationProjectSelected))
 			const assigneeAxiosSpy = jest.spyOn(axios, 'get')
-				.mockImplementationOnce(() => Promise.resolve({
-					status: 200,
-					data: availableProjectAssignees,
-				}))
+				.mockImplementationOnce(() => sendOCSResponse(availableProjectAssignees))
 
 			wrapper = mountWrapper(true, {
 				project: {
@@ -661,20 +611,11 @@ describe('CreateWorkPackageModal.vue', () => {
 
 		it('should empty the status if this status is not available for the selected type', async () => {
 			jest.spyOn(axios, 'get')
-				.mockImplementationOnce(() => Promise.resolve({
-					status: 200,
-					data: availableProjectsResponse,
-				}))
+				.mockImplementationOnce(() => sendOCSResponse(availableProjectsResponse))
 			const axiosSpyWorkPackageValidationForm = jest.spyOn(axios, 'post')
-				.mockImplementationOnce(() => Promise.resolve({
-					status: 200,
-					data: workpackageFormValidationProjectSelected,
-				}))
+				.mockImplementationOnce(() => sendOCSResponse(workpackageFormValidationProjectSelected))
 			const assigneeAxiosSpy = jest.spyOn(axios, 'get')
-				.mockImplementationOnce(() => Promise.resolve({
-					status: 200,
-					data: availableProjectAssignees,
-				}))
+				.mockImplementationOnce(() => sendOCSResponse(availableProjectAssignees))
 
 			wrapper = mountWrapper(true, {
 				project: {
@@ -739,15 +680,9 @@ describe('CreateWorkPackageModal.vue', () => {
 			},
 		}
 		jest.spyOn(axios, 'get')
-			.mockImplementationOnce(() => Promise.resolve({
-				status: 200,
-				data: availableProjectsResponse,
-			}))
+			.mockImplementationOnce(() => sendOCSResponse(availableProjectsResponse))
 		const axiosSpy = jest.spyOn(axios, 'post')
-			.mockImplementationOnce(() => Promise.resolve({
-				status: 201,
-				data: workpackageCreatedResponse,
-			}))
+			.mockImplementationOnce(() => sendOCSResponse(workpackageCreatedResponse, 201))
 		wrapper = mountWrapper(true, {
 			project: {
 				self: {
@@ -780,7 +715,7 @@ describe('CreateWorkPackageModal.vue', () => {
 		const emitSpy = jest.spyOn(wrapper.vm, '$emit')
 		await wrapper.find(createWorkpackageButtonSelector).trigger('click')
 		await wrapper.vm.$nextTick()
-		expect(axiosSpy).toHaveBeenCalledWith('http://localhost/apps/integration_openproject/create/work-packages', createWorkPackageBody)
+		expect(axiosSpy).toHaveBeenCalledWith(createWorkPackageUrl, createWorkPackageBody)
 		expect(emitSpy).toHaveBeenCalledWith('create-work-package', {
 			openProjectEventName: 'work_package_creation_success',
 			openProjectEventPayload: workpackageCreatedResponse,
@@ -821,15 +756,9 @@ describe('CreateWorkPackageModal.vue', () => {
 			},
 		]
 		jest.spyOn(axios, 'get')
-			.mockImplementationOnce(() => Promise.resolve({
-				status: 200,
-				data: availableProjectsResponse,
-			}))
+			.mockImplementationOnce(() => sendOCSResponse(availableProjectsResponse))
 		const axiosSpy = jest.spyOn(axios, 'post')
-			.mockImplementationOnce(() => Promise.resolve({
-				status: 200,
-				data: requiredTypeResponse,
-			}))
+			.mockImplementationOnce(() => sendOCSResponse(requiredTypeResponse))
 
 		wrapper = mountWrapper(true, {
 			project: {
@@ -855,7 +784,7 @@ describe('CreateWorkPackageModal.vue', () => {
 		await wrapper.find(typeInputFieldSelector).setValue('Required')
 		await wrapper.find(typeOptionsSelector).trigger('click')
 		await wrapper.vm.$nextTick()
-		expect(axiosSpy).toHaveBeenCalledWith('http://localhost/apps/integration_openproject/projects/2/work-packages/form', bodyFormValidation)
+		expect(axiosSpy).toHaveBeenCalledWith(util.format(workPackageFormUrl, 2), bodyFormValidation)
 		const typeError = wrapper.find(validationErrorTypeSelector)
 		expect(typeError.isVisible()).toBe(true)
 		expect(typeError.text()).toBe('This type has mandatory fields which cannot be filled here. Please, create work packages of this type directly in {htmlLink}.')
@@ -877,10 +806,7 @@ describe('CreateWorkPackageModal.vue', () => {
 
 	it('should display an error when the project status is empty', async () => {
 		jest.spyOn(axios, 'get')
-			.mockImplementationOnce(() => Promise.resolve({
-				status: 200,
-				data: availableProjectsResponse,
-			}))
+			.mockImplementationOnce(() => sendOCSResponse(availableProjectsResponse))
 
 		wrapper = mountWrapper(true, {
 			project: {
@@ -917,14 +843,19 @@ describe('CreateWorkPackageModal.vue', () => {
 		expect(error.text()).toBe('Status is not set to one of the allowed values.')
 	})
 })
+
+function sendOCSResponse(data, status = 200) {
+	return Promise.resolve({
+		status,
+		data: { ocs: { data } },
+	})
+}
+
 function mountWrapper(showModal, data) {
 	return mount(CreateWorkPackageModal, {
 		localVue,
 		mocks: {
 			t: (app, msg) => msg,
-			generateUrl() {
-				return '/'
-			},
 		},
 		data: () => ({
 			...data,

--- a/tests/jest/views/Dashboard.spec.js
+++ b/tests/jest/views/Dashboard.spec.js
@@ -11,6 +11,7 @@ import { shallowMount, createLocalVue } from '@vue/test-utils'
 import flushPromises from 'flush-promises'
 import util from 'util'
 import { showError, showSuccess } from '@nextcloud/dialogs'
+import { generateOcsUrl } from '@nextcloud/router'
 import axios from '@nextcloud/axios'
 import Dashboard from '../../../src/views/Dashboard.vue'
 import { STATE, AUTH_METHOD, checkOauthConnectionResult } from '../../../src/utils.js'
@@ -35,6 +36,11 @@ jest.mock('@nextcloud/initial-state', () => {
 		loadState: jest.fn(() => ''),
 	}
 })
+jest.mock('@nextcloud/router', () => ({
+	generateUrl: (path) => `http://nc.local${path}`,
+	generateOcsUrl: (path) => `http://nc.local${path}`,
+	imagePath: (path) => `http://nc.local${path}`,
+}))
 jest.mock('../../../src/utils.js', () => ({
 	...jest.requireActual('../../../src/utils.js'),
 	checkOauthConnectionResult: jest.fn(),
@@ -45,9 +51,9 @@ global.OC = {}
 const localVue = createLocalVue()
 
 // url
-const opUrl = 'http://localhost/apps/integration_openproject/url'
-const notificationUrl = 'http://localhost/apps/integration_openproject/notifications'
-const wpNotificationsUrl = 'http://localhost/apps/integration_openproject/work-packages/%s/notifications'
+const opUrl = generateOcsUrl('/apps/integration_openproject/api/v1/url')
+const notificationUrl = generateOcsUrl('/apps/integration_openproject/api/v1/notifications')
+const wpNotificationsUrl = generateOcsUrl('/apps/integration_openproject/api/v1/work-packages/%s/notifications')
 
 describe('Dashboard.vue', () => {
 	const errorLabelSelector = 'errorlabel-stub'
@@ -362,12 +368,12 @@ describe('Dashboard.vue', () => {
 
 function getAxiosGetMockFn(notificationResponse) {
 	if (!notificationResponse) {
-		notificationResponse = Promise.resolve({ data: notificationsResponse })
+		notificationResponse = Promise.resolve({ data: { ocs: { data: notificationsResponse } } })
 	}
 	return (url) => {
 		switch (url) {
 		case opUrl:
-			return Promise.resolve({ data: 'http://openproject.org' })
+			return Promise.resolve({ data: { ocs: { data: 'http://openproject.org' } } })
 		case notificationUrl:
 			return notificationResponse
 		default:
@@ -383,9 +389,6 @@ function getWrapper(data = {}) {
 			localVue,
 			mocks: {
 				t: (app, msg) => msg,
-				generateUrl() {
-					return '/'
-				},
 			},
 			propsData: {
 				title: 'dashboard',

--- a/tests/jest/views/ProjectsTab.spec.js
+++ b/tests/jest/views/ProjectsTab.spec.js
@@ -562,9 +562,7 @@ describe('ProjectsTab.vue', () => {
 						},
 					},
 				}]))
-			const axiosDeleteSpy = jest.spyOn(axios, 'delete').mockImplementationOnce(() => Promise.resolve(
-				{ status: 200 }),
-			)
+			const axiosDeleteSpy = jest.spyOn(axios, 'delete').mockImplementationOnce(() => sendOCSResponse({}))
 			wrapper = mountWrapper()
 			await wrapper.vm.unlinkWorkPackage(15, 6)
 			expect(axiosGetSpy).toBeCalledWith(util.format(wpFileLinksUrl, 15))

--- a/tests/jest/views/ProjectsTab.spec.js
+++ b/tests/jest/views/ProjectsTab.spec.js
@@ -77,7 +77,7 @@ const scrollSpy = jest.spyOn(window.HTMLElement.prototype, 'scrollIntoView')
 const localVue = createLocalVue()
 
 // url
-const workPackageFileIdUrl = generateOcsUrl('/apps/integration_openproject/api/v1/work-packages?fileId=%s')
+const wpFileIdUrl = generateOcsUrl('/apps/integration_openproject/api/v1/work-packages?fileId=%s')
 const statusUrl = generateOcsUrl('/apps/integration_openproject/api/v1/statuses/%s')
 const typesUrl = generateOcsUrl('/apps/integration_openproject/api/v1/types/%s')
 const wpFileLinksUrl = generateOcsUrl('/apps/integration_openproject/api/v1/work-packages/%s/file-links')
@@ -356,7 +356,7 @@ describe('ProjectsTab.vue', () => {
 				.mockImplementationOnce(() => sendOCSResponse(testCase.typeColor))
 			await wrapper.vm.update({ id: 789 })
 			expect(axiosGetSpy).toBeCalledWith(
-				util.format(workPackageFileIdUrl, 789),
+				util.format(wpFileIdUrl, 789),
 				{},
 			)
 			expect(axiosGetSpy).toBeCalledWith(
@@ -417,7 +417,7 @@ describe('ProjectsTab.vue', () => {
 				.mockImplementation(() => sendOCSResponse([]))
 			await wrapper.vm.update({ id: 2222 })
 			expect(axiosGetSpy).toBeCalledWith(
-				util.format(workPackageFileIdUrl, 2222),
+				util.format(wpFileIdUrl, 2222),
 				{},
 			)
 			expect(wrapper.vm.state).toBe(STATE.OK)

--- a/tests/jest/views/__snapshots__/Dashboard.spec.js.snap
+++ b/tests/jest/views/__snapshots__/Dashboard.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`Dashboard.vue auth method: OAUTH2 admin config is ok connected to OP should show the notification items 1`] = `
 [
   {
-    "avatarUrl": "http://localhost/apps/integration_openproject/avatar?userId=8&userName=Admin%20de%20DEV%20user",
+    "avatarUrl": "http://nc.local/apps/integration_openproject/api/v1/avatar?userId=8&userName=Admin%20de%20DEV%20user",
     "avatarUsername": "Admin de DEV userz",
     "id": "17",
     "mainText": "(6) Create wireframes for new landing page",
@@ -12,7 +12,7 @@ exports[`Dashboard.vue auth method: OAUTH2 admin config is ok connected to OP sh
     "targetUrl": "http://openproject.org/notifications/details/17/activity/",
   },
   {
-    "avatarUrl": "http://localhost/apps/integration_openproject/avatar?userId=9&userName=Artur%20Neumann",
+    "avatarUrl": "http://nc.local/apps/integration_openproject/api/v1/avatar?userId=9&userName=Artur%20Neumann",
     "avatarUsername": "Artur Neumannz",
     "id": "18",
     "mainText": "(1) Contact form",
@@ -21,7 +21,7 @@ exports[`Dashboard.vue auth method: OAUTH2 admin config is ok connected to OP sh
     "targetUrl": "http://openproject.org/notifications/details/18/activity/",
   },
   {
-    "avatarUrl": "http://localhost/apps/integration_openproject/avatar?userName=",
+    "avatarUrl": "http://nc.local/apps/integration_openproject/api/v1/avatar?userName=",
     "avatarUsername": "undefinedz",
     "id": "24",
     "mainText": "(1) Choose a content management system",
@@ -30,7 +30,7 @@ exports[`Dashboard.vue auth method: OAUTH2 admin config is ok connected to OP sh
     "targetUrl": "http://openproject.org/notifications/details/24/activity/",
   },
   {
-    "avatarUrl": "http://localhost/apps/integration_openproject/avatar?userId=8&userName=Admin%20de%20DEV%20user",
+    "avatarUrl": "http://nc.local/apps/integration_openproject/api/v1/avatar?userId=8&userName=Admin%20de%20DEV%20user",
     "avatarUsername": "Admin de DEV userz",
     "id": "36",
     "mainText": "(2) write a software",
@@ -44,7 +44,7 @@ exports[`Dashboard.vue auth method: OAUTH2 admin config is ok connected to OP sh
 exports[`Dashboard.vue auth method: OIDC OIDC user admin config is ok connected to OP should show the notification items 1`] = `
 [
   {
-    "avatarUrl": "http://localhost/apps/integration_openproject/avatar?userId=8&userName=Admin%20de%20DEV%20user",
+    "avatarUrl": "http://nc.local/apps/integration_openproject/api/v1/avatar?userId=8&userName=Admin%20de%20DEV%20user",
     "avatarUsername": "Admin de DEV userz",
     "id": "17",
     "mainText": "(6) Create wireframes for new landing page",
@@ -53,7 +53,7 @@ exports[`Dashboard.vue auth method: OIDC OIDC user admin config is ok connected 
     "targetUrl": "http://openproject.org/notifications/details/17/activity/",
   },
   {
-    "avatarUrl": "http://localhost/apps/integration_openproject/avatar?userId=9&userName=Artur%20Neumann",
+    "avatarUrl": "http://nc.local/apps/integration_openproject/api/v1/avatar?userId=9&userName=Artur%20Neumann",
     "avatarUsername": "Artur Neumannz",
     "id": "18",
     "mainText": "(1) Contact form",
@@ -62,7 +62,7 @@ exports[`Dashboard.vue auth method: OIDC OIDC user admin config is ok connected 
     "targetUrl": "http://openproject.org/notifications/details/18/activity/",
   },
   {
-    "avatarUrl": "http://localhost/apps/integration_openproject/avatar?userName=",
+    "avatarUrl": "http://nc.local/apps/integration_openproject/api/v1/avatar?userName=",
     "avatarUsername": "undefinedz",
     "id": "24",
     "mainText": "(1) Choose a content management system",
@@ -71,7 +71,7 @@ exports[`Dashboard.vue auth method: OIDC OIDC user admin config is ok connected 
     "targetUrl": "http://openproject.org/notifications/details/24/activity/",
   },
   {
-    "avatarUrl": "http://localhost/apps/integration_openproject/avatar?userId=8&userName=Admin%20de%20DEV%20user",
+    "avatarUrl": "http://nc.local/apps/integration_openproject/api/v1/avatar?userId=8&userName=Admin%20de%20DEV%20user",
     "avatarUsername": "Admin de DEV userz",
     "id": "36",
     "mainText": "(2) write a software",

--- a/tests/lib/Controller/OpenProjectAPIControllerTest.php
+++ b/tests/lib/Controller/OpenProjectAPIControllerTest.php
@@ -86,7 +86,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 	public function getOpenProjectAPIControllerMock(array $constructParams = []): OpenProjectAPIController {
 		$constructArgs = [
 			'request' => $this->createMock(IRequest::class),
-			'config' => $this->getConfigMock(),
+			'config' => $this->createMock(IConfig::class),
 			'openProjectAPIService' => $this->createMock(OpenProjectAPIService::class),
 			'userId' => 'test',
 		];

--- a/tests/lib/Controller/OpenProjectAPIControllerTest.php
+++ b/tests/lib/Controller/OpenProjectAPIControllerTest.php
@@ -9,43 +9,20 @@ namespace OCA\OpenProject\Controller;
 
 use Exception;
 use GuzzleHttp\Exception\BadResponseException;
-use GuzzleHttp\Exception\ClientException;
-use GuzzleHttp\Exception\ConnectException;
-use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Exception\ServerException;
 use InvalidArgumentException;
 use OCA\OpenProject\Exception\OpenprojectErrorException;
 use OCA\OpenProject\Exception\OpenprojectResponseException;
 use OCA\OpenProject\Service\OpenProjectAPIService;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\OCSController;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
 use OCP\Http\Client\IResponse;
-use OCP\Http\Client\LocalServerException;
 use OCP\IConfig;
 use OCP\IRequest;
-use OCP\IURLGenerator;
 use PHPUnit\Framework\TestCase;
-use Psr\Log\LoggerInterface;
 
 class OpenProjectAPIControllerTest extends TestCase {
-	/** @var IConfig */
-	private $configMock;
-
-	/** @var IRequest */
-	private $requestMock;
-
-	/**
-	 * @var IURLGenerator
-	 */
-	private $urlGeneratorMock;
-
-	/**
-	 * @var LoggerInterface
-	 */
-	private $loggerMock;
-
-
 	/**
 	 * @var array <mixed>
 	 */
@@ -70,46 +47,57 @@ class OpenProjectAPIControllerTest extends TestCase {
 	}
 
 	/**
-	 * @return void
-	 * @before
-	 */
-	public function setUpMocks(): void {
-		$this->requestMock = $this->createMock(IRequest::class);
-		$this->urlGeneratorMock = $this->createMock(IURLGenerator::class);
-		$this->loggerMock = $this->createMock(LoggerInterface::class);
-		$this->configMock = $this->getMockBuilder(IConfig::class)->getMock();
-		$this->configMock
-			->method('getAppValue')
-			->withConsecutive(
-				['integration_openproject', 'openproject_instance_url'],
-			)->willReturnOnConsecutiveCalls('https://openproject.org');
-	}
-
-	/**
 	 * @param string $authorizationMethod
 	 * @param string $authToken
 	 * @psalm-suppress UndefinedInterfaceMethod
-	 * @return void
+	 * @return IConfig
 	 */
-	public function getUserValueMock(string $authorizationMethod, $authToken = null): void {
-		$this->configMock = $this->getMockBuilder(IConfig::class)->getMock();
+	public function getConfigMock(string $authorizationMethod = '', $authToken = null, $opUrl = null): IConfig {
 		if ($authorizationMethod === OpenProjectAPIService::AUTH_METHOD_OAUTH) {
-			$token = $authToken === null ?  '123' : $authToken;
-			$this->configMock
-				->method('getUserValue')
-				->withConsecutive(
-					['test','integration_openproject', 'token'],
-					['test','integration_openproject', 'refresh_token'],
-				)->willReturnOnConsecutiveCalls($token, 'refreshToken');
+			$token = $authToken ?? '123';
+		} else {
+			$token = '';
 		}
-		$this->configMock
+
+		$configMock = $this->getMockBuilder(IConfig::class)->getMock();
+		$configMock
+			->method('getUserValue')
+			->withConsecutive(
+				['test','integration_openproject', 'token'],
+				['test','integration_openproject', 'refresh_token'],
+			)->willReturnOnConsecutiveCalls($token, 'refreshToken');
+
+		$opUrl = $opUrl ?? 'https://openproject.org';
+		$configMock
 			->method('getAppValue')
 			->withConsecutive(
 				['integration_openproject', 'openproject_instance_url'],
 				['integration_openproject', 'authorization_method'],
-			)->willReturnOnConsecutiveCalls(
-				'https://openproject.org',
-				$authorizationMethod);
+			)->willReturnOnConsecutiveCalls($opUrl, $authorizationMethod);
+		return $configMock;
+	}
+
+	/**
+	 * @param array<string, object> $constructParams
+	 *
+	 * @return OpenProjectAPIController
+	 */
+	public function getOpenProjectAPIControllerMock(array $constructParams = []): OpenProjectAPIController {
+		$constructArgs = [
+			'request' => $this->createMock(IRequest::class),
+			'config' => $this->getConfigMock(),
+			'openProjectAPIService' => $this->createMock(OpenProjectAPIService::class),
+			'userId' => 'test',
+		];
+		foreach ($constructParams as $key => $value) {
+			if (!array_key_exists($key, $constructArgs)) {
+				throw new \InvalidArgumentException("Invalid construct parameter: $key");
+			}
+
+			$constructArgs[$key] = $value;
+		}
+
+		return new OpenProjectAPIController('integration_openproject', ...array_values($constructArgs));
 	}
 
 	/**
@@ -119,7 +107,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 	 * @dataProvider getAuthorizationMethodDataProvider
 	 */
 	public function testGetNotifications(string $authorizationMethod): void {
-		$this->getUserValueMock($authorizationMethod);
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['getNotifications', 'getOIDCToken'])
@@ -132,15 +119,10 @@ class OpenProjectAPIControllerTest extends TestCase {
 			->method('getNotifications')
 			->willReturn(['some' => 'data']);
 
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test',
-		);
+		$controller = $this->getOpenProjectAPIControllerMock([
+			'openProjectAPIService' => $service,
+			'config' => $this->getConfigMock($authorizationMethod),
+		]);
 		$response = $controller->getNotifications();
 		$this->assertSame(Http::STATUS_OK, $response->getStatus());
 		$this->assertSame(['some' => 'data'], $response->getData());
@@ -155,7 +137,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 	 */
 	public function testGetNotificationsNoAccessToken(string $authorizationMethod) {
 		$authToken = '';
-		$this->getUserValueMock($authorizationMethod, $authToken);
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['getNotifications', 'getOIDCToken'])
@@ -163,16 +144,10 @@ class OpenProjectAPIControllerTest extends TestCase {
 		if ($authorizationMethod === OpenProjectAPIService::AUTH_METHOD_OIDC) {
 			$service->method('getOIDCToken')->willReturn($authToken);
 		}
-		$service = $this->createMock(OpenProjectAPIService::class);
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
+		$controller = $this->getOpenProjectAPIControllerMock([
+			'openProjectAPIService' => $service,
+			'config' => $this->getConfigMock($authorizationMethod, $authToken),
+		]);
 		$response = $controller->getNotifications();
 		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
 	}
@@ -185,13 +160,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 	 * @dataProvider getAuthorizationMethodDataProvider
 	 */
 	public function testGetNotificationsBadOPInstanceUrl(string $authorizationMethod) {
-		$this->getUserValueMock($authorizationMethod);
-		$this->configMock = $this->getMockBuilder(IConfig::class)->getMock();
-		$this->configMock
-			->method('getAppValue')
-			->withConsecutive(
-				['integration_openproject', 'openproject_instance_url'],
-			)->willReturnOnConsecutiveCalls('http:openproject.org');
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['getNotifications', 'getOIDCToken'])
@@ -199,15 +167,10 @@ class OpenProjectAPIControllerTest extends TestCase {
 		if ($authorizationMethod === OpenProjectAPIService::AUTH_METHOD_OIDC) {
 			$service->method('getOIDCToken')->willReturn('123');
 		}
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
+		$controller = $this->getOpenProjectAPIControllerMock([
+			'openProjectAPIService' => $service,
+			'config' => $this->getConfigMock($authorizationMethod, null, 'http:openproject.org'),
+		]);
 		$response = $controller->getNotifications();
 		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
 	}
@@ -220,7 +183,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 	 * @dataProvider getAuthorizationMethodDataProvider
 	 */
 	public function testGetNotificationsErrorResponse(string $authorizationMethod) {
-		$this->getUserValueMock($authorizationMethod);
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['getNotifications', 'getOIDCToken'])
@@ -232,15 +194,10 @@ class OpenProjectAPIControllerTest extends TestCase {
 			->method('getNotifications')
 			->willReturn(['error' => 'something went wrong']);
 
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
+		$controller = $this->getOpenProjectAPIControllerMock([
+			'openProjectAPIService' => $service,
+			'config' => $this->getConfigMock($authorizationMethod),
+		]);
 		$response = $controller->getNotifications();
 		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
 		$this->assertSame(['error' => 'something went wrong'], $response->getData());
@@ -254,7 +211,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 	 * @dataProvider getAuthorizationMethodDataProvider
 	 */
 	public function testGetOpenProjectAvatar(string $authorizationMethod) {
-		$this->getUserValueMock($authorizationMethod);
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['getOpenProjectAvatar', 'getOIDCToken'])
@@ -268,15 +224,10 @@ class OpenProjectAPIControllerTest extends TestCase {
 				'id', 'name'
 			)
 			->willReturn(['avatar' => 'some image data', 'type' => 'image/png']);
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
+		$controller = $this->getOpenProjectAPIControllerMock([
+			'openProjectAPIService' => $service,
+			'config' => $this->getConfigMock($authorizationMethod),
+		]);
 		$response = $controller->getOpenProjectAvatar('id', 'name');
 		$this->assertSame('some image data', $response->render());
 		$this->assertSame(
@@ -297,7 +248,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 	 * @dataProvider getAuthorizationMethodDataProvider
 	 */
 	public function testGetOpenProjectAvatarNoType(string $authorizationMethod) {
-		$this->getUserValueMock($authorizationMethod);
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['getOpenProjectAvatar', 'getOIDCToken'])
@@ -311,15 +261,10 @@ class OpenProjectAPIControllerTest extends TestCase {
 				'id', 'name'
 			)
 			->willReturn(['avatar' => 'some image data']);
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
+		$controller = $this->getOpenProjectAPIControllerMock([
+			'openProjectAPIService' => $service,
+			'config' => $this->getConfigMock($authorizationMethod),
+		]);
 		$response = $controller->getOpenProjectAvatar('id', 'name');
 		$this->assertSame('some image data', $response->render());
 		$this->assertSame(
@@ -352,7 +297,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 	 * @dataProvider searchWorkPackagesDataProvider
 	 */
 	public function testGetSearchedWorkPackages(string $authorizationMethod, ?string $searchQuery, ?int $fileId, array $expectedResponse):void {
-		$this->getUserValueMock($authorizationMethod);
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['searchWorkPackage', 'getOIDCToken'])
@@ -369,15 +313,10 @@ class OpenProjectAPIControllerTest extends TestCase {
 			)
 			->willReturn($expectedResponse);
 
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
+		$controller = $this->getOpenProjectAPIControllerMock([
+			'openProjectAPIService' => $service,
+			'config' => $this->getConfigMock($authorizationMethod),
+		]);
 		$response = $controller->getSearchedWorkPackages($searchQuery, $fileId);
 		$this->assertSame(Http::STATUS_OK, $response->getStatus());
 		$this->assertSame($expectedResponse, $response->getData());
@@ -391,7 +330,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 	 * @dataProvider getAuthorizationMethodDataProvider
 	 */
 	public function testGetSearchedWorkPackagesNoAccessToken(string $authorizationMethod): void {
-		$this->getUserValueMock($authorizationMethod, '');
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['getOIDCToken'])
@@ -399,15 +337,10 @@ class OpenProjectAPIControllerTest extends TestCase {
 		if ($authorizationMethod === OpenProjectAPIService::AUTH_METHOD_OIDC) {
 			$service->method('getOIDCToken')->willReturn('');
 		}
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
+		$controller = $this->getOpenProjectAPIControllerMock([
+			'openProjectAPIService' => $service,
+			'config' => $this->getConfigMock($authorizationMethod, ''),
+		]);
 		$response = $controller->getSearchedWorkPackages('test');
 		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
 	}
@@ -420,13 +353,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 	 * @dataProvider getAuthorizationMethodDataProvider
 	 */
 	public function testGetSearchedWorkPackagesBadOPInstanceUrl(string $authorizationMethod): void {
-		$this->getUserValueMock($authorizationMethod);
-		$this->configMock = $this->getMockBuilder(IConfig::class)->getMock();
-		$this->configMock
-			->method('getAppValue')
-			->withConsecutive(
-				['integration_openproject', 'openproject_instance_url'],
-			)->willReturnOnConsecutiveCalls('http:openproject');
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['getOIDCToken'])
@@ -434,15 +360,10 @@ class OpenProjectAPIControllerTest extends TestCase {
 		if ($authorizationMethod === OpenProjectAPIService::AUTH_METHOD_OIDC) {
 			$service->method('getOIDCToken')->willReturn('123');
 		}
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
+		$controller = $this->getOpenProjectAPIControllerMock([
+			'openProjectAPIService' => $service,
+			'config' => $this->getConfigMock($authorizationMethod, null, 'http:openproject'),
+		]);
 		$response = $controller->getSearchedWorkPackages('test');
 		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
 	}
@@ -455,7 +376,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 	 * @dataProvider getAuthorizationMethodDataProvider
 	 */
 	public function testGetSearchedWorkPackagesErrorResponse(string $authorizationMethod): void {
-		$this->getUserValueMock($authorizationMethod);
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['searchWorkPackage','getOIDCToken'])
@@ -464,15 +384,10 @@ class OpenProjectAPIControllerTest extends TestCase {
 			$service->method('getOIDCToken')->willReturn('123');
 		}
 		$service->method('searchWorkPackage')->willReturn(['error' => 'something went wrong']);
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
+		$controller = $this->getOpenProjectAPIControllerMock([
+			'openProjectAPIService' => $service,
+			'config' => $this->getConfigMock($authorizationMethod),
+		]);
 		$response = $controller->getSearchedWorkPackages('test');
 		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
 		$this->assertSame(['error' => 'something went wrong'], $response->getData());
@@ -486,7 +401,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 	 * @dataProvider getAuthorizationMethodDataProvider
 	 */
 	public function testGetOpenProjectWorkPackageStatus(string $authorizationMethod): void {
-		$this->getUserValueMock($authorizationMethod);
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['getOpenProjectWorkPackageStatus','getOIDCToken'])
@@ -501,15 +415,10 @@ class OpenProjectAPIControllerTest extends TestCase {
 				"isClosed" => false, "color" => "#CC5DE8", "isDefault" => false, "isReadonly" => false, "defaultDoneRatio" => null, "position" => 7
 			]);
 
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
+		$controller = $this->getOpenProjectAPIControllerMock([
+			'openProjectAPIService' => $service,
+			'config' => $this->getConfigMock($authorizationMethod),
+		]);
 		$response = $controller->getOpenProjectWorkPackageStatus('7');
 		$this->assertSame(Http::STATUS_OK, $response->getStatus());
 		$this->assertSame([
@@ -526,7 +435,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 	 * @dataProvider getAuthorizationMethodDataProvider
 	 */
 	public function testGetOpenProjectWorkPackageStatusNoToken(string $authorizationMethod): void {
-		$this->getUserValueMock($authorizationMethod, '');
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['getOIDCToken'])
@@ -534,15 +442,10 @@ class OpenProjectAPIControllerTest extends TestCase {
 		if ($authorizationMethod === OpenProjectAPIService::AUTH_METHOD_OIDC) {
 			$service->method('getOIDCToken')->willReturn('');
 		}
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
+		$controller = $this->getOpenProjectAPIControllerMock([
+			'openProjectAPIService' => $service,
+			'config' => $this->getConfigMock($authorizationMethod, ''),
+		]);
 		$response = $controller->getOpenProjectWorkPackageStatus('7');
 		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
 	}
@@ -555,7 +458,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 	 * @dataProvider getAuthorizationMethodDataProvider
 	 */
 	public function testGetOpenProjectWorkPackageStatusWithErrorResponse(string $authorizationMethod): void {
-		$this->getUserValueMock($authorizationMethod);
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['getOpenProjectWorkPackageStatus','getOIDCToken'])
@@ -567,15 +469,10 @@ class OpenProjectAPIControllerTest extends TestCase {
 			->method('getOpenProjectWorkPackageStatus')
 			->willReturn(['error' => 'something went wrong']);
 
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
+		$controller = $this->getOpenProjectAPIControllerMock([
+			'openProjectAPIService' => $service,
+			'config' => $this->getConfigMock($authorizationMethod),
+		]);
 		$response = $controller->getOpenProjectWorkPackageStatus('7');
 		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
 		$this->assertSame(['error' => 'something went wrong'], $response->getData());
@@ -589,13 +486,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 	 * @dataProvider getAuthorizationMethodDataProvider
 	 */
 	public function testGetOpenProjectWorkPackageStatusBadOPInstanceUrl(string $authorizationMethod): void {
-		$this->getUserValueMock($authorizationMethod);
-		$this->configMock = $this->getMockBuilder(IConfig::class)->getMock();
-		$this->configMock
-			->method('getAppValue')
-			->withConsecutive(
-				['integration_openproject', 'openproject_instance_url'],
-			)->willReturnOnConsecutiveCalls('http:openproject');
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['getOIDCToken'])
@@ -604,15 +494,10 @@ class OpenProjectAPIControllerTest extends TestCase {
 			$service->method('getOIDCToken')->willReturn('123');
 		}
 
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
+		$controller = $this->getOpenProjectAPIControllerMock([
+			'openProjectAPIService' => $service,
+			'config' => $this->getConfigMock($authorizationMethod, null, 'http:openproject'),
+		]);
 		$response = $controller->getOpenProjectWorkPackageStatus('7');
 		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
 	}
@@ -625,7 +510,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 	 * @dataProvider getAuthorizationMethodDataProvider
 	 */
 	public function testGetOpenProjectWorkPackageType(string $authorizationMethod): void {
-		$this->getUserValueMock($authorizationMethod);
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['getOpenProjectWorkPackageType', 'getOIDCToken'])
@@ -638,15 +522,10 @@ class OpenProjectAPIControllerTest extends TestCase {
 			->willReturn(["_type" => "Type", "id" => 3, "name" => "Phase",
 				"color" => "#CC5DE8", "position" => 4, "isDefault" => true, "isMilestone" => false, "createdAt" => "2022-01-12T08:53:15Z", "updatedAt" => "2022-01-12T08:53:34Z"]);
 
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
+		$controller = $this->getOpenProjectAPIControllerMock([
+			'openProjectAPIService' => $service,
+			'config' => $this->getConfigMock($authorizationMethod),
+		]);
 		$response = $controller->getOpenProjectWorkPackageType('3');
 		$this->assertSame(Http::STATUS_OK, $response->getStatus());
 		$this->assertSame(["_type" => "Type", "id" => 3, "name" => "Phase",
@@ -661,7 +540,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 	 * @dataProvider getAuthorizationMethodDataProvider
 	 */
 	public function testGetOpenProjectWorkPackageTypeNoAccessToken(string $authorizationMethod): void {
-		$this->getUserValueMock($authorizationMethod, '');
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['getOIDCToken'])
@@ -669,15 +547,10 @@ class OpenProjectAPIControllerTest extends TestCase {
 		if ($authorizationMethod === OpenProjectAPIService::AUTH_METHOD_OIDC) {
 			$service->method('getOIDCToken')->willReturn('');
 		}
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
+		$controller = $this->getOpenProjectAPIControllerMock([
+			'openProjectAPIService' => $service,
+			'config' => $this->getConfigMock($authorizationMethod, ''),
+		]);
 		$response = $controller->getOpenProjectWorkPackageType('3');
 		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
 	}
@@ -690,7 +563,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 	 * @dataProvider getAuthorizationMethodDataProvider
 	 */
 	public function testGetOpenProjectWorkPackageTypeErrorResponse(string $authorizationMethod): void {
-		$this->getUserValueMock($authorizationMethod);
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['getOpenProjectWorkPackageType','getOIDCToken'])
@@ -702,15 +574,10 @@ class OpenProjectAPIControllerTest extends TestCase {
 			->method('getOpenProjectWorkPackageType')
 			->willReturn(['error' => 'something went wrong']);
 
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
+		$controller = $this->getOpenProjectAPIControllerMock([
+			'openProjectAPIService' => $service,
+			'config' => $this->getConfigMock($authorizationMethod),
+		]);
 		$response = $controller->getOpenProjectWorkPackageType('3');
 		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
 		$this->assertSame(['error' => 'something went wrong'], $response->getData());
@@ -724,13 +591,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 	 * @dataProvider getAuthorizationMethodDataProvider
 	 */
 	public function testGetOpenProjectWorkPackageTypeBadOPInstanceUrl(string $authorizationMethod): void {
-		$this->getUserValueMock($authorizationMethod);
-		$this->configMock = $this->getMockBuilder(IConfig::class)->getMock();
-		$this->configMock
-			->method('getAppValue')
-			->withConsecutive(
-				['integration_openproject', 'openproject_instance_url'],
-			)->willReturnOnConsecutiveCalls('http:openproject');
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['getOIDCToken'])
@@ -739,15 +599,10 @@ class OpenProjectAPIControllerTest extends TestCase {
 			$service->method('getOIDCToken')->willReturn('123');
 		}
 
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
+		$controller = $this->getOpenProjectAPIControllerMock([
+			'openProjectAPIService' => $service,
+			'config' => $this->getConfigMock($authorizationMethod, null, 'http:openproject'),
+		]);
 		$response = $controller->getOpenProjectWorkPackageType('3');
 		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
 	}
@@ -760,7 +615,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 	 * @dataProvider getAuthorizationMethodDataProvider
 	 */
 	public function testGetWorkPackageFileLinks(string $authorizationMethod): void {
-		$this->getUserValueMock($authorizationMethod);
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['getWorkPackageFileLinks', 'getOIDCToken'])
@@ -778,15 +632,10 @@ class OpenProjectAPIControllerTest extends TestCase {
 				]
 			]]);
 
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
+		$controller = $this->getOpenProjectAPIControllerMock([
+			'openProjectAPIService' => $service,
+			'config' => $this->getConfigMock($authorizationMethod),
+		]);
 		$response = $controller->getWorkPackageFileLinks(7);
 		$this->assertSame(Http::STATUS_OK, $response->getStatus());
 		$this->assertSame([[
@@ -806,7 +655,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 	 * @dataProvider getAuthorizationMethodDataProvider
 	 */
 	public function testGetWorkPackageFileLinksNoAccessToken(string $authorizationMethod): void {
-		$this->getUserValueMock($authorizationMethod, '');
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['getOIDCToken'])
@@ -814,15 +662,10 @@ class OpenProjectAPIControllerTest extends TestCase {
 		if ($authorizationMethod === OpenProjectAPIService::AUTH_METHOD_OIDC) {
 			$service->method('getOIDCToken')->willReturn('');
 		}
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
+		$controller = $this->getOpenProjectAPIControllerMock([
+			'openProjectAPIService' => $service,
+			'config' => $this->getConfigMock($authorizationMethod, ''),
+		]);
 		$response = $controller->getWorkPackageFileLinks(7);
 		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
 	}
@@ -835,7 +678,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 	 * @dataProvider getAuthorizationMethodDataProvider
 	 */
 	public function testGetWorkPackageFileLinksNotFound(string $authorizationMethod): void {
-		$this->getUserValueMock($authorizationMethod);
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['getWorkPackageFileLinks','getOIDCToken'])
@@ -846,15 +688,10 @@ class OpenProjectAPIControllerTest extends TestCase {
 		$service
 			->method('getWorkPackageFileLinks')
 			->willThrowException(new NotFoundException('work package not found'));
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
+		$controller = $this->getOpenProjectAPIControllerMock([
+			'openProjectAPIService' => $service,
+			'config' => $this->getConfigMock($authorizationMethod),
+		]);
 		$response = $controller->getWorkPackageFileLinks(7);
 		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
 		$this->assertSame('work package not found', $response->getData());
@@ -868,7 +705,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 	 * @dataProvider getAuthorizationMethodDataProvider
 	 */
 	public function testGetWorkPackageFileLinksInternalServerError(string $authorizationMethod): void {
-		$this->getUserValueMock($authorizationMethod);
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['getWorkPackageFileLinks','getOIDCToken'])
@@ -879,15 +715,10 @@ class OpenProjectAPIControllerTest extends TestCase {
 		$service
 			->method('getWorkPackageFileLinks')
 			->willThrowException(new Exception('something went wrong'));
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
+		$controller = $this->getOpenProjectAPIControllerMock([
+			'openProjectAPIService' => $service,
+			'config' => $this->getConfigMock($authorizationMethod),
+		]);
 		$response = $controller->getWorkPackageFileLinks(7);
 		$this->assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
 		$this->assertSame('something went wrong', $response->getData());
@@ -901,7 +732,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 	 * @dataProvider getAuthorizationMethodDataProvider
 	 */
 	public function testDeleteFileLink(string $authorizationMethod): void {
-		$this->getUserValueMock($authorizationMethod);
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['deleteFileLink','getOIDCToken'])
@@ -913,15 +743,10 @@ class OpenProjectAPIControllerTest extends TestCase {
 			->method('deleteFileLink')
 			->willReturn(['success' => true]);
 
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
+		$controller = $this->getOpenProjectAPIControllerMock([
+			'openProjectAPIService' => $service,
+			'config' => $this->getConfigMock($authorizationMethod),
+		]);
 		$response = $controller->deleteFileLink(7);
 		$this->assertSame(Http::STATUS_OK, $response->getStatus());
 		$this->assertSame(['success' => true], $response->getData());
@@ -935,7 +760,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 	 * @dataProvider getAuthorizationMethodDataProvider
 	 */
 	public function testDeleteFileLinkNoAccessToken(string $authorizationMethod): void {
-		$this->getUserValueMock($authorizationMethod, '');
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['getOIDCToken'])
@@ -943,15 +767,10 @@ class OpenProjectAPIControllerTest extends TestCase {
 		if ($authorizationMethod === OpenProjectAPIService::AUTH_METHOD_OIDC) {
 			$service->method('getOIDCToken')->willReturn('');
 		}
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
+		$controller = $this->getOpenProjectAPIControllerMock([
+			'openProjectAPIService' => $service,
+			'config' => $this->getConfigMock($authorizationMethod, ''),
+		]);
 		$response = $controller->deleteFileLink(7);
 		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
 	}
@@ -964,7 +783,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 	 * @dataProvider getAuthorizationMethodDataProvider
 	 */
 	public function testDeleteFileLinkFileNotFound(string $authorizationMethod): void {
-		$this->getUserValueMock($authorizationMethod);
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['deleteFileLink','getOIDCToken'])
@@ -975,15 +793,10 @@ class OpenProjectAPIControllerTest extends TestCase {
 		$service
 			->method('deleteFileLink')
 			->willThrowException(new NotFoundException('file not found'));
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
+		$controller = $this->getOpenProjectAPIControllerMock([
+			'openProjectAPIService' => $service,
+			'config' => $this->getConfigMock($authorizationMethod),
+		]);
 		$response = $controller->deleteFileLink(7);
 		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
 		$this->assertSame('file not found', $response->getData());
@@ -997,7 +810,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 	 * @dataProvider getAuthorizationMethodDataProvider
 	 */
 	public function testDeleteFileLinkInternalServerError(string $authorizationMethod): void {
-		$this->getUserValueMock($authorizationMethod);
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['deleteFileLink','getOIDCToken'])
@@ -1008,329 +820,13 @@ class OpenProjectAPIControllerTest extends TestCase {
 		$service
 			->method('deleteFileLink')
 			->willThrowException(new Exception('something went wrong'));
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
+		$controller = $this->getOpenProjectAPIControllerMock([
+			'openProjectAPIService' => $service,
+			'config' => $this->getConfigMock($authorizationMethod),
+		]);
 		$response = $controller->deleteFileLink(7);
 		$this->assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
 		$this->assertSame('something went wrong', $response->getData());
-	}
-
-	/**
-	 * @return array<mixed>
-	 */
-	public function isValidOpenProjectInstanceDataProvider() {
-		return [
-			['{"_type":"Root","instanceName":"OpenProject"}', true],
-			['{"_type":"something","instanceName":"OpenProject"}', 'not_valid_body'],
-			['{"_type":"Root","someData":"whatever"}', 'not_valid_body'],
-			['<h1>hello world</h1>', 'not_valid_body'],
-		];
-	}
-
-	/**
-	 * @dataProvider isValidOpenProjectInstanceDataProvider
-	 * @param string $body
-	 * @param string|bool $expectedResult
-	 * @return void
-	 */
-	public function testIsValidOpenProjectInstance(
-		string $body, $expectedResult
-	): void {
-		$response = $this->getMockBuilder(IResponse::class)->getMock();
-		$response->method('getBody')->willReturn($body);
-		$service = $this->getMockBuilder(OpenProjectAPIService::class)
-			->disableOriginalConstructor()
-			->onlyMethods(['rawRequest','isAdminAuditConfigSetCorrectly'])
-			->getMock();
-		$service
-			->method('isAdminAuditConfigSetCorrectly')
-			->willReturn(false);
-		$service
-			->method('rawRequest')
-			->willReturn($response);
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
-		$result = $controller->isValidOpenProjectInstance('http://openproject.org');
-		if ($expectedResult === true) {
-			$this->assertSame([ 'result' => true], $result->getData());
-		} else {
-			$this->assertSame(
-				[ 'result' => $expectedResult, 'details' => $body ],
-				$result->getData()
-			);
-		}
-	}
-
-
-	public function testIsValidOpenProjectInstanceRedirect(): void {
-		$response = $this->getMockBuilder(IResponse::class)->getMock();
-		$response->method('getStatusCode')->willReturn(302);
-		$response->method('getHeader')
-			->with('Location')
-			->willReturn('https://openproject.org/api/v3/');
-		$service = $this->getMockBuilder(OpenProjectAPIService::class)
-			->disableOriginalConstructor()
-			->onlyMethods(['rawRequest'])
-			->getMock();
-		$service
-			->method('rawRequest')
-			->willReturn($response);
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
-		$result = $controller->isValidOpenProjectInstance('http://openproject.org');
-		$this->assertSame(
-			[ 'result' => 'redirected', 'details' => 'https://openproject.org/'],
-			$result->getData()
-		);
-	}
-
-	public function testIsValidOpenProjectInstanceRedirectNoLocationHeader(): void {
-		$response = $this->getMockBuilder(IResponse::class)->getMock();
-		$response->method('getStatusCode')->willReturn(302);
-		$response->method('getHeader')
-			->with('Location')
-			->willReturn('');
-		$service = $this->getMockBuilder(OpenProjectAPIService::class)
-			->disableOriginalConstructor()
-			->onlyMethods(['rawRequest','isAdminAuditConfigSetCorrectly'])
-			->getMock();
-		$service
-			->method('rawRequest')
-			->willReturn($response);
-		$service
-			->method('isAdminAuditConfigSetCorrectly')
-			->willReturn(false);
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
-		$result = $controller->isValidOpenProjectInstance('http://openproject.org');
-		$this->assertSame(
-			[
-				'result' => 'unexpected_error',
-				'details' => 'received a redirect status code (302) but no "Location" header'
-			],
-			$result->getData()
-		);
-	}
-
-	/**
-	 * @return array<mixed>
-	 */
-	public function isValidOpenProjectInstanceExpectionDataProvider() {
-		$requestMock = $this->getMockBuilder('\Psr\Http\Message\RequestInterface')->getMock();
-		$privateInstance = $this->getMockBuilder('\Psr\Http\Message\ResponseInterface')->getMock();
-		$privateInstance->method('getBody')->willReturn(
-			'{"_type":"Error","errorIdentifier":"urn:openproject-org:api:v3:errors:Unauthenticated"}'
-		);
-		$notOP = $this->getMockBuilder('\Psr\Http\Message\ResponseInterface')->getMock();
-		$notOP->method('getBody')->willReturn('Unauthenticated');
-		$notOP->method('getReasonPhrase')->willReturn('Unauthenticated');
-		$notOP->method('getStatusCode')->willReturn('401');
-		$notOPButJSON = $this->getMockBuilder('\Psr\Http\Message\ResponseInterface')->getMock();
-		$notOPButJSON->method('getBody')->willReturn(
-			'{"what":"Error","why":"Unauthenticated"}'
-		);
-		$notOPButJSON->method('getReasonPhrase')->willReturn('Unauthenticated');
-		$notOPButJSON->method('getStatusCode')->willReturn('401');
-		$otherResponseMock = $this->getMockBuilder('\Psr\Http\Message\ResponseInterface')->getMock();
-		$otherResponseMock->method('getReasonPhrase')->willReturn('Internal Server Error');
-		$otherResponseMock->method('getStatusCode')->willReturn('500');
-		return [
-			[
-				new ConnectException('a connection problem', $requestMock),
-				[ 'result' => 'network_error', 'details' => 'a connection problem']
-			],
-			[
-				new ClientException('valid but private instance', $requestMock, $privateInstance),
-				[ 'result' => true ]
-			],
-			[
-				new ClientException('not a OP instance', $requestMock, $notOP),
-				[ 'result' => 'client_exception', 'details' => '401 Unauthenticated' ]
-			],
-			[
-				new ClientException('not a OP instance but return JSON', $requestMock, $notOPButJSON),
-				[ 'result' => 'client_exception', 'details' => '401 Unauthenticated' ]
-			],
-			[
-				new ServerException('some server issue', $requestMock, $otherResponseMock),
-				[ 'result' => 'server_exception', 'details' => '500 Internal Server Error' ]
-			],
-			[
-				new BadResponseException('some issue', $requestMock, $otherResponseMock),
-				[ 'result' => 'request_exception', 'details' => 'some issue' ]
-			],
-			[
-				new LocalServerException('Host violates local access rules'),
-				[ 'result' => 'local_remote_servers_not_allowed' ]
-			],
-			[
-				new RequestException('some issue', $requestMock, $otherResponseMock),
-				[ 'result' => 'request_exception', 'details' => 'some issue' ]
-			],
-			[
-				new \Exception('some issue'),
-				[ 'result' => 'unexpected_error', 'details' => 'some issue' ]
-			],
-
-		];
-	}
-
-	/**
-	 * @dataProvider isValidOpenProjectInstanceExpectionDataProvider
-	 * @param Exception $thrownException
-	 * @param bool|string $expectedResult
-	 * @return void
-	 */
-	public function testIsValidOpenProjectInstanceException(
-		$thrownException, $expectedResult
-	): void {
-		$service = $this->getMockBuilder(OpenProjectAPIService::class)
-			->disableOriginalConstructor()
-			->onlyMethods(['rawRequest', 'isAdminAuditConfigSetCorrectly'])
-			->getMock();
-		$service
-			->method('isAdminAuditConfigSetCorrectly')
-			->willReturn(false);
-		$service
-			->method('rawRequest')
-			->willThrowException($thrownException);
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
-		$result = $controller->isValidOpenProjectInstance('http://openproject.org');
-		$this->assertSame($expectedResult, $result->getData());
-	}
-
-	/**
-	 * @return array<int, array<int, string>>
-	 */
-	public function isValidOpenProjectInstanceInvalidUrlDataProvider() {
-		return [
-			[ '123' ],
-			[ 'htt://something' ],
-			[ '' ],
-			[ 'ftp://something.org ']
-		];
-	}
-	/**
-	 * @dataProvider isValidOpenProjectInstanceInvalidUrlDataProvider
-	 * @return void
-	 */
-	public function testIsValidOpenProjectInstanceInvalidUrl(string $url): void {
-		$service = $this->getMockBuilder(OpenProjectAPIService::class)
-			->disableOriginalConstructor()
-			->onlyMethods([])
-			->getMock();
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
-		$result = $controller->isValidOpenProjectInstance($url);
-		$this->assertSame(['result' => 'invalid'], $result->getData());
-	}
-
-	public function testGetOpenProjectOauthURLWithStateAndPKCE(): void {
-		$service = $this->getMockBuilder(OpenProjectAPIService::class)
-			->disableOriginalConstructor()
-			->onlyMethods([])
-			->getMock();
-		$this->configMock = $this->getMockBuilder(IConfig::class)->getMock();
-		$this->configMock
-			->method('getAppValue')
-			->withConsecutive(
-				['integration_openproject', 'openproject_instance_url'],
-				['integration_openproject', 'authorization_method'],
-				['integration_openproject', 'openproject_client_id'],
-				['integration_openproject', 'openproject_client_secret'],
-				['integration_openproject', 'openproject_instance_url'],
-				['integration_openproject', 'openproject_client_id'],
-				['integration_openproject', 'openproject_instance_url'],
-			)->willReturnOnConsecutiveCalls(
-				'http://openproject.org',
-				OpenProjectAPIService::AUTH_METHOD_OAUTH,
-				'myClientID',
-				'myClientSecret',
-				'http://openproject.org',
-				'myClientID',
-				'http://openproject.org',
-			);
-		$this->configMock
-			->expects($this->exactly(2))
-			->method('setUserValue')
-			->withConsecutive(
-				[
-					'test',
-					'integration_openproject',
-					'oauth_state',
-					$this->matchesRegularExpression('/[a-z0-9]{10}/')
-				],
-				[
-					'test',
-					'integration_openproject',
-					'code_verifier',
-					$this->matchesRegularExpression('/[A-Za-z0-9\-._~]{128}/')
-				],
-			);
-
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
-		$result = $controller->getOpenProjectOauthURLWithStateAndPKCE();
-		$this->assertMatchesRegularExpression(
-			'/^http:\/\/openproject\.org\/oauth\/authorize\?' .
-			'client_id=myClientID&' .
-			'redirect_uri=&' .
-			'response_type=code&' .
-			'state=[a-z0-9]{10}&' .
-			'code_challenge=[a-zA-Z0-9\-_]{43}&' .
-			'code_challenge_method=S256$/',
-			(string) $result->getData()
-		);
 	}
 
 	/**
@@ -1341,7 +837,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 	 * @dataProvider getAuthorizationMethodDataProvider
 	 */
 	public function testLinkWorkPackageToSingleFile(string $authorizationMethod) {
-		$this->getUserValueMock($authorizationMethod);
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['linkWorkPackageToFile', 'getOIDCToken'])
@@ -1354,15 +849,10 @@ class OpenProjectAPIControllerTest extends TestCase {
 			->with($this->fileInformationToLinkToWorkPackage, 'test')
 			->willReturn([2]);
 
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
+		$controller = $this->getOpenProjectAPIControllerMock([
+			'openProjectAPIService' => $service,
+			'config' => $this->getConfigMock($authorizationMethod),
+		]);
 		$response = $controller->linkWorkPackageToFile($this->fileInformationToLinkToWorkPackage);
 		$this->assertSame([2], $response->getData());
 	}
@@ -1376,7 +866,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 	 * @dataProvider getAuthorizationMethodDataProvider
 	 */
 	public function testLinkWorkPackageToMultipleFiles(string $authorizationMethod) {
-		$this->getUserValueMock($authorizationMethod);
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['linkWorkPackageToFile', 'getOIDCToken'])
@@ -1405,15 +894,10 @@ class OpenProjectAPIControllerTest extends TestCase {
 			], 'test')
 			->willReturn([5, 6, 7]);
 
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
+		$controller = $this->getOpenProjectAPIControllerMock([
+			'openProjectAPIService' => $service,
+			'config' => $this->getConfigMock($authorizationMethod),
+		]);
 		$response = $controller->linkWorkPackageToFile([
 			"workpackageId" => 123,
 			"fileinfo" => [
@@ -1442,7 +926,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 	 * @dataProvider getAuthorizationMethodDataProvider
 	 */
 	public function testLinkWorkPackageToFileNoAccessToken(string $authorizationMethod) {
-		$this->getUserValueMock($authorizationMethod, '');
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['getOIDCToken'])
@@ -1450,15 +933,10 @@ class OpenProjectAPIControllerTest extends TestCase {
 		if ($authorizationMethod === OpenProjectAPIService::AUTH_METHOD_OIDC) {
 			$service->method('getOIDCToken')->willReturn('');
 		}
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
+		$controller = $this->getOpenProjectAPIControllerMock([
+			'openProjectAPIService' => $service,
+			'config' => $this->getConfigMock($authorizationMethod, ''),
+		]);
 		$response = $controller->linkWorkPackageToFile($this->fileInformationToLinkToWorkPackage);
 		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
 	}
@@ -1471,7 +949,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 	 * @dataProvider getAuthorizationMethodDataProvider
 	 */
 	public function testLinkWorkPackageToFileNotEnoughPermissions(string $authorizationMethod): void {
-		$this->getUserValueMock($authorizationMethod);
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['linkWorkPackageToFile', 'getOIDCToken'])
@@ -1482,15 +959,10 @@ class OpenProjectAPIControllerTest extends TestCase {
 		$service
 			->method('linkWorkPackageToFile')
 			->willThrowException(new NotPermittedException());
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
+		$controller = $this->getOpenProjectAPIControllerMock([
+			'openProjectAPIService' => $service,
+			'config' => $this->getConfigMock($authorizationMethod),
+		]);
 		$response = $controller->linkWorkPackageToFile($this->fileInformationToLinkToWorkPackage);
 		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
 	}
@@ -1503,7 +975,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 	 * @dataProvider getAuthorizationMethodDataProvider
 	 */
 	public function testLinkWorkPackageToFileOpenProjectErrorException(string $authorizationMethod): void {
-		$this->getUserValueMock($authorizationMethod);
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['linkWorkPackageToFile', 'getOIDCToken'])
@@ -1514,15 +985,10 @@ class OpenProjectAPIControllerTest extends TestCase {
 		$service
 			->method('linkWorkPackageToFile')
 			->willThrowException(new OpenprojectErrorException('Error while linking file to a work package', 400));
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
+		$controller = $this->getOpenProjectAPIControllerMock([
+			'openProjectAPIService' => $service,
+			'config' => $this->getConfigMock($authorizationMethod),
+		]);
 		$response = $controller->linkWorkPackageToFile($this->fileInformationToLinkToWorkPackage);
 		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
 		$this->assertSame('Error while linking file to a work package', $response->getData());
@@ -1536,7 +1002,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 	 * @dataProvider getAuthorizationMethodDataProvider
 	 */
 	public function testLinkWorkPackageToFileOpenprojectResponseException(string $authorizationMethod): void {
-		$this->getUserValueMock($authorizationMethod);
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['linkWorkPackageToFile', 'getOIDCToken'])
@@ -1547,15 +1012,10 @@ class OpenProjectAPIControllerTest extends TestCase {
 		$service
 			->method('linkWorkPackageToFile')
 			->willThrowException(new OpenprojectResponseException('Malformed response'));
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
+		$controller = $this->getOpenProjectAPIControllerMock([
+			'openProjectAPIService' => $service,
+			'config' => $this->getConfigMock($authorizationMethod),
+		]);
 		$response = $controller->linkWorkPackageToFile($this->fileInformationToLinkToWorkPackage);
 		$this->assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
 		$this->assertSame('Malformed response', $response->getData());
@@ -1569,7 +1029,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 	 * @dataProvider getAuthorizationMethodDataProvider
 	 */
 	public function testLinkWorkPackageToFileForInvalidKeyError(string $authorizationMethod): void {
-		$this->getUserValueMock($authorizationMethod);
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['linkWorkPackageToFile', 'getOIDCToken'])
@@ -1580,15 +1039,10 @@ class OpenProjectAPIControllerTest extends TestCase {
 		$service
 			->method('linkWorkPackageToFile')
 			->willThrowException(new InvalidArgumentException('invalid key'));
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
+		$controller = $this->getOpenProjectAPIControllerMock([
+			'openProjectAPIService' => $service,
+			'config' => $this->getConfigMock($authorizationMethod),
+		]);
 		$response = $controller->linkWorkPackageToFile($this->fileInformationToLinkToWorkPackage);
 		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
 		$this->assertSame('invalid key', $response->getData());
@@ -1602,7 +1056,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 	 * @dataProvider getAuthorizationMethodDataProvider
 	 */
 	public function testLinkWorkPackageToFileForInvalidDataError(string $authorizationMethod): void {
-		$this->getUserValueMock($authorizationMethod);
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['linkWorkPackageToFile', 'getOIDCToken'])
@@ -1613,15 +1066,10 @@ class OpenProjectAPIControllerTest extends TestCase {
 		$service
 			->method('linkWorkPackageToFile')
 			->willThrowException(new InvalidArgumentException('invalid data'));
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
+		$controller = $this->getOpenProjectAPIControllerMock([
+			'openProjectAPIService' => $service,
+			'config' => $this->getConfigMock($authorizationMethod),
+		]);
 		$response = $controller->linkWorkPackageToFile($this->fileInformationToLinkToWorkPackage);
 		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
 		$this->assertSame('invalid data', $response->getData());
@@ -1679,7 +1127,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 	 * @dataProvider getAuthorizationMethodDataProvider
 	 */
 	public function testGetAvailableOpenProjectProjects(string $authorizationMethod): void {
-		$this->getUserValueMock($authorizationMethod);
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['getAvailableOpenProjectProjects','getOIDCToken'])
@@ -1700,15 +1147,10 @@ class OpenProjectAPIControllerTest extends TestCase {
 					]
 				]
 			]);
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
+		$controller = $this->getOpenProjectAPIControllerMock([
+			'openProjectAPIService' => $service,
+			'config' => $this->getConfigMock($authorizationMethod),
+		]);
 		$response = $controller->getAvailableOpenProjectProjects();
 		$this->assertSame(Http::STATUS_OK, $response->getStatus());
 		$this->assertSame([
@@ -1738,7 +1180,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 		int $expectedHttpStatusCode,
 		string $expectedError
 	):void {
-		$this->getUserValueMock($authorizationMethod);
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['getAvailableOpenProjectProjects', 'getOIDCToken'])
@@ -1749,15 +1190,10 @@ class OpenProjectAPIControllerTest extends TestCase {
 		$service
 			->method('getAvailableOpenProjectProjects')
 			->willThrowException($exception);
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
+		$controller = $this->getOpenProjectAPIControllerMock([
+			'openProjectAPIService' => $service,
+			'config' => $this->getConfigMock($authorizationMethod),
+		]);
 		$response = $controller->getAvailableOpenProjectProjects();
 		$this->assertSame($expectedHttpStatusCode, $response->getStatus());
 		$this->assertSame($expectedError, $response->getData());
@@ -1771,7 +1207,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 	 * @dataProvider getAuthorizationMethodDataProvider
 	 */
 	public function testGetOpenProjectWorkPackageForm(string $authorizationMethod): void {
-		$this->getUserValueMock($authorizationMethod);
 		$body = [
 			"_links" => [
 				"type" => [
@@ -1830,15 +1265,10 @@ class OpenProjectAPIControllerTest extends TestCase {
 			->method('getOpenProjectWorkPackageForm')
 			->with('test', 6, $body)
 			->willReturn($result);
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
+		$controller = $this->getOpenProjectAPIControllerMock([
+			'openProjectAPIService' => $service,
+			'config' => $this->getConfigMock($authorizationMethod),
+		]);
 		$response = $controller->getOpenProjectWorkPackageForm('6', $body);
 		$this->assertSame(Http::STATUS_OK, $response->getStatus());
 		$this->assertSame($result, $response->getData());
@@ -1858,7 +1288,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 		Exception $exception,
 		int $expectedHttpStatusCode,
 		string $expectedError): void {
-		$this->getUserValueMock($authorizationMethod);
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['getOpenProjectWorkPackageForm','getOIDCToken'])
@@ -1869,15 +1298,10 @@ class OpenProjectAPIControllerTest extends TestCase {
 		$service
 			->method('getOpenProjectWorkPackageForm')
 			->willThrowException($exception);
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
+		$controller = $this->getOpenProjectAPIControllerMock([
+			'openProjectAPIService' => $service,
+			'config' => $this->getConfigMock($authorizationMethod),
+		]);
 		$response = $controller->getOpenProjectWorkPackageForm('6', ["_links" => [
 			"type" => [
 				"href" => "/api/v3/types/2",
@@ -1895,7 +1319,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 	 * @dataProvider getAuthorizationMethodDataProvider
 	 */
 	public function testGetOpenProjectWorkPackageFormEmptyBody(string $authorizationMethod): void {
-		$this->getUserValueMock($authorizationMethod);
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['getOpenProjectWorkPackageForm', 'getOIDCToken'])
@@ -1906,15 +1329,10 @@ class OpenProjectAPIControllerTest extends TestCase {
 		$service
 			->method('getOpenProjectWorkPackageForm')
 			->willReturn([]);
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
+		$controller = $this->getOpenProjectAPIControllerMock([
+			'openProjectAPIService' => $service,
+			'config' => $this->getConfigMock($authorizationMethod),
+		]);
 		$response = $controller->getOpenProjectWorkPackageForm('6', []);
 		$this->assertSame(HTTP::STATUS_OK, $response->getStatus());
 		$this->assertSame([], $response->getData());
@@ -1928,7 +1346,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 	 * @dataProvider getAuthorizationMethodDataProvider
 	 */
 	public function testGetAvailableAssigneesOfAProject(string $authorizationMethod) : void {
-		$this->getUserValueMock($authorizationMethod);
 		$result = [ 0 => [
 			"_type" => "User",
 			"id" => 10,
@@ -1963,15 +1380,10 @@ class OpenProjectAPIControllerTest extends TestCase {
 			->method('getAvailableAssigneesOfAProject')
 			->with('test', 6)
 			->willReturn($result);
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
+		$controller = $this->getOpenProjectAPIControllerMock([
+			'openProjectAPIService' => $service,
+			'config' => $this->getConfigMock($authorizationMethod),
+		]);
 		$response = $controller->getAvailableAssigneesOfAProject('6');
 		$this->assertSame(Http::STATUS_OK, $response->getStatus());
 		$this->assertSame(
@@ -1994,7 +1406,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 		int $expectedHttpStatusCode,
 		string $expectedError
 	):void {
-		$this->getUserValueMock($authorizationMethod);
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['getAvailableAssigneesOfAProject', 'getOIDCToken'])
@@ -2005,15 +1416,10 @@ class OpenProjectAPIControllerTest extends TestCase {
 		$service
 			->method('getAvailableAssigneesOfAProject')
 			->willThrowException($exception);
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
+		$controller = $this->getOpenProjectAPIControllerMock([
+			'openProjectAPIService' => $service,
+			'config' => $this->getConfigMock($authorizationMethod),
+		]);
 		$response = $controller->getAvailableAssigneesOfAProject('6');
 		$this->assertSame($expectedHttpStatusCode, $response->getStatus());
 		$this->assertSame($expectedError, $response->getData());
@@ -2027,7 +1433,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 	 * @dataProvider getAuthorizationMethodDataProvider
 	 */
 	public function testCreateWorkpackages(string $authorizationMethod): void {
-		$this->getUserValueMock($authorizationMethod);
 		$body = [
 			"_links" => [
 				"type" => [
@@ -2096,15 +1501,10 @@ class OpenProjectAPIControllerTest extends TestCase {
 			->with('test', $body)
 			->willReturn($response);
 
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
+		$controller = $this->getOpenProjectAPIControllerMock([
+			'openProjectAPIService' => $service,
+			'config' => $this->getConfigMock($authorizationMethod),
+		]);
 		$result = $controller->createWorkPackage($body);
 		$this->assertSame(Http::STATUS_CREATED, $result->getStatus());
 		$this->assertSame(
@@ -2126,7 +1526,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 		int $expectedHttpStatusCode,
 		string $expectedError
 	):void {
-		$this->getUserValueMock($authorizationMethod);
 		$body = [
 			"_links" => [
 				"type" => [
@@ -2163,15 +1562,10 @@ class OpenProjectAPIControllerTest extends TestCase {
 		$service
 			->method('createWorkPackage')
 			->willThrowException($exception);
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
+		$controller = $this->getOpenProjectAPIControllerMock([
+			'openProjectAPIService' => $service,
+			'config' => $this->getConfigMock($authorizationMethod),
+		]);
 		$response = $controller->createWorkPackage($body);
 		$this->assertSame($expectedHttpStatusCode, $response->getStatus());
 		$this->assertSame($expectedError, $response->getData());
@@ -2185,7 +1579,6 @@ class OpenProjectAPIControllerTest extends TestCase {
 	 * @dataProvider getAuthorizationMethodDataProvider
 	 */
 	public function testCreateWorkpackagesEmptyBody(string $authorizationMethod): void {
-		$this->getUserValueMock($authorizationMethod);
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['getOIDCToken'])
@@ -2193,15 +1586,10 @@ class OpenProjectAPIControllerTest extends TestCase {
 		if ($authorizationMethod === OpenProjectAPIService::AUTH_METHOD_OIDC) {
 			$service->method('getOIDCToken')->willReturn('123');
 		}
-		$controller = new OpenProjectAPIController(
-			'integration_openproject',
-			$this->requestMock,
-			$this->configMock,
-			$service,
-			$this->urlGeneratorMock,
-			$this->loggerMock,
-			'test'
-		);
+		$controller = $this->getOpenProjectAPIControllerMock([
+			'openProjectAPIService' => $service,
+			'config' => $this->getConfigMock($authorizationMethod),
+		]);
 		$response = $controller->createWorkPackage([]);
 		$this->assertSame(HTTP::STATUS_BAD_REQUEST, $response->getStatus());
 		$this->assertSame('Body cannot be empty', $response->getData());

--- a/tests/lib/Controller/OpenProjectAPIControllerTest.php
+++ b/tests/lib/Controller/OpenProjectAPIControllerTest.php
@@ -8,16 +8,13 @@
 namespace OCA\OpenProject\Controller;
 
 use Exception;
-use GuzzleHttp\Exception\BadResponseException;
 use InvalidArgumentException;
 use OCA\OpenProject\Exception\OpenprojectErrorException;
 use OCA\OpenProject\Exception\OpenprojectResponseException;
 use OCA\OpenProject\Service\OpenProjectAPIService;
 use OCP\AppFramework\Http;
-use OCP\AppFramework\OCSController;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
-use OCP\Http\Client\IResponse;
 use OCP\IConfig;
 use OCP\IRequest;
 use PHPUnit\Framework\TestCase;
@@ -98,6 +95,9 @@ class OpenProjectAPIControllerTest extends TestCase {
 			$constructArgs[$key] = $value;
 		}
 
+		/**
+		 * @psalm-suppress InvalidArgument
+		 */
 		return new OpenProjectAPIController('integration_openproject', ...array_values($constructArgs));
 	}
 

--- a/tests/lib/Controller/OpenProjectAPIControllerTest.php
+++ b/tests/lib/Controller/OpenProjectAPIControllerTest.php
@@ -49,6 +49,7 @@ class OpenProjectAPIControllerTest extends TestCase {
 	/**
 	 * @param string $authorizationMethod
 	 * @param string $authToken
+	 * @param string $opUrl
 	 * @psalm-suppress UndefinedInterfaceMethod
 	 * @return IConfig
 	 */

--- a/tests/lib/Controller/OpenProjectControllerTest.php
+++ b/tests/lib/Controller/OpenProjectControllerTest.php
@@ -14,7 +14,6 @@ use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Exception\ServerException;
 use OCA\OpenProject\Service\OpenProjectAPIService;
-use OCP\AppFramework\Http;
 use OCP\Http\Client\IResponse;
 use OCP\Http\Client\LocalServerException;
 use OCP\IConfig;
@@ -46,6 +45,9 @@ class OpenProjectControllerTest extends TestCase {
 			$constructArgs[$key] = $value;
 		}
 
+		/**
+		 * @psalm-suppress InvalidArgument
+		 */
 		return new OpenProjectController('integration_openproject', ...array_values($constructArgs));
 	}
 

--- a/tests/lib/Controller/OpenProjectControllerTest.php
+++ b/tests/lib/Controller/OpenProjectControllerTest.php
@@ -1,0 +1,331 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2022-2025 Jankari Tech Pvt. Ltd.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\OpenProject\Controller;
+
+use Exception;
+use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\ServerException;
+use OCA\OpenProject\Service\OpenProjectAPIService;
+use OCP\AppFramework\Http;
+use OCP\Http\Client\IResponse;
+use OCP\Http\Client\LocalServerException;
+use OCP\IConfig;
+use OCP\IRequest;
+use OCP\IURLGenerator;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class OpenProjectControllerTest extends TestCase {
+	/**
+	 * @param array<string, object> $constructParams
+	 *
+	 * @return OpenProjectController
+	 */
+	public function getOpenProjectControllerMock(array $constructParams = []): OpenProjectController {
+		$constructArgs = [
+			'request' => $this->createMock(IRequest::class),
+			'config' => $this->createMock(IConfig::class),
+			'openProjectAPIService' => $this->createMock(OpenProjectAPIService::class),
+			'urlGenerator' => $this->createMock(IURLGenerator::class),
+			'loggerInterface' => $this->createMock(LoggerInterface::class),
+			'userId' => 'test',
+		];
+		foreach ($constructParams as $key => $value) {
+			if (!array_key_exists($key, $constructArgs)) {
+				throw new \InvalidArgumentException("Invalid construct parameter: $key");
+			}
+
+			$constructArgs[$key] = $value;
+		}
+
+		return new OpenProjectController('integration_openproject', ...array_values($constructArgs));
+	}
+
+	/**
+	 * @return array<mixed>
+	 */
+	public function isValidOpenProjectInstanceDataProvider() {
+		return [
+			['{"_type":"Root","instanceName":"OpenProject"}', true],
+			['{"_type":"something","instanceName":"OpenProject"}', 'not_valid_body'],
+			['{"_type":"Root","someData":"whatever"}', 'not_valid_body'],
+			['<h1>hello world</h1>', 'not_valid_body'],
+		];
+	}
+
+	/**
+	 * @dataProvider isValidOpenProjectInstanceDataProvider
+	 * @param string $body
+	 * @param string|bool $expectedResult
+	 * @return void
+	 */
+	public function testIsValidOpenProjectInstance(
+		string $body, $expectedResult
+	): void {
+		$response = $this->getMockBuilder(IResponse::class)->getMock();
+		$response->method('getBody')->willReturn($body);
+		$service = $this->getMockBuilder(OpenProjectAPIService::class)
+			->disableOriginalConstructor()
+			->onlyMethods(['rawRequest','isAdminAuditConfigSetCorrectly'])
+			->getMock();
+		$service
+			->method('isAdminAuditConfigSetCorrectly')
+			->willReturn(false);
+		$service
+			->method('rawRequest')
+			->willReturn($response);
+
+		$controller = $this->getOpenProjectControllerMock([
+			'openProjectAPIService' => $service,
+		]);
+		$result = $controller->isValidOpenProjectInstance('http://openproject.org');
+		if ($expectedResult === true) {
+			$this->assertSame([ 'result' => true], $result->getData());
+		} else {
+			$this->assertSame(
+				[ 'result' => $expectedResult, 'details' => $body ],
+				$result->getData()
+			);
+		}
+	}
+
+
+	public function testIsValidOpenProjectInstanceRedirect(): void {
+		$response = $this->getMockBuilder(IResponse::class)->getMock();
+		$response->method('getStatusCode')->willReturn(302);
+		$response->method('getHeader')
+			->with('Location')
+			->willReturn('https://openproject.org/api/v3/');
+		$service = $this->getMockBuilder(OpenProjectAPIService::class)
+			->disableOriginalConstructor()
+			->onlyMethods(['rawRequest'])
+			->getMock();
+		$service
+			->method('rawRequest')
+			->willReturn($response);
+
+		$controller = $this->getOpenProjectControllerMock([
+			'openProjectAPIService' => $service,
+		]);
+		$result = $controller->isValidOpenProjectInstance('http://openproject.org');
+		$this->assertSame(
+			[ 'result' => 'redirected', 'details' => 'https://openproject.org/'],
+			$result->getData()
+		);
+	}
+
+	public function testIsValidOpenProjectInstanceRedirectNoLocationHeader(): void {
+		$response = $this->getMockBuilder(IResponse::class)->getMock();
+		$response->method('getStatusCode')->willReturn(302);
+		$response->method('getHeader')
+			->with('Location')
+			->willReturn('');
+		$service = $this->getMockBuilder(OpenProjectAPIService::class)
+			->disableOriginalConstructor()
+			->onlyMethods(['rawRequest','isAdminAuditConfigSetCorrectly'])
+			->getMock();
+		$service
+			->method('rawRequest')
+			->willReturn($response);
+		$service
+			->method('isAdminAuditConfigSetCorrectly')
+			->willReturn(false);
+
+		$controller = $this->getOpenProjectControllerMock([
+			'openProjectAPIService' => $service,
+		]);
+		$result = $controller->isValidOpenProjectInstance('http://openproject.org');
+		$this->assertSame(
+			[
+				'result' => 'unexpected_error',
+				'details' => 'received a redirect status code (302) but no "Location" header'
+			],
+			$result->getData()
+		);
+	}
+
+	/**
+	 * @return array<mixed>
+	 */
+	public function isValidOpenProjectInstanceExpectionDataProvider() {
+		$requestMock = $this->getMockBuilder('\Psr\Http\Message\RequestInterface')->getMock();
+		$privateInstance = $this->getMockBuilder('\Psr\Http\Message\ResponseInterface')->getMock();
+		$privateInstance->method('getBody')->willReturn(
+			'{"_type":"Error","errorIdentifier":"urn:openproject-org:api:v3:errors:Unauthenticated"}'
+		);
+		$notOP = $this->getMockBuilder('\Psr\Http\Message\ResponseInterface')->getMock();
+		$notOP->method('getBody')->willReturn('Unauthenticated');
+		$notOP->method('getReasonPhrase')->willReturn('Unauthenticated');
+		$notOP->method('getStatusCode')->willReturn('401');
+		$notOPButJSON = $this->getMockBuilder('\Psr\Http\Message\ResponseInterface')->getMock();
+		$notOPButJSON->method('getBody')->willReturn(
+			'{"what":"Error","why":"Unauthenticated"}'
+		);
+		$notOPButJSON->method('getReasonPhrase')->willReturn('Unauthenticated');
+		$notOPButJSON->method('getStatusCode')->willReturn('401');
+		$otherResponseMock = $this->getMockBuilder('\Psr\Http\Message\ResponseInterface')->getMock();
+		$otherResponseMock->method('getReasonPhrase')->willReturn('Internal Server Error');
+		$otherResponseMock->method('getStatusCode')->willReturn('500');
+		return [
+			[
+				new ConnectException('a connection problem', $requestMock),
+				[ 'result' => 'network_error', 'details' => 'a connection problem']
+			],
+			[
+				new ClientException('valid but private instance', $requestMock, $privateInstance),
+				[ 'result' => true ]
+			],
+			[
+				new ClientException('not a OP instance', $requestMock, $notOP),
+				[ 'result' => 'client_exception', 'details' => '401 Unauthenticated' ]
+			],
+			[
+				new ClientException('not a OP instance but return JSON', $requestMock, $notOPButJSON),
+				[ 'result' => 'client_exception', 'details' => '401 Unauthenticated' ]
+			],
+			[
+				new ServerException('some server issue', $requestMock, $otherResponseMock),
+				[ 'result' => 'server_exception', 'details' => '500 Internal Server Error' ]
+			],
+			[
+				new BadResponseException('some issue', $requestMock, $otherResponseMock),
+				[ 'result' => 'request_exception', 'details' => 'some issue' ]
+			],
+			[
+				new LocalServerException('Host violates local access rules'),
+				[ 'result' => 'local_remote_servers_not_allowed' ]
+			],
+			[
+				new RequestException('some issue', $requestMock, $otherResponseMock),
+				[ 'result' => 'request_exception', 'details' => 'some issue' ]
+			],
+			[
+				new \Exception('some issue'),
+				[ 'result' => 'unexpected_error', 'details' => 'some issue' ]
+			],
+
+		];
+	}
+
+	/**
+	 * @dataProvider isValidOpenProjectInstanceExpectionDataProvider
+	 * @param Exception $thrownException
+	 * @param bool|string $expectedResult
+	 * @return void
+	 */
+	public function testIsValidOpenProjectInstanceException(
+		$thrownException, $expectedResult
+	): void {
+		$service = $this->getMockBuilder(OpenProjectAPIService::class)
+			->disableOriginalConstructor()
+			->onlyMethods(['rawRequest', 'isAdminAuditConfigSetCorrectly'])
+			->getMock();
+		$service
+			->method('isAdminAuditConfigSetCorrectly')
+			->willReturn(false);
+		$service
+			->method('rawRequest')
+			->willThrowException($thrownException);
+
+		$controller = $this->getOpenProjectControllerMock([
+			'openProjectAPIService' => $service,
+		]);
+		$result = $controller->isValidOpenProjectInstance('http://openproject.org');
+		$this->assertSame($expectedResult, $result->getData());
+	}
+
+	/**
+	 * @return array<int, array<int, string>>
+	 */
+	public function isValidOpenProjectInstanceInvalidUrlDataProvider() {
+		return [
+			[ '123' ],
+			[ 'htt://something' ],
+			[ '' ],
+			[ 'ftp://something.org ']
+		];
+	}
+	/**
+	 * @dataProvider isValidOpenProjectInstanceInvalidUrlDataProvider
+	 * @return void
+	 */
+	public function testIsValidOpenProjectInstanceInvalidUrl(string $url): void {
+		$service = $this->getMockBuilder(OpenProjectAPIService::class)
+			->disableOriginalConstructor()
+			->onlyMethods([])
+			->getMock();
+
+		$controller = $this->getOpenProjectControllerMock([
+			'openProjectAPIService' => $service,
+		]);
+		$result = $controller->isValidOpenProjectInstance($url);
+		$this->assertSame(['result' => 'invalid'], $result->getData());
+	}
+
+	public function testGetOpenProjectOauthURLWithStateAndPKCE(): void {
+		$service = $this->getMockBuilder(OpenProjectAPIService::class)
+			->disableOriginalConstructor()
+			->onlyMethods([])
+			->getMock();
+
+		$configMock = $this->getMockBuilder(IConfig::class)->getMock();
+		$configMock
+			->method('getAppValue')
+			->withConsecutive(
+				['integration_openproject', 'authorization_method'],
+				['integration_openproject', 'openproject_client_id'],
+				['integration_openproject', 'openproject_client_secret'],
+				['integration_openproject', 'openproject_instance_url'],
+				['integration_openproject', 'openproject_client_id'],
+				['integration_openproject', 'openproject_instance_url'],
+			)->willReturnOnConsecutiveCalls(
+				OpenProjectAPIService::AUTH_METHOD_OAUTH,
+				'myClientID',
+				'myClientSecret',
+				'http://openproject.org',
+				'myClientID',
+				'http://openproject.org',
+			);
+		$configMock
+			->expects($this->exactly(2))
+			->method('setUserValue')
+			->withConsecutive(
+				[
+					'test',
+					'integration_openproject',
+					'oauth_state',
+					$this->matchesRegularExpression('/[a-z0-9]{10}/')
+				],
+				[
+					'test',
+					'integration_openproject',
+					'code_verifier',
+					$this->matchesRegularExpression('/[A-Za-z0-9\-._~]{128}/')
+				],
+			);
+
+		$controller = $this->getOpenProjectControllerMock([
+			'openProjectAPIService' => $service,
+			'config' => $configMock,
+		]);
+		$result = $controller->getOpenProjectOauthURLWithStateAndPKCE();
+		$this->assertMatchesRegularExpression(
+			'/^http:\/\/openproject\.org\/oauth\/authorize\?' .
+			'client_id=myClientID&' .
+			'redirect_uri=&' .
+			'response_type=code&' .
+			'state=[a-z0-9]{10}&' .
+			'code_challenge=[a-zA-Z0-9\-_]{43}&' .
+			'code_challenge_method=S256$/',
+			(string) $result->getData()
+		);
+	}
+}

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -3935,7 +3935,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 				'urlGenerator' => $iULGeneratorMock,
 			],
 		);
-		$imageURL = 'http://nextcloud/server/index.php/apps/integration_openproject/avatar?userId=3&userName=OpenProject Admin';
+		$imageURL = 'http://nextcloud/server/ocs/v1.php/apps/integration_openproject/api/v1/avatar?userId=3&userName=OpenProject Admin';
 		$iULGeneratorMock->method('getAbsoluteURL')->willReturn($imageURL);
 		$testUser = 'testUser';
 		$workPackageId = 123;

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -2148,7 +2148,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 			'config' => $configMock,
 			'clientService' => $clientService,
 		]);
-	
+
 		$service = new OpenProjectAPIService(...$constructArgs);
 
 		$response = $service->request('', '', []);
@@ -3935,7 +3935,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 				'urlGenerator' => $iULGeneratorMock,
 			],
 		);
-		$imageURL = 'http://nextcloud/server/ocs/v1.php/apps/integration_openproject/api/v1/avatar?userId=3&userName=OpenProject Admin';
+		$imageURL = 'http://nextcloud/server/ocs/v2.php/apps/integration_openproject/api/v1/avatar?userId=3&userName=OpenProject Admin';
 		$iULGeneratorMock->method('getAbsoluteURL')->willReturn($imageURL);
 		$testUser = 'testUser';
 		$workPackageId = 123;

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -3936,7 +3936,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 			],
 		);
 		$imageURL = 'http://nextcloud/server/ocs/v2.php/apps/integration_openproject/api/v1/avatar?userId=3&userName=OpenProject Admin';
-		$iULGeneratorMock->method('getAbsoluteURL')->willReturn($imageURL);
+		$iULGeneratorMock->method('linkToOCSRouteAbsolute')->willReturn($imageURL);
 		$testUser = 'testUser';
 		$workPackageId = 123;
 		$service->method('searchWorkPackage')->with($testUser, null, null, false, $workPackageId)->willReturn([$this->wpInformationResponse]);


### PR DESCRIPTION
Hey there!

Here is a change suggestion to make it possible to use this integration app from somewhere else than the web UI.
All the endpoints that communicate with OP are grouped in an OCS controller.
OCS endpoints can be reached without having a web session but with any supported authentication method (basic auth, app password etc...).

OCS endpoints always return an `ocs` object which contains a `meta` key and a `data` one. More info at https://docs.nextcloud.com/server/latest/developer_manual/client_apis/OCS/ocs-api-overview.html

The frontend has been adjusted but not tested IRL. This does not affect how the app works.

This would allow us, in [the agency feature](https://docs.nextcloud.com/server/latest/admin_manual/ai/app_context_agent.html), to make OP-related tools. In short, NC users would be able to ask a conversational agent to create a work package in OP for example.

cc @wielinde 