### PR TITLE
test: fix quota test steps order

### DIFF
--- a/tests/acceptance/features/api/directUpload.feature
+++ b/tests/acceptance/features/api/directUpload.feature
@@ -725,8 +725,8 @@ Feature: API endpoint for direct upload
 
 
   Scenario: Upload a file into a folder, exceeding the users quota
-    Given the quota of user "Carol" has been set to "9 B"
-    And user "Carol" has created folder "/forOP"
+    Given user "Carol" has created folder "/forOP"
+    And the quota of user "Carol" has been set to "9 B"
     And user "Carol" got a direct-upload token for "/forOP"
     When an anonymous user sends a multipart form data POST request to the "direct-upload/%last-created-direct-upload-token%" endpoint with:
       | file_name | file.txt   |
@@ -748,9 +748,9 @@ Feature: API endpoint for direct upload
 
   Scenario: Upload a file into a shared folder exceeding the quota of the user sharing the folder
     Given user "Brian" has been created
+    And user "Brian" has created folder "/toShare"
     And the quota of user "Carol" has been set to "10 B"
     And the quota of user "Brian" has been set to "9 B"
-    And user "Brian" has created folder "/toShare"
     And user "Brian" has shared folder "/toShare" with user "Carol" with "all" permissions
     And user "Carol" got a direct-upload token for "/toShare"
     When an anonymous user sends a multipart form data POST request to the "direct-upload/%last-created-direct-upload-token%" endpoint with:
@@ -773,9 +773,9 @@ Feature: API endpoint for direct upload
 
   Scenario: Upload a file into a shared folder exceeding the quota of sharee but not that of sharer
     Given user "Brian" has been created
+    And user "Brian" has created folder "/toShare"
     And the quota of user "Carol" has been set to "10 B"
     And the quota of user "Brian" has been set to "20 B"
-    And user "Brian" has created folder "/toShare"
     And user "Brian" has shared folder "/toShare" with user "Carol" with "all" permissions
     And user "Carol" got a direct-upload token for "/toShare"
     When an anonymous user sends a multipart form data POST request to the "direct-upload/%last-created-direct-upload-token%" endpoint with:


### PR DESCRIPTION
## Description
The PR https://github.com/nextcloud/server/pull/51750 has been merged and backported to other release branches (29, 30, 31). This change doesn't allow creating a folder after setting an insufficient quota. To create a folder at least `3584 bytes` is required.
Therefore, rearranging the order of the test steps fixes the failing tests.


## Related Issue or Workpackage
- [WP#62654](https://community.openproject.org/wp/62654)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
