### PR TITLE
fix: disbale error message if NC Hub option is not selectable

### DIFF
--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -168,7 +168,8 @@
 					</NcCheckboxRadioSwitch>
 					<ErrorLabel
 						v-if="!hasEnabledSupportedOIDCApp"
-						:error="`${messagesFmt.appNotEnabledOrSupported('oidc')}. ${messagesFmt.minimumVersionRequired(getMinSupportedOIDCVersion)}`" />
+						:error="`${messagesFmt.appNotEnabledOrSupported('oidc')}. ${messagesFmt.minimumVersionRequired(getMinSupportedOIDCVersion)}`"
+						:disabled="disableNCHubUnsupportedHint" />
 					<NcCheckboxRadioSwitch
 						:checked.sync="authorizationSetting.SSOProviderType"
 						:disabled="!isOIDCAppInstalledAndEnabled || !isOIDCAppSupported"
@@ -926,6 +927,12 @@ export default {
 		isExternalSSOProvider() {
 			return this.authorizationSetting.SSOProviderType === SSO_PROVIDER_TYPE.external
 		},
+		disableNCHubUnsupportedHint() {
+			if (!this.hasEnabledSupportedOIDCApp && (this.formMode.SSOSettings === F_MODES.DISABLE || this.formMode.SSOSettings === F_MODES.NEW)) {
+				return true
+			}
+			return false
+		},
 	},
 	watch: {
 		'authorizationSetting.SSOProviderType'() {
@@ -936,7 +943,7 @@ export default {
 	},
 	created() {
 		this.init()
-		if (!this.hasEnabledSupportedOIDCApp && this.formMode.SSOSettings === F_MODES.NEW) {
+		if (!this.hasEnabledSupportedOIDCApp && (this.formMode.SSOSettings === F_MODES.DISABLE || this.formMode.SSOSettings === F_MODES.NEW)) {
 			this.authorizationSetting.SSOProviderType = SSO_PROVIDER_TYPE.external
 		}
 	},

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -928,8 +928,12 @@ export default {
 			return this.authorizationSetting.SSOProviderType === SSO_PROVIDER_TYPE.external
 		},
 		disableNCHubUnsupportedHint() {
-			if (!this.hasEnabledSupportedOIDCApp && (this.formMode.SSOSettings === F_MODES.DISABLE || this.formMode.SSOSettings === F_MODES.NEW)) {
-				return true
+			if (!this.hasEnabledSupportedOIDCApp) {
+				if (this.formMode.SSOSettings === F_MODES.DISABLE || this.formMode.SSOSettings === F_MODES.NEW) {
+					return true
+				} else if (this.isExternalSSOProvider) {
+					return true
+				}
 			}
 			return false
 		},

--- a/src/components/ErrorLabel.vue
+++ b/src/components/ErrorLabel.vue
@@ -3,7 +3,7 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <template>
-	<p class="error">
+	<p class="error" :disabled="disabled">
 		{{ error }}
 	</p>
 </template>
@@ -16,6 +16,10 @@ export default {
 			type: String,
 			required: true,
 		},
+		disabled: {
+			type: Boolean,
+			default: false,
+		},
 	},
 }
 </script>
@@ -23,5 +27,9 @@ export default {
 <style scoped lang="scss">
 .error {
 	color: var(--color-error);
+}
+
+.error[disabled] {
+	color: var(--color-text-maxcontrast);
 }
 </style>

--- a/tests/jest/components/AdminSettings.spec.js
+++ b/tests/jest/components/AdminSettings.spec.js
@@ -1416,6 +1416,50 @@ describe('AdminSettings.vue', () => {
 					)
 				})
 			})
+
+			describe('unsupported oidc app', () => {
+				beforeEach(async () => {
+					wrapper = getWrapper({
+						state: {
+							openproject_instance_url: 'http://openproject.com',
+							authorization_method: AUTH_METHOD.OIDC,
+							authorization_settings: {
+								oidc_provider: 'Nextcloud Hub',
+								targeted_audience_client_id: 'some-target-aud-client-id',
+								sso_provider_type: 'nextcloud_hub',
+							},
+							user_oidc_enabled: true,
+							user_oidc_supported: true,
+							apps: {
+								oidc: {
+									enabled: false,
+									supported: false,
+									minimum_version: appState.apps.oidc.minimum_version,
+								},
+							},
+						},
+					})
+					await wrapper.setData({
+						formMode: {
+							authorizationSetting: F_MODES.EDIT,
+							SSOSettings: F_MODES.EDIT,
+						},
+						isFormCompleted: { authorizationSetting: false },
+					})
+				})
+
+				it('should show app not supported error messages', () => {
+					const errorLabel = wrapper.find(errorLabelSelector)
+					const ncProviderRadio = wrapper.find(NCProviderTypeSelector)
+					const externalProviderRadio = wrapper.find(externalProviderTypeSelector)
+
+					expect(ncProviderRadio.attributes().disabled).toBe('true')
+					expect(ncProviderRadio.attributes().checked).toBe('nextcloud_hub')
+					expect(externalProviderRadio.attributes().disabled).toBe(undefined)
+					expect(errorLabel.attributes().error).toBe(`${messagesFmt.appNotEnabledOrSupported('oidc')}. ${messagesFmt.minimumVersionRequired('oidc')}`)
+					expect(errorLabel.attributes().disabled).toBe(undefined)
+				})
+			})
 		})
 
 		describe('edit mode, incomplete admin configuration', () => {
@@ -1724,6 +1768,7 @@ describe('AdminSettings.vue', () => {
 					expect(ncProviderRadio.attributes().checked).toBe('external')
 					expect(externalProviderRadio.attributes().disabled).toBe(undefined)
 					expect(errorLabel.attributes().error).toBe(`${messagesFmt.appNotEnabledOrSupported('oidc')}. ${messagesFmt.minimumVersionRequired('oidc')}`)
+					expect(errorLabel.attributes().disabled).toBe('true')
 				})
 			})
 		})


### PR DESCRIPTION
## Description
Disable error message if the oidc app is not enabled or unsupported and incomplete auth settings.

## Related Issue or Workpackage
- [WP#62209](https://community.openproject.org/wp/62209)

## Screenshots (if appropriate):
First setting | After completion of settings
--|--
![Screenshot from 2025-03-17 16-44-46](https://github.com/user-attachments/assets/44bc7445-35e2-4183-9118-94d73cd1ca59) | ![Screenshot from 2025-03-17 16-46-08](https://github.com/user-attachments/assets/731cd78e-7458-4c66-908e-5d3573be8147)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
