### PR TITLE
[WP #60683][display error if groupfolders app not supported]

### DIFF
--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -1067,6 +1067,8 @@ export default {
 			const url = generateUrl('settings/apps/files/groupfolders')
 			const htmlLink = `<a class="link" href="${url}" target="_blank" title="${linkText}">${linkText}</a>`
 			switch (errorKey) {
+			case 'The "Group folders" app is not supported' :
+				return t('integration_openproject', 'Please update the "Group folders" app to be able to use automatically managed folders. {htmlLink}', { htmlLink }, null, { escape: false, sanitize: false })
 			case 'The "Group folders" app is not installed' :
 				return t('integration_openproject', 'Please install the "Group folders" app to be able to use automatically managed folders. {htmlLink}', { htmlLink }, null, { escape: false, sanitize: false })
 			default:


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
In this PR, an error message is added which will display if the `groupfolders` app is not supported with the integration OpenProject.

## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://community.openproject.org/projects/nextcloud-integration/work_packages/60683

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

![image](https://github.com/user-attachments/assets/aa2af8cf-144d-4f25-8b02-df18329e300f)




## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
