### PR TITLE
CI: use single valid comparison operator in condition

### DIFF
--- a/.github/workflows/shared_workflow.yml
+++ b/.github/workflows/shared_workflow.yml
@@ -259,7 +259,7 @@ jobs:
         run: |
           cd server/apps/integration_openproject
           # The following if block can be removed once Nextcloud no longer supports PHP 8.0
-          if [ "${{ matrix.phpVersion }}" == "8.0" ]; then
+          if [ "${{ matrix.phpVersion }}" = "8.0" ]; then
             make phpunitforphp8.0 || (echo "A few of the unit tests were unsuccessful. Rerunning the unit test once again......" && make phpunitforphp8.0)
           else
             make phpunit || (echo "A few of the unit tests were unsuccessful. Rerunning the unit test once again......" && make phpunit)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The CI was failing due to the use of an invalid comparison operator `==` in a shell script condition. sh only supports the single equals sign `=` for string comparison inside `[ ]`. So in this PR, we're making that adjustment to fix the operator and ensure CI runs successfully.



## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
