### PR TITLE
feat: request token with scope

### DIFF
--- a/.github/workflows/shared_workflow.yml
+++ b/.github/workflows/shared_workflow.yml
@@ -10,7 +10,7 @@ on:
       nextcloud_versions:
         required: false
         type: string
-        default: "28 29 30 31 master"
+        default: "28 29 30 31"
       php_versions:
         required: false
         type: string

--- a/.github/workflows/shared_workflow.yml
+++ b/.github/workflows/shared_workflow.yml
@@ -10,7 +10,7 @@ on:
       nextcloud_versions:
         required: false
         type: string
-        default: "28 29 30 31"
+        default: "28 29 30 31 master"
       php_versions:
         required: false
         type: string
@@ -123,7 +123,7 @@ jobs:
           SQL: ${{ matrix.database }}
           SERVER_BRANCH: ${{ matrix.nextcloudVersion }}
           NEXTCLOUD_AUTOINSTALL: "Yes"
-          NEXTCLOUD_AUTOINSTALL_APPS: "integration_openproject"
+          NEXTCLOUD_AUTOINSTALL_APPS: "viewer activity groupfolders integration_openproject"
           NEXTCLOUD_TRUSTED_DOMAINS: nextcloud
           VIRTUAL_HOST: "nextcloud"
           WITH_REDIS: "YES"
@@ -261,7 +261,8 @@ jobs:
           if [ "${{matrix.nextcloudVersion}}" != "stable27" ]; then
             cp -r ../../user_oidc ../../oidc apps
             ./occ a:e user_oidc
-            ./occ a:e oidc
+            # enable app even if it is not compatible with the current server version
+            ./occ a:e -f oidc
           fi
 
       - name: PHP Unit Tests

--- a/.github/workflows/shared_workflow.yml
+++ b/.github/workflows/shared_workflow.yml
@@ -123,7 +123,7 @@ jobs:
           SQL: ${{ matrix.database }}
           SERVER_BRANCH: ${{ matrix.nextcloudVersion }}
           NEXTCLOUD_AUTOINSTALL: "Yes"
-          NEXTCLOUD_AUTOINSTALL_APPS: "viewer activity groupfolders integration_openproject"
+          NEXTCLOUD_AUTOINSTALL_APPS: "integration_openproject"
           NEXTCLOUD_TRUSTED_DOMAINS: nextcloud
           VIRTUAL_HOST: "nextcloud"
           WITH_REDIS: "YES"
@@ -189,6 +189,12 @@ jobs:
           repository: nextcloud/user_oidc
           path: user_oidc
 
+      - name: Checkout oidc app
+        uses: actions/checkout@v3
+        with:
+          repository: h2CK/oidc
+          path: oidc
+  
       - name: Checkout server (for phpunit and psalm)
         uses: actions/checkout@v3
         with:
@@ -253,8 +259,9 @@ jobs:
           cd server
           ./occ a:e groupfolders integration_openproject activity
           if [ "${{matrix.nextcloudVersion}}" != "stable27" ]; then
-            cp -r ../../user_oidc apps
+            cp -r ../../user_oidc ../../oidc apps
             ./occ a:e user_oidc
+            ./occ a:e oidc
           fi
 
       - name: PHP Unit Tests

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -52,6 +52,8 @@ use OCP\User\Events\UserChangedEvent;
 class Application extends App implements IBootstrap {
 	public const APP_ID = 'integration_openproject';
 	public const  OPEN_PROJECT_ENTITIES_NAME = 'OpenProject';
+	public const  OPEN_PROJECT_API_SCOPE = 'api_v3';
+
 	/**
 	 * @var mixed
 	 */

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -52,7 +52,7 @@ use OCP\User\Events\UserChangedEvent;
 class Application extends App implements IBootstrap {
 	public const APP_ID = 'integration_openproject';
 	public const  OPEN_PROJECT_ENTITIES_NAME = 'OpenProject';
-	public const  OPEN_PROJECT_API_SCOPE = 'api_v3';
+	public const  OPENPROJECT_API_SCOPES = ['api_v3'];
 
 	/**
 	 * @var mixed

--- a/lib/OIDCClientMapper.php
+++ b/lib/OIDCClientMapper.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2025 Jankari Tech Pvt. Ltd.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCA\OpenProject;
+
+use OCA\OIDCIdentityProvider\Db\Client;
+use OCA\OIDCIdentityProvider\Db\ClientMapper;
+use OCA\OIDCIdentityProvider\Db\RedirectUriMapper;
+use OCP\AppFramework\Services\IAppConfig;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IDBConnection;
+use OCP\Security\ISecureRandom;
+use Psr\Log\LoggerInterface;
+
+class OIDCClientMapper {
+	private ClientMapper $clientMapper;
+
+	public function __construct(
+		private LoggerInterface $logger,
+		private ISecureRandom $random,
+		private IDBConnection $db,
+		private ITimeFactory $timeFactory,
+		private IAppConfig $appConfig,
+	) {
+	}
+
+	/**
+	 * @param string $clientIdentifier
+	 *
+	 * @return Client
+	 */
+	public function getClient(string $clientIdentifier): ?Client {
+		/**
+		 * @psalm-suppress RedundantPropertyInitializationCheck
+		 */
+		if (!isset($this->clientMapper)) {
+			$this->clientMapper = new ClientMapper(
+				$this->db,
+				$this->timeFactory,
+				$this->appConfig,
+				new RedirectUriMapper($this->db, $this->timeFactory, $this->appConfig),
+				$this->random,
+				$this->logger,
+			);
+		}
+
+		return $this->clientMapper->getByIdentifier($clientIdentifier);
+	}
+}

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -66,7 +66,7 @@ class OpenProjectAPIService {
 	public const AUTH_METHOD_OAUTH = 'oauth2';
 	public const AUTH_METHOD_OIDC = 'oidc';
 	public const MIN_SUPPORTED_USER_OIDC_APP_VERSION = '7.1.0';
-	public const MIN_SUPPORTED_OIDC_APP_VERSION = '1.5.0';
+	public const MIN_SUPPORTED_OIDC_APP_VERSION = '1.6.0';
 	public const NEXTCLOUD_HUB_PROVIDER = "nextcloud_hub";
 
 	/**

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -20,6 +20,8 @@ use OC\Authentication\Token\IProvider;
 use OC\User\NoUserException;
 use OCA\AdminAudit\AuditLogger;
 use OCA\GroupFolders\Folder\FolderManager;
+use OCA\OIDCIdentityProvider\Exceptions\ClientNotFoundException;
+use OCA\OIDCIdentityProvider\Db\ClientMapper;
 use OCA\OpenProject\AppInfo\Application;
 use OCA\OpenProject\Exception\OpenprojectAvatarErrorException;
 use OCA\OpenProject\Exception\OpenprojectErrorException;
@@ -65,7 +67,7 @@ define('CACHE_TTL', 3600);
 class OpenProjectAPIService {
 	public const AUTH_METHOD_OAUTH = 'oauth2';
 	public const AUTH_METHOD_OIDC = 'oidc';
-	public const MIN_SUPPORTED_USER_OIDC_APP_VERSION = '7.1.0';
+	public const MIN_SUPPORTED_USER_OIDC_APP_VERSION = '7.2.0';
 	public const MIN_SUPPORTED_OIDC_APP_VERSION = '1.6.0';
 	public const NEXTCLOUD_HUB_PROVIDER = "nextcloud_hub";
 
@@ -169,6 +171,7 @@ class OpenProjectAPIService {
 		IManager $encryptionManager,
 		TokenEventFactory $tokenEventFactory,
 		IUserSession $userSession,
+		private ClientMapper $clientMapper,
 	) {
 		$this->appName = $appName;
 		$this->avatarManager = $avatarManager;
@@ -1595,6 +1598,26 @@ class OpenProjectAPIService {
 		}
 		// token expiration info
 		$this->logger->debug('Obtained a token that expires in ' . $token->getExpiresInFromNow());
+
+		$SSOProviderType = $this->config->getAppValue(Application::APP_ID, 'sso_provider_type');
+		if ($SSOProviderType === self::NEXTCLOUD_HUB_PROVIDER) {
+			$oidcClientId = $this->config->getAppValue(Application::APP_ID, 'targeted_audience_client_id');
+			$clientTokenType = '';
+			try {
+				$oidcClient = $this->clientMapper->getByIdentifier($oidcClientId);
+				$clientTokenType = $oidcClient->getTokenType();
+			} catch (ClientNotFoundException) {
+				$this->logger->error("Client '$oidcClientId' not found");
+			}
+			// OpenProject does not support opaque tokens.
+			// oidc client MUST be configured to return JWT token
+			if ($clientTokenType !== 'jwt') {
+				$this->logger->error(
+					"JWT access token is not enabled for oidc client '$oidcClientId' in OIDC provider app."
+					. " The opaque token is not supported by OpenProject."
+				);
+			}
+		}
 		return $token->getAccessToken();
 	}
 

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -1595,12 +1595,6 @@ class OpenProjectAPIService {
 		}
 		// token expiration info
 		$this->logger->debug('Obtained a token that expires in ' . $token->getExpiresInFromNow());
-
-		// with Nextcloud Hub setup, we need to use the id-token to authenticate OpenProject API
-		$SSOProviderType = $this->config->getAppValue(Application::APP_ID, 'sso_provider_type');
-		if ($SSOProviderType === self::NEXTCLOUD_HUB_PROVIDER) {
-			return $token->getIdToken();
-		}
 		return $token->getAccessToken();
 	}
 

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -20,14 +20,13 @@ use OC\Authentication\Token\IProvider;
 use OC\User\NoUserException;
 use OCA\AdminAudit\AuditLogger;
 use OCA\GroupFolders\Folder\FolderManager;
-use OCA\OIDCIdentityProvider\Db\ClientMapper as OIDCClientMapper;
-use OCA\OIDCIdentityProvider\Db\RedirectUriMapper;
 use OCA\OIDCIdentityProvider\Exceptions\ClientNotFoundException;
 use OCA\OpenProject\AppInfo\Application;
 use OCA\OpenProject\Exception\OpenprojectAvatarErrorException;
 use OCA\OpenProject\Exception\OpenprojectErrorException;
 use OCA\OpenProject\Exception\OpenprojectGroupfolderSetupConflictException;
 use OCA\OpenProject\Exception\OpenprojectResponseException;
+use OCA\OpenProject\OIDCClientMapper;
 use OCA\OpenProject\TokenEventFactory;
 use OCA\TermsOfService\Db\Entities\Signatory;
 use OCA\TermsOfService\Db\Mapper\SignatoryMapper;
@@ -36,8 +35,6 @@ use OCA\UserOIDC\Db\ProviderMapper;
 use OCA\UserOIDC\User\Backend as OIDCBackend;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Http;
-use OCP\AppFramework\Services\IAppConfig;
-use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Encryption\IManager;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\InvalidPathException;
@@ -174,8 +171,7 @@ class OpenProjectAPIService {
 		IManager $encryptionManager,
 		TokenEventFactory $tokenEventFactory,
 		IUserSession $userSession,
-		private ITimeFactory $timeFactory,
-		private IAppConfig $appConfig,
+		private OIDCClientMapper $oidcClientMapper,
 	) {
 		$this->appName = $appName;
 		$this->avatarManager = $avatarManager;
@@ -1608,15 +1604,7 @@ class OpenProjectAPIService {
 			$oidcClientId = $this->config->getAppValue(Application::APP_ID, 'targeted_audience_client_id');
 			$clientTokenType = '';
 			try {
-				$clientMapper = new OIDCClientMapper(
-					$this->db,
-					$this->timeFactory,
-					$this->appConfig,
-					new RedirectUriMapper($this->db, $this->timeFactory, $this->appConfig),
-					$this->random,
-					$this->logger,
-				);
-				$oidcClient = $clientMapper->getByIdentifier($oidcClientId);
+				$oidcClient = $this->oidcClientMapper->getClient($oidcClientId);
 				$clientTokenType = $oidcClient->getTokenType();
 			} catch (ClientNotFoundException) {
 				$this->logger->error("Client '$oidcClientId' not found");

--- a/lib/TokenEventFactory.php
+++ b/lib/TokenEventFactory.php
@@ -34,7 +34,7 @@ class TokenEventFactory {
 		// If the SSO provider is Nextcloud Hub,
 		// get token from internal IDP (oidc)
 		if ($SSOProviderType === OpenProjectAPIService::NEXTCLOUD_HUB_PROVIDER) {
-			return new InternalTokenEvent($targetAudience, Application::OPEN_PROJECT_API_SCOPE, $targetAudience);
+			return new InternalTokenEvent($targetAudience, Application::OPENPROJECT_API_SCOPES, $targetAudience);
 		}
 
 		// If the SSO provider is external and token exchange is disabled,
@@ -46,6 +46,6 @@ class TokenEventFactory {
 
 		// If the SSO provider is external and token exchange is enabled,
 		// exchange the token for targeted audience client
-		return new ExchangedTokenEvent($targetAudience, Application::OPEN_PROJECT_API_SCOPE);
+		return new ExchangedTokenEvent($targetAudience, Application::OPENPROJECT_API_SCOPES);
 	}
 }

--- a/lib/TokenEventFactory.php
+++ b/lib/TokenEventFactory.php
@@ -40,7 +40,8 @@ class TokenEventFactory {
 		// If the SSO provider is external and token exchange is disabled,
 		// get the login token
 		if (!$tokenExchange) {
-			return new ExternalTokenEvent(Application::OPEN_PROJECT_API_SCOPE);
+			// NOTE: cannot request new scopes with ExternalTokenEvent
+			return new ExternalTokenEvent();
 		}
 
 		// If the SSO provider is external and token exchange is enabled,

--- a/lib/TokenEventFactory.php
+++ b/lib/TokenEventFactory.php
@@ -34,17 +34,17 @@ class TokenEventFactory {
 		// If the SSO provider is Nextcloud Hub,
 		// get token from internal IDP (oidc)
 		if ($SSOProviderType === OpenProjectAPIService::NEXTCLOUD_HUB_PROVIDER) {
-			return new InternalTokenEvent($targetAudience);
+			return new InternalTokenEvent($targetAudience, Application::OPEN_PROJECT_API_SCOPE, $targetAudience);
 		}
 
 		// If the SSO provider is external and token exchange is disabled,
 		// get the login token
 		if (!$tokenExchange) {
-			return new ExternalTokenEvent();
+			return new ExternalTokenEvent(Application::OPEN_PROJECT_API_SCOPE);
 		}
 
 		// If the SSO provider is external and token exchange is enabled,
 		// exchange the token for targeted audience client
-		return new ExchangedTokenEvent($targetAudience);
+		return new ExchangedTokenEvent($targetAudience, Application::OPEN_PROJECT_API_SCOPE);
 	}
 }

--- a/psalm.xml
+++ b/psalm.xml
@@ -39,6 +39,10 @@
 				<referencedClass name="OCA\TermsOfService\Db\Mapper\SignatoryMapper" />
 				<referencedClass name="OCA\TermsOfService\Db\Entities\Signatory" />
 				<referencedClass name="OCA\TermsOfService\Db\Mapper\TermsMapper" />
+				<!-- these classes belong to the oidc app -->
+				<referencedClass name="OCA\OIDCIdentityProvider\Db\ClientMapper" />
+				<referencedClass name="OCA\OIDCIdentityProvider\Db\RedirectUriMapper" />
+				<referencedClass name="OCA\OIDCIdentityProvider\Exceptions\ClientNotFoundException" />
 				<!-- these classes belong to the user_oidc app, which isn't compulsory, so might not exist while running psalm -->
 				<referencedClass name="OCA\UserOIDC\Db\ProviderMapper" />
 				<referencedClass name="OCA\UserOIDC\Model\Token" />
@@ -99,6 +103,10 @@
 				<referencedClass name="OC\Http\Client\LocalAddressChecker"/>
 				<!-- these are classes form terms_of_service app, which isn't cloned while doing static code analysis -->
 				<referencedClass name="OCA\TermsOfService\Db\Mapper\SignatoryMapper" />
+				<!-- these classes belong to the oidc app -->
+				<referencedClass name="OCA\OIDCIdentityProvider\Db\ClientMapper" />
+				<referencedClass name="OCA\OIDCIdentityProvider\Db\RedirectUriMapper" />
+				<referencedClass name="OCA\OIDCIdentityProvider\Exceptions\ClientNotFoundException" />
 				<!-- these classes belong to the user_oidc app, which isn't compulsory, so might not exist while running psalm -->
 				<referencedClass name="OCA\UserOIDC\Model\Token" />
 				<referencedClass name="OCA\UserOIDC\Event\ExchangedTokenRequestedEvent" />

--- a/psalm.xml
+++ b/psalm.xml
@@ -40,6 +40,7 @@
 				<referencedClass name="OCA\TermsOfService\Db\Entities\Signatory" />
 				<referencedClass name="OCA\TermsOfService\Db\Mapper\TermsMapper" />
 				<!-- these classes belong to the oidc app -->
+				<referencedClass name="OCA\OIDCIdentityProvider\Db\Client" />
 				<referencedClass name="OCA\OIDCIdentityProvider\Db\ClientMapper" />
 				<referencedClass name="OCA\OIDCIdentityProvider\Db\RedirectUriMapper" />
 				<referencedClass name="OCA\OIDCIdentityProvider\Exceptions\ClientNotFoundException" />
@@ -104,6 +105,7 @@
 				<!-- these are classes form terms_of_service app, which isn't cloned while doing static code analysis -->
 				<referencedClass name="OCA\TermsOfService\Db\Mapper\SignatoryMapper" />
 				<!-- these classes belong to the oidc app -->
+				<referencedClass name="OCA\OIDCIdentityProvider\Db\Client" />
 				<referencedClass name="OCA\OIDCIdentityProvider\Db\ClientMapper" />
 				<referencedClass name="OCA\OIDCIdentityProvider\Db\RedirectUriMapper" />
 				<referencedClass name="OCA\OIDCIdentityProvider\Exceptions\ClientNotFoundException" />

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -585,7 +585,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 			'openproject_instance_url' => $this->pactMockServerConfig->getBaseUri()->__toString(),
 			'oidc_provider' => '',
 			'targeted_audience_client_id' => '',
-			'sso_provider_type' => OpenProjectAPIService::NEXTCLOUD_HUB_PROVIDER,
+			'sso_provider_type' => 'external',
 		];
 		$appValues = [];
 		foreach ($withValues as $key => $value) {
@@ -4260,6 +4260,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$configMock->method('getAppValue')
 			->willReturnMap($this->getAppValues([
 				'targeted_audience_client_id' => 'testclient',
+				'sso_provider_type' => OpenProjectAPIService::NEXTCLOUD_HUB_PROVIDER,
 			]));
 		$iManagerMock = $this->getMockBuilder(IManager::class)->getMock();
 		$iAppManagerMock = $this->getMockBuilder(IAppManager::class)->getMock();

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -18,6 +18,7 @@ use OC\Authentication\Token\IToken;
 use OC\Avatar\GuestAvatar;
 use OC\Http\Client\Client;
 use OCA\GroupFolders\Folder\FolderManager;
+use OCA\OIDCIdentityProvider\Db\ClientMapper;
 use OCA\OpenProject\AppInfo\Application;
 use OCA\OpenProject\Exception\OpenprojectErrorException;
 use OCA\OpenProject\Exception\OpenprojectResponseException;
@@ -682,6 +683,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 			'manager' => $this->createMock(IManager::class),
 			'tokenEventFactory' => $this->createMock(TokenEventFactory::class),
 			'userSession' => $this->createMock(IUserSession::class),
+			'clientMapper' => $this->createMock(ClientMapper::class)
 		];
 
 		// replace default mocks with manually passed in mocks

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -19,6 +19,7 @@ use OC\Avatar\GuestAvatar;
 use OC\Http\Client\Client;
 use OCA\GroupFolders\Folder\FolderManager;
 use OCA\OIDCIdentityProvider\Db\ClientMapper;
+use OCA\OIDCIdentityProvider\Db\RedirectUriMapper;
 use OCA\OpenProject\AppInfo\Application;
 use OCA\OpenProject\Exception\OpenprojectErrorException;
 use OCA\OpenProject\Exception\OpenprojectResponseException;
@@ -30,6 +31,8 @@ use OCA\UserOIDC\Model\Token;
 use OCA\UserOIDC\User\Backend as OIDCBackend;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Services\IAppConfig;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Encryption\IManager;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\IRootFolder;
@@ -683,7 +686,8 @@ class OpenProjectAPIServiceTest extends TestCase {
 			'manager' => $this->createMock(IManager::class),
 			'tokenEventFactory' => $this->createMock(TokenEventFactory::class),
 			'userSession' => $this->createMock(IUserSession::class),
-			'clientMapper' => $this->createMock(ClientMapper::class)
+			'timeFactory' => $this->createMock(ITimeFactory::class),
+			'appConfig' => $this->createMock(IAppConfig::class),
 		];
 
 		// replace default mocks with manually passed in mocks


### PR DESCRIPTION
## Description
Send a token requested event with `api_v3` scope.

>With `ExternalTokenRequestedEvent` (login token), it is not possible to request extra scope. For `ExternalTokenRequestedEvent` to include extra scopes, **required extra scopes MUST be added beforehand in the provider configuration**


Open Task:
- [x] bump `oidc` version: `1.6.0`
- [x] bump `user_oidc` app version: `7.2.0`

## Related Issue or Workpackage
- [WP#62620](https://community.openproject.org/wp/62620)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
