### PR TITLE
ci: drop nc 28 and 29 CI pipelines

### DIFF
--- a/.github/workflows/nighlty-ci-release-branch.yml
+++ b/.github/workflows/nighlty-ci-release-branch.yml
@@ -15,4 +15,4 @@ jobs:
     secrets: inherit
     with:
       branch: release/2.9
-      nextcloud_versions: "28 29 30 31"
+      nextcloud_versions: "30 31"

--- a/.github/workflows/shared_workflow.yml
+++ b/.github/workflows/shared_workflow.yml
@@ -10,7 +10,7 @@ on:
       nextcloud_versions:
         required: false
         type: string
-        default: "28 29 30 31"
+        default: "30 31"
       php_versions:
         required: false
         type: string


### PR DESCRIPTION
## Description
drop nc 28 and 29 CI pipelines

## Related Issue or Workpackage
- Closes [WP#64202](https://community.openproject.org/wp/64202)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
