### PR TITLE
Chore: replace deprecated OC_Helper::uploadLimit() with Util::uploadLimit()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - Rename admin settings labels: `Authorization` -> `Authentication` [#758](https://github.com/nextcloud/integration_openproject/pull/758)
+- Replaced deprecated method "\OC_Helper::uploadLimit()" with "\OCP\Util::uploadLimit()" [#825](https://github.com/nextcloud/integration_openproject/pull/825)
 
 ## 2.8.1 - 2025-02-05
 

--- a/lib/Controller/DirectUploadController.php
+++ b/lib/Controller/DirectUploadController.php
@@ -275,7 +275,7 @@ class DirectUploadController extends ApiController {
 		} catch (OpenprojectFileNotUploadedException $e) {
 			return new DataResponse([
 				'error' => $this->l->t($e->getMessage()),
-				'upload_limit' => \OC_Helper::uploadLimit()
+				'upload_limit' => \OCP\Util::uploadLimit()
 			], Http::STATUS_REQUEST_ENTITY_TOO_LARGE);
 		} catch (InvalidContentException $e) { // files_antivirus throws this exception
 			return new DataResponse([


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The deprecated `\OC_Helper::uploadLimit()` method, which simply wrapped `\OCP\Util::uploadLimit()`, has now been removed in nextcloud master ([PR link](https://github.com/nextcloud/server/pull/52912)).
Method `(\OCP\Util::uploadLimit())` is available in stable versions `28`, `29`, `30`, and `31`. It works the same way as `\OC_Helper::uploadLimit()` , so it won't affect any of the Nextcloud versions we currently support.
So, in this PR, directly using `\OCP\Util::uploadLimit()`

## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
