### PR TITLE
CI: add occ command to disable the share rate limit

### DIFF
--- a/.github/workflows/shared_workflow.yml
+++ b/.github/workflows/shared_workflow.yml
@@ -232,6 +232,8 @@ jobs:
           # user_oidc app
           composer install --no-interaction --prefer-dist --optimize-autoloader --working-dir=../user_oidc
           cd server && ./occ maintenance:install --admin-pass=admin
+          # Disable share rate limit protection
+          docker exec nextcloud /bin/bash -c 'occ config:system:set ratelimit.protection.enabled --value false --type bool'
 
       - name: PHP code analysis and linting
         run: |


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Recently, nextcloud added a new feature that limits share rate ([PR link](https://github.com/nextcloud/server/pull/50905))  . This caused some API tests to fail on CI. To fix this, the PR  disables the share rate limit during API testing on CI.

## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
