### PR TITLE
fix: persist authentication settings form values after save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-### Fixes
+### Fixed
 
 - Fix authentication-method not being set after upgrading to 2.9.0 [#833](https://github.com/nextcloud/integration_openproject/pull/833)
+<<<<<<< HEAD
 - Fix OpenProject icon for proper rendering [#835](https://github.com/nextcloud/integration_openproject/pull/834)
+=======
+- Persist authentication settings form state after save [#827](https://github.com/nextcloud/integration_openproject/pull/827)
+>>>>>>> cfddf7fa (chore: add changelog entry)
 
 ## 2.9.0 - 2025-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fix authentication-method not being set after upgrading to 2.9.0 [#833](https://github.com/nextcloud/integration_openproject/pull/833)
-<<<<<<< HEAD
 - Fix OpenProject icon for proper rendering [#835](https://github.com/nextcloud/integration_openproject/pull/834)
-=======
 - Persist authentication settings form state after save [#827](https://github.com/nextcloud/integration_openproject/pull/827)
->>>>>>> cfddf7fa (chore: add changelog entry)
 
 ## 2.9.0 - 2025-05-21
 

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -1139,8 +1139,10 @@ export default {
 			this.formMode.authorizationSetting = F_MODES.VIEW
 			this.formMode.SSOSettings = F_MODES.VIEW
 			this.isFormCompleted.authorizationSetting = true
-			this.authorizationSetting.currentTargetedAudienceClientIdSelected = this.state.authorization_settings.targeted_audience_client_id
 			this.authorizationSetting.SSOProviderType = this.state.authorization_settings.sso_provider_type
+			this.authorizationSetting.currentOIDCProviderSelected = this.state.authorization_settings.oidc_provider
+			this.authorizationSetting.enableTokenExchange = this.state.authorization_settings.token_exchange
+			this.authorizationSetting.currentTargetedAudienceClientIdSelected = this.state.authorization_settings.targeted_audience_client_id
 		},
 		setServerHostFormToEditMode() {
 			this.formMode.server = F_MODES.EDIT
@@ -1300,6 +1302,10 @@ export default {
 					this.isProjectFolderSwitchEnabled = true
 					this.textLabelProjectFolderSetupButton = this.buttonTextLabel.completeWithProjectFolderSetup
 				}
+				this.state.authorization_settings.sso_provider_type = this.authorizationSetting.SSOProviderType
+				this.state.authorization_settings.oidc_provider = this.authorizationSetting.currentOIDCProviderSelected
+				this.state.authorization_settings.token_exchange = this.authorizationSetting.enableTokenExchange
+				this.state.authorization_settings.targeted_audience_client_id = this.authorizationSetting.currentTargetedAudienceClientIdSelected
 			}
 			this.loadingAuthorizationMethodForm = false
 		},

--- a/tests/jest/components/AdminSettings.spec.js
+++ b/tests/jest/components/AdminSettings.spec.js
@@ -1783,11 +1783,15 @@ describe('AdminSettings.vue', () => {
 									...state,
 									user_oidc_enabled: true,
 									user_oidc_supported: true,
+									authorization_settings: {},
 								},
+							 })
+							 await wrapper.setData({
 								authorizationSetting: {
 									SSOProviderType: 'external',
 								},
 							 })
+							await localVue.nextTick()
 							const providerInputField = wrapper.find(selectors.providerInput)
 							await providerInputField.setValue('key')
 							await localVue.nextTick()

--- a/tests/jest/components/AdminSettings.spec.js
+++ b/tests/jest/components/AdminSettings.spec.js
@@ -1770,6 +1770,10 @@ describe('AdminSettings.vue', () => {
 								},
 							)
 							expect(wrapper.vm.formMode.authorizationSetting).toBe(F_MODES.VIEW)
+							expect(wrapper.vm.state.authorization_settings.sso_provider_type).toBe('nextcloud_hub')
+							expect(wrapper.vm.state.authorization_settings.oidc_provider).toBe('Nextcloud Hub')
+							expect(wrapper.vm.state.authorization_settings.token_exchange).toBe(false)
+							expect(wrapper.vm.state.authorization_settings.targeted_audience_client_id).toBe('openproject')
 						})
 					})
 
@@ -1822,6 +1826,10 @@ describe('AdminSettings.vue', () => {
 								},
 							)
 							expect(wrapper.vm.formMode.authorizationSetting).toBe(F_MODES.VIEW)
+							expect(wrapper.vm.state.authorization_settings.sso_provider_type).toBe('external')
+							expect(wrapper.vm.state.authorization_settings.oidc_provider).toBe('keycloak')
+							expect(wrapper.vm.state.authorization_settings.token_exchange).toBe(false)
+							expect(wrapper.vm.state.authorization_settings.targeted_audience_client_id).toBe(null)
 						})
 					})
 				})


### PR DESCRIPTION
## Description
Persist the authentication settings form values after saving the form. The saved values are then displayed in the form view mode

## Related Issue or Workpackage
- Fixes https://community.openproject.org/wp/64269

## Screenshots (if appropriate):
![Screenshot from 2025-05-28 14-57-40](https://github.com/user-attachments/assets/a6a7b054-4eee-41a2-abe6-a7c1a37b203b) | ![Screenshot from 2025-05-28 14-58-03](https://github.com/user-attachments/assets/f40625cf-0a71-4c0f-9e1f-44b57b92e5b0)
--|--
![Screenshot from 2025-05-28 14-57-53](https://github.com/user-attachments/assets/ebd31296-7137-4a79-98e6-00f172054a13) |

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Updated `CHANGELOG.md` file
