### PR TITLE
refactor: rename authorization to authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Show error when the user_oidc app not supported [#768](https://github.com/nextcloud/integration_openproject/pull/768)
 - Support setup with Nextcloud Hub [#778](https://github.com/nextcloud/integration_openproject/pull/778)
 
+### Changed
+
+- Rename admin settings labels: `Authorization` -> `Authentication` [#758](https://github.com/nextcloud/integration_openproject/pull/758)
+
 ## 2.8.1 - 2025-02-05
 
 ### Fixed

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -64,7 +64,7 @@
 		</div>
 		<div class="authorization-method">
 			<FormHeading index="2"
-				:title="t('integration_openproject', 'Authorization method')"
+				:title="t('integration_openproject', 'Authentication method')"
 				:is-complete="isAuthorizationMethodFormComplete"
 				:is-disabled="isAuthorizationFormInDisabledMode"
 				:is-dark-theme="isDarkTheme" />
@@ -108,7 +108,7 @@
 						<template #icon>
 							<PencilIcon :size="20" />
 						</template>
-						{{ t('integration_openproject', 'Edit authorization method') }}
+						{{ t('integration_openproject', 'Edit authentication method') }}
 					</NcButton>
 					<NcButton v-if="isAuthorizationFormInEditMode && authorizationMethod.currentAuthorizationMethodSelected !== null"
 						class="mr-2"
@@ -132,7 +132,7 @@
 		</div>
 		<div v-if="authorizationMethod.currentAuthorizationMethodSelected === authMethods.OIDC" class="authorization-settings">
 			<FormHeading index="3"
-				:title="t('integration_openproject', 'Authorization settings')"
+				:title="t('integration_openproject', 'Authentication settings')"
 				:is-complete="isAuthorizationSettingFormComplete"
 				:is-disabled="isAuthorizationSettingFormInDisabledMode"
 				:is-dark-theme="isDarkTheme"
@@ -226,7 +226,7 @@
 					<template #icon>
 						<PencilIcon :size="20" />
 					</template>
-					{{ t('integration_openproject', 'Edit authorization settings') }}
+					{{ t('integration_openproject', 'Edit authentication settings') }}
 				</NcButton>
 				<NcButton v-if="isSSOSettingsInEditMode"
 					class="mr-2"
@@ -822,7 +822,7 @@ export default {
 			return t('integration_openproject', 'Server-side encryption is active, but encryption for Group Folders is not yet enabled. To ensure secure storage of files in project folders, please follow the configuration steps in the {htmlLink}.', { htmlLink }, null, { escape: false, sanitize: false })
 		},
 		getAuthorizationMethodHintText() {
-			const linkText = t('integration_openproject', 'authorization methods you can use with OpenProject')
+			const linkText = t('integration_openproject', 'authentication methods you can use with OpenProject')
 			const htmlLink = `<a class="link" href="https://www.openproject.org/docs/system-admin-guide/integrations/nextcloud/#files-are-not-encrypted-when-using-nextcloud-server-side-encryption" target="_blank" title="${linkText}">${linkText}</a>`
 			return t('integration_openproject', 'Please read our guide on {htmlLink}.', { htmlLink }, null, { escape: false, sanitize: false })
 		},
@@ -830,7 +830,7 @@ export default {
 			const linkText = t('integration_openproject', 'User OIDC')
 			const url = this.appLinks.user_oidc.installLink
 			const htmlLink = `<a class="link" href="${url}" target="_blank" title="${linkText}">${linkText}</a>`
-			return t('integration_openproject', 'Please install the {htmlLink} app to be able to use Keycloak for authorization with OpenProject.', { htmlLink }, null, { escape: false, sanitize: false })
+			return t('integration_openproject', 'Please install the {htmlLink} app to be able to use Keycloak for authentication with OpenProject.', { htmlLink }, null, { escape: false, sanitize: false })
 		},
 		getConfigureOIDCHintText() {
 			const linkText = t('integration_openproject', 'OpenID Connect settings')
@@ -1275,8 +1275,8 @@ export default {
 			// open the confirmation dialog when only swithing back and forth between two authorization method
 			if (this.isAuthorizationFormInEditMode && this.authorizationMethod.currentAuthorizationMethodSelected !== null) {
 				await OC.dialogs.confirmDestructive(
-					t('integration_openproject', `If you proceed this method, you will have an ${this.authorizationMethod.authorizationMethodSet.toUpperCase()} based authorization configuration which will delete all the configuration setting for current ${this.authorizationMethod.currentAuthorizationMethodSelected.toUpperCase()} based authorization. You can switch back to it anytime.`),
-					t('integration_openproject', 'Switch Authorization Method'),
+					t('integration_openproject', `If you proceed this method, you will have an ${this.authorizationMethod.authorizationMethodSet.toUpperCase()} based authentication configuration which will delete all the configuration setting for current ${this.authorizationMethod.currentAuthorizationMethodSelected.toUpperCase()} based authentication. You can switch back to it anytime.`),
+					t('integration_openproject', 'Switch Authentication Method'),
 					{
 						type: OC.dialogs.YES_NO_BUTTONS,
 						confirm: t('integration_openproject', 'Yes, switch'),

--- a/src/constants/messages.js
+++ b/src/constants/messages.js
@@ -7,7 +7,7 @@ import { translate as t } from '@nextcloud/l10n'
 import APP_ID from './appID.js'
 
 export const messages = {
-	appRequiredForOIDCMethod: t(APP_ID, 'This app is required to use the OIDC authorization method'),
+	appRequiredForOIDCMethod: t(APP_ID, 'This app is required to use the OIDC authentication method'),
 	downloadAndEnableApp: t(APP_ID, 'Download and enable it'),
 	featureNotAvailable: t(APP_ID, 'This feature is not available for this user account'),
 	opConnectionUnauthorized: t(APP_ID, 'Unauthorized to connect to OpenProject'),

--- a/src/utils.js
+++ b/src/utils.js
@@ -79,8 +79,8 @@ export const AUTH_METHOD = {
 }
 
 export const AUTH_METHOD_LABEL = {
-	OAUTH2: t('integration_openproject', 'OAuth2 two-way authorization code flow'),
-	OIDC: t('integration_openproject', 'OpenID identity provider'),
+	OAUTH2: t('integration_openproject', 'Two-way OAuth 2.0 authorization code flow'),
+	OIDC: t('integration_openproject', 'Single-Sign-On through OpenID Connect Identity Provider'),
 }
 
 export const SSO_PROVIDER_TYPE = {

--- a/tests/jest/components/AdminSettings.spec.js
+++ b/tests/jest/components/AdminSettings.spec.js
@@ -1027,10 +1027,10 @@ describe('AdminSettings.vue', () => {
 								user_oidc_supported: true,
 							},
 						})
-						const expectedDialogMessage = 'If you proceed this method, you will have an OIDC based authorization configuration which will delete'
-							+ ' all the configuration setting for current OAUTH2 based authorization.'
+						const expectedDialogMessage = 'If you proceed this method, you will have an OIDC based authentication configuration which will delete'
+							+ ' all the configuration setting for current OAUTH2 based authentication.'
 							+ ' You can switch back to it anytime.'
-						const expectedDialogTitle = 'Switch Authorization Method'
+						const expectedDialogTitle = 'Switch Authentication Method'
 						const expectedDialogOpts = {
 							cancel: 'Cancel',
 							confirm: 'Yes, switch',
@@ -1110,10 +1110,10 @@ describe('AdminSettings.vue', () => {
 
 				describe('on trigger save button', () => {
 					it('should open auth method switch dialog confirm "Yes, Switch"', async () => {
-						const expectedDialogMessage = 'If you proceed this method, you will have an OAUTH2 based authorization configuration which will delete'
-							+ ' all the configuration setting for current OIDC based authorization.'
+						const expectedDialogMessage = 'If you proceed this method, you will have an OAUTH2 based authentication configuration which will delete'
+							+ ' all the configuration setting for current OIDC based authentication.'
 							+ ' You can switch back to it anytime.'
-						const expectedDialogTitle = 'Switch Authorization Method'
+						const expectedDialogTitle = 'Switch Authentication Method'
 						const expectedDialogOpts = {
 							cancel: 'Cancel',
 							confirm: 'Yes, switch',

--- a/tests/jest/components/__snapshots__/AdminSettings.spec.js.snap
+++ b/tests/jest/components/__snapshots__/AdminSettings.spec.js.snap
@@ -32,13 +32,13 @@ exports[`AdminSettings.vue OIDC authorization settings form complete: view mode 
     haserror="true"
     index="3"
     iscomplete="true"
-    title="Authorization settings"
+    title="Authentication settings"
   />
    
   <errornote-stub
     errorlink="http://localhost/settings/apps/files/user_oidc"
     errorlinklabel="Download and enable it"
-    errormessage="This app is required to use the OIDC authorization method"
+    errormessage="This app is required to use the OIDC authentication method"
     errortitle="The "{app}" app is not installed"
   />
    
@@ -74,7 +74,7 @@ exports[`AdminSettings.vue OIDC authorization settings form complete: view mode 
       type="secondary"
     >
       
-				Edit authorization settings
+				Edit authentication settings
 			
     </ncbutton-stub>
      
@@ -92,7 +92,7 @@ exports[`AdminSettings.vue OIDC authorization settings form complete: view mode 
   <formheading-stub
     index="3"
     iscomplete="true"
-    title="Authorization settings"
+    title="Authentication settings"
   />
    
   <!---->
@@ -129,7 +129,7 @@ exports[`AdminSettings.vue OIDC authorization settings form complete: view mode 
       type="secondary"
     >
       
-				Edit authorization settings
+				Edit authentication settings
 			
     </ncbutton-stub>
      
@@ -148,7 +148,7 @@ exports[`AdminSettings.vue OIDC authorization settings form complete: view mode 
     haserror="true"
     index="3"
     iscomplete="true"
-    title="Authorization settings"
+    title="Authentication settings"
   />
    
   <!---->
@@ -190,7 +190,7 @@ exports[`AdminSettings.vue OIDC authorization settings form complete: view mode 
       type="secondary"
     >
       
-				Edit authorization settings
+				Edit authentication settings
 			
     </ncbutton-stub>
      
@@ -208,7 +208,7 @@ exports[`AdminSettings.vue OIDC authorization settings form complete: view mode 
   <formheading-stub
     index="3"
     iscomplete="true"
-    title="Authorization settings"
+    title="Authentication settings"
   />
    
   <!---->
@@ -250,7 +250,7 @@ exports[`AdminSettings.vue OIDC authorization settings form complete: view mode 
       type="secondary"
     >
       
-				Edit authorization settings
+				Edit authentication settings
 			
     </ncbutton-stub>
      


### PR DESCRIPTION
## Description
Renamed settings label:
- `Authorization` -> `Authentication`
- `OAuth2 two-way authorization code flow` -> `Two-way OAuth 2.0 authorization code flow`
- `OpenID identity provider` -> `Single-Sign-On through OpenID Connect Identity Provider`

## Related Issue or Workpackage
- Fixes [WP#62248](https://community.openproject.org/wp/62248)

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Updated `CHANGELOG.md` file
