### PR TITLE
fix: set correct authentication-method if there is existing complete oauth2 setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-### Added
+### Fixes
+
+- Fix authentication-method not being set after upgrading to 2.9.0 [#833](https://github.com/nextcloud/integration_openproject/pull/833)
 
 ## 2.9.0 - 2025-05-21
 

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -54,7 +54,7 @@ class Admin implements ISettings {
 	public function getForm(): TemplateResponse {
 		$clientID = $this->config->getAppValue(Application::APP_ID, 'openproject_client_id');
 		$clientSecret = $this->config->getAppValue(Application::APP_ID, 'openproject_client_secret');
-		$oauthUrl = $this->config->getAppValue(Application::APP_ID, 'openproject_instance_url');
+		$opUrl = $this->config->getAppValue(Application::APP_ID, 'openproject_instance_url');
 
 		// get automatically created NC oauth client for OP
 		$clientInfo = null;
@@ -77,10 +77,14 @@ class Admin implements ISettings {
 		}
 
 		$adminConfig = [
+			// admin settings form
+			'openproject_instance_url' => $opUrl,
+			'authorization_method' => $authenticationMethod,
+			// oauth2 form configs
 			'openproject_client_id' => $clientID,
 			'openproject_client_secret' => $clientSecret,
-			'openproject_instance_url' => $oauthUrl,
-			'authorization_method' => $authenticationMethod,
+			'nc_oauth_client' => $clientInfo,
+			// oidc form configs
 			'authorization_settings' => [
 				'oidc_provider' => $this->config->getAppValue(Application::APP_ID, 'oidc_provider', ''),
 				'targeted_audience_client_id' => $this->config->getAppValue(
@@ -89,12 +93,14 @@ class Admin implements ISettings {
 				'sso_provider_type' => $this->config->getAppValue(Application::APP_ID, 'sso_provider_type', ''),
 				'token_exchange' => \boolval($this->config->getAppValue(Application::APP_ID, 'token_exchange')),
 			],
-			'nc_oauth_client' => $clientInfo,
+			// project folder form configs
+			'fresh_project_folder_setup' => $this->config->getAppValue(Application::APP_ID, 'fresh_project_folder_setup', '0') === '1',
+			'project_folder_info' => $projectFolderStatusInformation,
+			'app_password_set' => $this->openProjectAPIService->hasAppPassword(),
+			// general form configs
 			'default_enable_navigation' => $this->config->getAppValue(Application::APP_ID, 'default_enable_navigation', '0') === '1',
 			'default_enable_unified_search' => $this->config->getAppValue(Application::APP_ID, 'default_enable_unified_search', '0') === '1',
-			'app_password_set' => $this->openProjectAPIService->hasAppPassword(),
-			'project_folder_info' => $projectFolderStatusInformation,
-			'fresh_project_folder_setup' => $this->config->getAppValue(Application::APP_ID, 'fresh_project_folder_setup', '0') === '1',
+			// other states
 			'all_terms_of_services_signed' => $isAllTermsOfServiceSignedForUserOpenProject,
 			'admin_audit_configuration_correct' => $isAdminAuditConfigurationSetUpCorrectly,
 			'encryption_info' => [

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -71,7 +71,7 @@ class Admin implements ISettings {
 		// set 'authorization_method' to Oauth2 if authorization_method is not set
 		// and there is existing complete Oauth2 setup
 		$authenticationMethod = $this->config->getAppValue(Application::APP_ID, 'authorization_method', '');
-		if (!$authenticationMethod && $this->openProjectAPIService->isAdminConfigOkForOauth2($this->config)) {
+		if (!$authenticationMethod && OpenProjectAPIService::isAdminConfigOkForOauth2($this->config)) {
 			$authenticationMethod = OpenProjectAPIService::AUTH_METHOD_OAUTH;
 			$this->config->setAppValue(Application::APP_ID, 'authorization_method', $authenticationMethod);
 		}

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -68,7 +68,8 @@ class Admin implements ISettings {
 		$isAdminAuditConfigurationSetUpCorrectly = $this->openProjectAPIService->isAdminAuditConfigSetCorrectly();
 
 		// NOTE: for migration compatibility
-		// set 'authorization_method' to Oauth2 if authorization_method is not set and there is existing Oauth2
+		// set 'authorization_method' to Oauth2 if authorization_method is not set
+		// and there is existing complete Oauth2 setup
 		$authenticationMethod = $this->config->getAppValue(Application::APP_ID, 'authorization_method', '');
 		if (!$authenticationMethod && $this->openProjectAPIService->isAdminConfigOkForOauth2($this->config)){
 			$authenticationMethod = OpenProjectAPIService::AUTH_METHOD_OAUTH;

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -71,7 +71,7 @@ class Admin implements ISettings {
 		// set 'authorization_method' to Oauth2 if authorization_method is not set
 		// and there is existing complete Oauth2 setup
 		$authenticationMethod = $this->config->getAppValue(Application::APP_ID, 'authorization_method', '');
-		if (!$authenticationMethod && $this->openProjectAPIService->isAdminConfigOkForOauth2($this->config)){
+		if (!$authenticationMethod && $this->openProjectAPIService->isAdminConfigOkForOauth2($this->config)) {
 			$authenticationMethod = OpenProjectAPIService::AUTH_METHOD_OAUTH;
 			$this->config->setAppValue(Application::APP_ID, 'authorization_method', $authenticationMethod);
 		}

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -67,11 +67,18 @@ class Admin implements ISettings {
 		$isAllTermsOfServiceSignedForUserOpenProject = $this->openProjectAPIService->isAllTermsOfServiceSignedForUserOpenProject();
 		$isAdminAuditConfigurationSetUpCorrectly = $this->openProjectAPIService->isAdminAuditConfigSetCorrectly();
 
+		// NOTE: for migration compatibility
+		// set 'authorization_method' to Oauth2 if authorization_method is not set and there is existing Oauth2
+		$authenticationMethod = $this->config->getAppValue(Application::APP_ID, 'authorization_method', '');
+		if (!$authenticationMethod && $this->openProjectAPIService->isAdminConfigOkForOauth2($this->config)){
+			$authenticationMethod = OpenProjectAPIService::AUTH_METHOD_OAUTH;
+		}
+
 		$adminConfig = [
 			'openproject_client_id' => $clientID,
 			'openproject_client_secret' => $clientSecret,
 			'openproject_instance_url' => $oauthUrl,
-			'authorization_method' => $this->config->getAppValue(Application::APP_ID, 'authorization_method', ''),
+			'authorization_method' => $authenticationMethod,
 			'authorization_settings' => [
 				'oidc_provider' => $this->config->getAppValue(Application::APP_ID, 'oidc_provider', ''),
 				'targeted_audience_client_id' => $this->config->getAppValue(

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -73,6 +73,7 @@ class Admin implements ISettings {
 		$authenticationMethod = $this->config->getAppValue(Application::APP_ID, 'authorization_method', '');
 		if (!$authenticationMethod && $this->openProjectAPIService->isAdminConfigOkForOauth2($this->config)){
 			$authenticationMethod = OpenProjectAPIService::AUTH_METHOD_OAUTH;
+			$this->config->setAppValue(Application::APP_ID, 'authorization_method', $authenticationMethod);
 		}
 
 		$adminConfig = [

--- a/tests/lib/Settings/AdminTest.php
+++ b/tests/lib/Settings/AdminTest.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2025 Jankari Tech Pvt. Ltd.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\OpenProject\Settings;
+
+use OCA\OpenProject\AppInfo\Application;
+use OCA\OpenProject\Service\OauthService;
+use OCA\OpenProject\Service\OpenProjectAPIService;
+use OCA\OpenProject\Service\SettingsService;
+use OCP\AppFramework\Services\IInitialState;
+use OCP\IConfig;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class AdminTest extends TestCase {
+	private Admin $setting;
+	private MockObject|IConfig $config;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->config = $this->createMock(IConfig::class);
+		$initialState = $this->createMock(IInitialState::class);
+		$oauthService = $this->createMock(OauthService::class);
+		$openProjectService = $this->createMock(OpenProjectAPIService::class);
+		$this->setting = new Admin($this->config, $oauthService, $openProjectService, $initialState);
+	}
+
+	/**
+	 * @return array<mixed>
+	 */
+	public function dataTestGetForm(): array {
+		return [
+			"initial admin config" => [
+				"config" => [
+					"openproject_instance_url" => "",
+					"authorization_method" => "",
+					"openproject_client_id" => "",
+					"openproject_client_secret" => "",
+				],
+				"setupWithOauth" => false,
+			],
+			"incomplete admin config" => [
+				"config" => [
+					"openproject_instance_url" => "http://op.local.test",
+					"authorization_method" => "",
+					"openproject_client_id" => "",
+					"openproject_client_secret" => "",
+				],
+				"setupWithOauth" => false,
+			],
+			"complete oauth2 admin config with unset authorization_method" => [
+				"config" => [
+					"openproject_instance_url" => "http://op.local.test",
+					"authorization_method" => "",
+					"openproject_client_id" => "openproject",
+					"openproject_client_secret" => "op-secret",
+				],
+				"setupWithOauth" => true,
+			],
+			"complete oauth2 admin config with correct authorization_method" => [
+				"config" => [
+					"openproject_instance_url" => "http://op.local.test",
+					"authorization_method" => SettingsService::AUTH_METHOD_OAUTH,
+					"openproject_client_id" => "openproject",
+					"openproject_client_secret" => "op-secret",
+				],
+				"setupWithOauth" => true,
+			],
+			"complete oidc admin config" => [
+				"config" => [
+					"openproject_instance_url" => "http://op.local.test",
+					"authorization_method" => SettingsService::AUTH_METHOD_OIDC,
+				],
+				"setupWithOauth" => false,
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider dataTestGetForm
+	 *
+	 * @param array $config
+	 * @param bool $setupWithOauth
+	 * @return void
+	 */
+	public function testGetForm(array $config, bool $setupWithOauth): void {
+		$appValues = [];
+		foreach ($config as $key => $value) {
+			$appValues[] = [Application::APP_ID, $key, '', $value];
+		}
+		$this->config
+			->method('getAppValue')
+			->willReturnMap($appValues);
+
+		if (!$config['authorization_method'] && $setupWithOauth) {
+			$this->config->expects($this->once())
+				->method('setAppValue')
+				->with(Application::APP_ID, 'authorization_method', SettingsService::AUTH_METHOD_OAUTH);
+		} else {
+			$this->config->expects($this->never())->method('setAppValue');
+		}
+		$this->setting->getForm();
+	}
+}


### PR DESCRIPTION
## Description
If `authorization_method` is not set and there is oauth2 complete setup, then set `authorization_method` to `oauth2`.

## Related Issue or Workpackage
- Fixes [#64314](https://community.openproject.org/wp/64314)

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [x] Updated `CHANGELOG.md` file
