### PR TITLE
Chore: fix the nextcloud app version compare in oidc setup script file

### DIFF
--- a/integration_oidc_setup.sh
+++ b/integration_oidc_setup.sh
@@ -254,7 +254,7 @@ ncCheckAppVersion() {
   if [ -z "$nc_app_version" ]; then
     log_error "Failed to get the version information for the '$app_name' app. This might indicate that the app does not exist or is not enabled"
     exit 1
-  elif [[ "$nc_app_version" < "$app_min_version" ]]; then
+  elif ! printf "%s\n%s" "$app_min_version" "$nc_app_version" | sort -VC; then
     log_error "This script requires $app_name apps Version greater than or equal to '$app_min_version' but found version '$nc_app_version'"
     exit 1
   fi


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Currently, on [integration_oidc_setup.sh](https://github.com/nextcloud/integration_openproject/compare/fixed/oidc-setup-script?expand=1#diff-7684bd1add12c1647b7d47d090752e0c90e4058e435c2028e45d8ce93f0eed06), there is an issue with the nextcloud version comparison when the version included characters such as `2.10.0-alpha1`.  Because of this, 2.10.0-alpha1 was seen as smaller than 2.9.0, which caused an error.
This PR fixes the issue by using a better way for comparing version numbers, which works correctly even when their include characters.

## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
