### PR TITLE
Remove myself from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @julien-nc @juliusknorr @individual-it @akabiru @ba1ash @dominic-braeunlein @Kharonus @lindenthal @nabim777 @psatyal @saw-jan @wielinde @NobodysNightmare
+* @julien-nc @individual-it @akabiru @ba1ash @dominic-braeunlein @Kharonus @lindenthal @nabim777 @psatyal @saw-jan @wielinde @NobodysNightmare


### PR DESCRIPTION
While I'm happy to review code from time if specific insights are needed where my feedback is wanted, having myself as a code owner here is nothing I can cope with given my current workload and rate of github notifications.

Therefore removing me to avoid getting notified about every PR.