### PR TITLE
chore: Rename group folder app to team folders

### DIFF
--- a/docs/setting_up_as_admin.md
+++ b/docs/setting_up_as_admin.md
@@ -20,9 +20,9 @@ To set up or update the integration following data needs to be provided:
 > Note:
 > - We can set up the integration with or without `project folders`
 > - To set up the integration without `project folders` we need to set data `setup_project_folder=false` and `setup_app_password=false`
-> - To set up the integration with `project folders` we need to set data `setup_project_folder=true` and `setup_app_password=true`, this will create a new user, group, and group folder named OpenProject if the system doesn't already have one or more of these present. Also, an application password will be provided for the user `OpenProject`
+> - To set up the integration with `project folders` we need to set data `setup_project_folder=true` and `setup_app_password=true`, this will create a new user, group, and team folder named OpenProject if the system doesn't already have one or more of these present. Also, an application password will be provided for the user `OpenProject`
 > - Once the `project folder` has already been set up, the created `OpenProject` user and group cannot be disabled or removed.
-> - If there is any error related to `OpenProject` user, group, group folders when setting up the whole integration or if the admin user wants to remove those entities then this [troubleshooting guide](https://www.openproject.org/docs/system-admin-guide/integrations/nextcloud/#troubleshooting) can be followed up on how to resolve it. 
+> - If there is any error related to `OpenProject` user, group, team folders when setting up the whole integration or if the admin user wants to remove those entities then this [troubleshooting guide](https://www.openproject.org/docs/system-admin-guide/integrations/nextcloud/#troubleshooting) can be followed up on how to resolve it. 
 
 
 1. **Set up the whole integration with a [POST] request**

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -1009,7 +1009,7 @@ class OpenProjectAPIService {
 	public function isSystemReadyForProjectFolderSetUp(): bool {
 		if ($this->userManager->userExists(Application::OPEN_PROJECT_ENTITIES_NAME) && $this->groupManager->groupExists(Application::OPEN_PROJECT_ENTITIES_NAME)) {
 			if (!$this->isGroupfoldersAppEnabled()) {
-				throw new \Exception('The "Group folders" app is not installed');
+				throw new \Exception('The "groupfolders" app is not installed');
 			}
 		}
 		if ($this->userManager->userExists(Application::OPEN_PROJECT_ENTITIES_NAME)) {
@@ -1017,10 +1017,10 @@ class OpenProjectAPIService {
 		} elseif ($this->groupManager->groupExists(Application::OPEN_PROJECT_ENTITIES_NAME)) {
 			throw new OpenprojectGroupfolderSetupConflictException('The group "'. Application::OPEN_PROJECT_ENTITIES_NAME .'" already exists');
 		} elseif (!$this->isGroupfoldersAppEnabled()) {
-			throw new \Exception('The "Group folders" app is not installed');
+			throw new \Exception('The "groupfolders" app is not installed');
 		} elseif ($this->isOpenProjectGroupfolderCreated()) {
 			throw new OpenprojectGroupfolderSetupConflictException(
-				'The group folder name "' .
+				'The team folder name "' .
 				Application::OPEN_PROJECT_ENTITIES_NAME .
 				'" already exists'
 			);

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -437,7 +437,7 @@
 						<b>{{ t('integration_openproject', 'OpenProject user, group and folder') }}</b>
 						<p class="project-folder-description">
 							{{
-								t('integration_openproject', 'For automatically managing project folders, this app needs to setup a special group folder, assigned to a group and managed by a user, each called "OpenProject".')
+								t('integration_openproject', 'For automatically managing project folders, this app needs to setup a special team folder, assigned to a group and managed by a user, each called "OpenProject".')
 							}} <br>
 							{{
 								t('integration_openproject', 'The app will never delete files or folders, even if you deactivate this later.')
@@ -485,7 +485,7 @@
 					</NcNoteCard>
 					<NcNoteCard v-else-if="showEncryptionWarningForGroupFolders" class="note-card" type="warning">
 						<p class="note-card--title">
-							<b>{{ t('integration_openproject', 'Encryption for the Group Folders App is not enabled.') }}</b>
+							<b>{{ t('integration_openproject', 'Encryption for the Team Folders App is not enabled.') }}</b>
 						</p>
 						<p class="note-card--warning-description" v-html="getGroupFoldersEncryptionWarningHint" /> <!-- eslint-disable-line vue/no-v-html -->
 					</NcNoteCard>
@@ -832,7 +832,7 @@ export default {
 		errorHintForProjectFolderConfigAlreadyExists() {
 			const linkText = t('integration_openproject', 'troubleshooting guide')
 			const htmlLink = `<a class="link" href="https://www.openproject.org/docs/system-admin-guide/integrations/nextcloud/#troubleshooting" target="_blank" title="${linkText}">${linkText}</a>`
-			return t('integration_openproject', 'Setting up the OpenProject user, group and group folder was not possible. Please check this {htmlLink} on how to resolve this situation.', { htmlLink }, null, { escape: false, sanitize: false })
+			return t('integration_openproject', 'Setting up the OpenProject user, group and team folder was not possible. Please check this {htmlLink} on how to resolve this situation.', { htmlLink }, null, { escape: false, sanitize: false })
 		},
 		getAdminAuditConfigurationHint() {
 			const linkTextForAdminAudit = t('integration_openproject', 'Admin Audit')
@@ -846,7 +846,7 @@ export default {
 		getGroupFoldersEncryptionWarningHint() {
 			const linkText = t('integration_openproject', 'documentation')
 			const htmlLink = `<a class="link" href="https://www.openproject.org/docs/system-admin-guide/integrations/nextcloud/#files-are-not-encrypted-when-using-nextcloud-server-side-encryption" target="_blank" title="${linkText}">${linkText}</a>`
-			return t('integration_openproject', 'Server-side encryption is active, but encryption for Group Folders is not yet enabled. To ensure secure storage of files in project folders, please follow the configuration steps in the {htmlLink}.', { htmlLink }, null, { escape: false, sanitize: false })
+			return t('integration_openproject', 'Server-side encryption is active, but encryption for Team Folders is not yet enabled. To ensure secure storage of files in project folders, please follow the configuration steps in the {htmlLink}.', { htmlLink }, null, { escape: false, sanitize: false })
 		},
 		getAuthorizationMethodHintText() {
 			const linkText = t('integration_openproject', 'authentication methods you can use with OpenProject')
@@ -1118,8 +1118,8 @@ export default {
 			const url = generateUrl('settings/apps/files/groupfolders')
 			const htmlLink = `<a class="link" href="${url}" target="_blank" title="${linkText}">${linkText}</a>`
 			switch (errorKey) {
-			case 'The "Group folders" app is not installed' :
-				return t('integration_openproject', 'Please install the "Group folders" app to be able to use automatically managed folders. {htmlLink}', { htmlLink }, null, { escape: false, sanitize: false })
+			case 'The "groupfolders" app is not installed' :
+				return t('integration_openproject', 'Please install the "groupfolders" app to be able to use automatically managed folders. {htmlLink}', { htmlLink }, null, { escape: false, sanitize: false })
 			default:
 				return this.errorHintForProjectFolderConfigAlreadyExists
 			}

--- a/tests/acceptance/features/api/capabilities.feature
+++ b/tests/acceptance/features/api/capabilities.feature
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 Feature: get capabilities of the app
 
-  Scenario: Get capabilities when group folder app is enabled
+  Scenario: Get capabilities when team folder app is enabled
     Given user "Carol" has been created
     When the administrator requests the nextcloud capabilities
     Then the HTTP status code should be "200"

--- a/tests/acceptance/features/api/getFileinfoByFileIDAPI.feature
+++ b/tests/acceptance/features/api/getFileinfoByFileIDAPI.feature
@@ -1308,12 +1308,12 @@ Feature: retrieve file information of a single file, using the file ID
       | read+create+update+share  | SRGNVCK                   | RGDNVCK               |
 
 
-  Scenario: get information of a group folder
+  Scenario: get information of a team folder
     Given user "Carol" has been created
     And group "grp1" has been created
     And user "Carol" has been added to the group "grp1"
-    And group folder "groupFolder" has been created
-    And  group "grp1" has been added to group folder "groupFolder"
+    And team folder "groupFolder" has been created
+    And  group "grp1" has been added to team folder "groupFolder"
     When user "Carol" gets the information of the folder "/groupFolder"
     Then the HTTP status code should be "200"
     And the ocs data of the response should match

--- a/tests/acceptance/features/api/getFilesinfoByFileIDsAPI.feature
+++ b/tests/acceptance/features/api/getFilesinfoByFileIDsAPI.feature
@@ -3,12 +3,12 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 Feature: retrieve information of multiple files using the file IDs
 
-  Scenario: get information of four files, group folders, one own, one received as share, one trashed, one not accessible
+  Scenario: get information of four files, team folders, one own, one received as share, one trashed, one not accessible
     Given user "Carol" has been created
     And group "grp1" has been created
     And user "Carol" has been added to the group "grp1"
-    And group folder "groupFolder" has been created
-    And  group "grp1" has been added to group folder "groupFolder"
+    And team folder "groupFolder" has been created
+    And  group "grp1" has been added to team folder "groupFolder"
     And user "Brian" has been created with display-name "Brian Adams"
     And user "Carol" has uploaded file with content "some data" to "file.txt"
     And user "Brian" has uploaded file with content "some data" to "fromBrian.txt"
@@ -20,7 +20,7 @@ Feature: retrieve information of multiple files using the file IDs
     And user "Carol" has emptied the trash-bin
     And user "Carol" has deleted file "trashed.txt"
     And user "Carol" has renamed file "/fromBrian.txt" to "/renamedByCarol.txt"
-    When user "Carol" gets the information of all files and group folder "groupFolder" created in this scenario
+    When user "Carol" gets the information of all files and team folder "groupFolder" created in this scenario
     Then the HTTP status code should be "200"
     And the ocs data of the response should match
     """"

--- a/tests/acceptance/features/api/setup.feature
+++ b/tests/acceptance/features/api/setup.feature
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 Feature: setup the integration through an API
 
-  Scenario: valid setup without group folder
+  Scenario: valid setup without team folder
     When the administrator sends a POST request to the "setup" endpoint with this data:
       """
       {
@@ -679,7 +679,7 @@ Feature: setup the integration through an API
     Then the HTTP status code should be "401"
 
 
-  Scenario: check version of uploaded file inside a group folder
+  Scenario: check version of uploaded file inside a team folder
     Given user "Carol" has been created
     And user "Carol" has been added to the group "OpenProject"
     And user "Carol" has created folder "/OpenProject/OpenProject/project-demo"
@@ -692,7 +692,7 @@ Feature: setup the integration through an API
     Then the HTTP status code should be 204
 
 
-  Scenario: check version of uploaded file after an update inside a group folder
+  Scenario: check version of uploaded file after an update inside a team folder
     Given user "Carol" has been created
     And user "Carol" has been added to the group "OpenProject"
     And user "OpenProject" has created folder "/OpenProject/OpenProject/project-test"

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -477,7 +477,7 @@ class FeatureContext implements Context {
 	}
 
 	/**
-	 * @When user :user gets the information of all files and group folder :groupFolder created in this scenario
+	 * @When user :user gets the information of all files and team folder :groupFolder created in this scenario
 	 */
 	public function userGetsTheInformationOfAllCreatedFiles(string $user, string $groupFolder): void {
 		$this->createdFiles[] = $this->getIdOfFileOrFolder($user, $groupFolder);

--- a/tests/acceptance/features/bootstrap/GroupfoldersContext.php
+++ b/tests/acceptance/features/bootstrap/GroupfoldersContext.php
@@ -23,7 +23,7 @@ class GroupfoldersContext implements Context {
 
 
 	/**
-	 * @Given group folder :folderName has been created
+	 * @Given team folder :folderName has been created
 	 */
 	public function groupFolderHasBeenCreated(string $folderName): void {
 		$fullUrl = $this->featureContext->getBaseUrl() .
@@ -54,7 +54,7 @@ class GroupfoldersContext implements Context {
 	}
 
 	/**
-	 * @Given group :group has been added to group folder :groupfolder
+	 * @Given group :group has been added to team folder :groupfolder
 	 */
 	public function groupHasBeenAddedToGroupFolder(string $group, string $groupfolder):void {
 		$groupfolderId = $this->createdGroupFolders[$groupfolder];

--- a/tests/jest/components/AdminSettings.spec.js
+++ b/tests/jest/components/AdminSettings.spec.js
@@ -2347,7 +2347,7 @@ describe('AdminSettings.vue', () => {
 					expect(completeProjectFolderSetupWithGroupFolderButton.text()).toBe('Setup OpenProject user, group and folder')
 				})
 
-				it('should show button text label "Complete without group folder setup" when the switch is "off"', async () => {
+				it('should show button text label "Complete without team folder setup" when the switch is "off"', async () => {
 					const wrapper = getMountedWrapper({
 						state: {
 							openproject_instance_url: 'http://openproject.com',
@@ -2359,7 +2359,7 @@ describe('AdminSettings.vue', () => {
 								nextcloud_client_secret: 'some-nc-client-secret-here',
 							},
 							fresh_project_folder_setup: true,
-							// group folder is already not set up
+							// team folder is already not set up
 							project_folder_info: {
 								status: false,
 							},
@@ -2379,7 +2379,7 @@ describe('AdminSettings.vue', () => {
 					expect(completeWithoutProjectFolderSetupButton.text()).toBe('Complete without project folders')
 				})
 
-				describe('on trigger "Complete without group folder setup"', () => {
+				describe('on trigger "Complete without team folder setup"', () => {
 					let wrapper = {}
 					let saveOPOptionsSpy
 					beforeEach(async () => {
@@ -2452,7 +2452,7 @@ describe('AdminSettings.vue', () => {
 					})
 				})
 
-				// test for error while setting up the group folder
+				// test for error while setting up the team folder
 				describe('trigger on "Setup OpenProject user, group and folder" button', () => {
 					beforeEach(async () => {
 						axios.put.mockReset()
@@ -2462,31 +2462,31 @@ describe('AdminSettings.vue', () => {
 					describe('upon failure', () => {
 						it.each([
 							[
-								'should set the project folder error message and error details when group folders app is not enabled',
+								'should set the project folder error message and error details when team folders app is not enabled',
 								{
-									error: 'The "Group folders" app is not installed',
-									expectedErrorDetailsMessage: 'Please install the "Group folders" app to be able to use automatically managed folders. {htmlLink}',
+									error: 'The "groupfolders" app is not installed',
+									expectedErrorDetailsMessage: 'Please install the "groupfolders" app to be able to use automatically managed folders. {htmlLink}',
 								},
 							],
 							[
 								'should set the user already exists error message and error details when user already exists',
 								{
 									error: 'The user "OpenProject" already exists',
-									expectedErrorDetailsMessage: 'Setting up the OpenProject user, group and group folder was not possible. Please check this troubleshooting guide on how to resolve this situation.',
+									expectedErrorDetailsMessage: 'Setting up the OpenProject user, group and team folder was not possible. Please check this troubleshooting guide on how to resolve this situation.',
 								},
 							],
 							[
-								'should set the group folder name already exists error message and error details when group folder already exists',
+								'should set the team folder name already exists error message and error details when team folder already exists',
 								{
-									error: 'The group folder name "OpenProject" already exists',
-									expectedErrorDetailsMessage: 'Setting up the OpenProject user, group and group folder was not possible. Please check this troubleshooting guide on how to resolve this situation.',
+									error: 'The team folder name "OpenProject" already exists',
+									expectedErrorDetailsMessage: 'Setting up the OpenProject user, group and team folder was not possible. Please check this troubleshooting guide on how to resolve this situation.',
 								},
 							],
 							[
 								'should set the group already exists error message and error details when group already exists',
 								{
 									error: 'The group "OpenProject" already exists',
-									expectedErrorDetailsMessage: 'Setting up the OpenProject user, group and group folder was not possible. Please check this troubleshooting guide on how to resolve this situation.',
+									expectedErrorDetailsMessage: 'Setting up the OpenProject user, group and team folder was not possible. Please check this troubleshooting guide on how to resolve this situation.',
 								},
 							],
 
@@ -2531,9 +2531,9 @@ describe('AdminSettings.vue', () => {
 
 							const saveOPOptionsSpy = jest.spyOn(axios, 'put')
 								.mockImplementationOnce(() => Promise.reject(err))
-							if (expectedErrorDetails.error !== 'The "Group folders" app is not installed') {
+							if (expectedErrorDetails.error !== 'The "groupfolders" app is not installed') {
 								jest.spyOn(wrapper.vm, 'projectFolderSetUpErrorMessageDescription').mockReturnValue(
-									'Setting up the OpenProject user, group and group folder was not possible. Please check this troubleshooting guide on how to resolve this situation.',
+									'Setting up the OpenProject user, group and team folder was not possible. Please check this troubleshooting guide on how to resolve this situation.',
 								)
 							}
 							const completeProjectFolderSetupWithGroupFolderButton = wrapper.find(selectors.completeProjectFolderSetupWithGroupFolderButton)
@@ -2735,7 +2735,7 @@ describe('AdminSettings.vue', () => {
 								nextcloud_client_secret: 'some-nc-client-secret-here',
 							},
 							fresh_project_folder_setup: false,
-							// group folder is already not set up
+							// team folder is already not set up
 							project_folder_info: {
 								status: false,
 							},
@@ -2830,7 +2830,7 @@ describe('AdminSettings.vue', () => {
 						expect(wrapper.vm.oPUserAppPassword).toBe('opUserPassword')
 					})
 
-					it('should show button label as "Complete without group folder setup" when switch is "off" ', async () => {
+					it('should show button label as "Complete without team folder setup" when switch is "off" ', async () => {
 						const projectFolderSetupSwitchButton = wrapper.find(selectors.projectFolderSetupSwitch)
 						await projectFolderSetupSwitchButton.trigger('click')
 						const completeWithoutProjectFolderSetupButton = wrapper.find(selectors.completeWithoutProjectFolderSetupButton)
@@ -2938,17 +2938,17 @@ describe('AdminSettings.vue', () => {
 		})
 		it.each([
 			[
-				'should set the project folder error message and error details when group folders app is not enabled',
+				'should set the project folder error message and error details when team folders app is not enabled',
 				{
-					error: 'The "Group folders" app is not installed',
-					expectedErrorDetailsMessage: 'Please install the "Group folders" app to be able to use automatically managed folders. {htmlLink}',
+					error: 'The "groupfolders" app is not installed',
+					expectedErrorDetailsMessage: 'Please install the "groupfolders" app to be able to use automatically managed folders. {htmlLink}',
 				},
 			],
 			[
 				'should set the user already exists error message and error details when user already exists',
 				{
 					error: 'The user "OpenProject" already exists',
-					expectedErrorDetailsMessage: 'Setting up the OpenProject user, group and group folder was not possible.',
+					expectedErrorDetailsMessage: 'Setting up the OpenProject user, group and team folder was not possible.',
 				},
 			],
 		])('%s', async (name, expectedErrorDetails) => {
@@ -2977,7 +2977,7 @@ describe('AdminSettings.vue', () => {
 			const projectFolderErrorMessage = wrapper.find(selectors.projectFolderErrorMessage)
 			const projectFolderErrorMessageDetails = wrapper.find(selectors.projectFolderErrorMessageDetails)
 			expect(projectFolderErrorMessage.text()).toBe(expectedErrorDetails.error)
-			if (expectedErrorDetails.error !== 'The "Group folders" app is not installed') {
+			if (expectedErrorDetails.error !== 'The "groupfolders" app is not installed') {
 				expect(projectFolderErrorMessageDetails.text()).toContain(expectedErrorDetails.expectedErrorDetailsMessage)
 			} else {
 				expect(projectFolderErrorMessageDetails.text()).toBe(expectedErrorDetails.expectedErrorDetailsMessage)

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -2505,11 +2505,11 @@ class OpenProjectAPIServiceTest extends TestCase {
 	 */
 	public function isSystemReadyForGroupFolderSetUpUserOrGroupExistsExceptionDataProvider(): array {
 		return [
-			[true, true, false, false,'The "Group folders" app is not installed'],
+			[true, true, false, false,'The "groupfolders" app is not installed'],
 			[true, false, false, false,'The user "'. Application::OPEN_PROJECT_ENTITIES_NAME .'" already exists'],
 			[false, true, false, false,'The group "'. Application::OPEN_PROJECT_ENTITIES_NAME .'" already exists'],
-			[false, false, false, false,'The "Group folders" app is not installed'],
-			[false, false, true, true,'The group folder name "'. Application::OPEN_PROJECT_ENTITIES_NAME .'" already exists'],
+			[false, false, false, false,'The "groupfolders" app is not installed'],
+			[false, false, true, true,'The team folder name "'. Application::OPEN_PROJECT_ENTITIES_NAME .'" already exists'],
 		];
 	}
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
There is a change in the Group Folders app: "Group folders" have been renamed to "Team folders".
PR link: https://github.com/nextcloud/groupfolders/pull/3536

In this PR, the "group folder" name is updated to "team folder".



## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://community.openproject.org/projects/nextcloud-integration/work_packages/63603

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
