### PR TITLE
fix: do not trigger user-info request for oauth2 auth-method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fix initial set-up with external IDP without token exchange [#848](https://github.com/nextcloud/integration_openproject/pull/848)
 - Consume groupfolder properties as an array [#851](https://github.com/nextcloud/integration_openproject/pull/851)
+- Prevent unnecessary API calls when the account is setup via OAuth2 but not connected[#856](https://github.com/nextcloud/integration_openproject/pull/856)
 
 ## 2.9.1 - 2025-06-13
 

--- a/lib/Listener/LoadSidebarScript.php
+++ b/lib/Listener/LoadSidebarScript.php
@@ -91,7 +91,6 @@ class LoadSidebarScript implements IEventListener {
 
 	public function handle(Event $event): void {
 		$authorizationMethod = $this->config->getAppValue(Application::APP_ID, 'authorization_method', '');
-		$accessToken = null;
 		// When user is non oidc based or there is some error when getting token for the targeted client
 		// then we need to hide the oidc based connection for the user
 		// so this check is required

--- a/lib/Listener/LoadSidebarScript.php
+++ b/lib/Listener/LoadSidebarScript.php
@@ -90,14 +90,18 @@ class LoadSidebarScript implements IEventListener {
 	}
 
 	public function handle(Event $event): void {
+		$authorizationMethod = $this->config->getAppValue(Application::APP_ID, 'authorization_method', '');
+		$accessToken = null;
 		// When user is non oidc based or there is some error when getting token for the targeted client
 		// then we need to hide the oidc based connection for the user
 		// so this check is required
-		if (
-			$this->config->getAppValue(Application::APP_ID, 'authorization_method', '') === OpenProjectAPIService::AUTH_METHOD_OIDC &&
-			!$this->openProjectAPIService->getOIDCToken()
-		) {
-			return;
+		if ($authorizationMethod === OpenProjectAPIService::AUTH_METHOD_OIDC) {
+			$accessToken = $this->openProjectAPIService->getOIDCToken();
+			if (!$accessToken) {
+				return;
+			}
+			// for 'oidc' the user info needs to be set (once token has been exchanged)
+			$this->openProjectAPIService->setUserInfoForOidcBasedAuth($this->userId);
 		}
 		if (!($event instanceof LoadSidebar)) {
 			return;
@@ -114,7 +118,6 @@ class LoadSidebarScript implements IEventListener {
 		}
 		Util::addStyle(Application::APP_ID, 'tab');
 
-		$authorizationMethod = $this->config->getAppValue(Application::APP_ID, 'authorization_method', '');
 		$this->initialStateService->provideInitialState('authorization_method', $authorizationMethod);
 		$this->initialStateService->provideInitialState(
 			'openproject-url', $this->config->getAppValue(Application::APP_ID, 'openproject_instance_url')
@@ -122,11 +125,6 @@ class LoadSidebarScript implements IEventListener {
 		$this->initialStateService->provideInitialState(
 			'admin_config_ok', OpenProjectAPIService::isAdminConfigOk($this->config)
 		);
-
-		// authorization method can be either a 'oidc' or 'oauth2'
-		// for 'oidc' the user info needs to be set (once token has been exchanged)
-		$this->openProjectAPIService->setUserInfoForOidcBasedAuth($this->userId);
-
 		// for 'oauth2' state to be loaded
 		$this->initialStateService->provideInitialState(
 			'oauth-connection-result', $this->oauthConnectionResult

--- a/tests/lib/Listener/LoadSidebarScriptTest.php
+++ b/tests/lib/Listener/LoadSidebarScriptTest.php
@@ -14,13 +14,14 @@ use OCP\AppFramework\Services\IInitialState;
 use OCP\EventDispatcher\Event;
 use OCP\IConfig;
 use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class LoadSidebarScriptTest extends TestCase {
 	private LoadSidebarScript $listener;
-	private IConfig $config;
-	private IInitialState $initialState;
-	private OpenProjectAPIService $openProjectService;
+	private MockObject|IConfig $config;
+	private MockObject|IInitialState $initialState;
+	private MockObject|OpenProjectAPIService $openProjectService;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -87,7 +88,7 @@ class LoadSidebarScriptTest extends TestCase {
 		} else {
 			$this->openProjectService->expects($this->never())
 				->method('setUserInfoForOidcBasedAuth');
-		}	
+		}
 
 		$this->listener->handle($this->createMock(Event::class));
 	}

--- a/tests/lib/Listener/LoadSidebarScriptTest.php
+++ b/tests/lib/Listener/LoadSidebarScriptTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2025 Jankari Tech Pvt. Ltd.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\OpenProject\Listener;
+
+use OCA\OpenProject\AppInfo\Application;
+use OCA\OpenProject\Service\OpenProjectAPIService;
+use OCP\App\IAppManager;
+use OCP\AppFramework\Services\IInitialState;
+use OCP\EventDispatcher\Event;
+use OCP\IConfig;
+use OCP\IUserSession;
+use PHPUnit\Framework\TestCase;
+
+class LoadSidebarScriptTest extends TestCase {
+	private LoadSidebarScript $listener;
+	private IConfig $config;
+	private IInitialState $initialState;
+	private OpenProjectAPIService $openProjectService;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->config = $this->createMock(IConfig::class);
+		$this->initialState = $this->createMock(IInitialState::class);
+		$userSession = $this->createMock(IUserSession::class);
+		$appManager = $this->createMock(IAppManager::class);
+		$this->openProjectService = $this->createMock(OpenProjectAPIService::class);
+		$this->listener = new LoadSidebarScript(
+			$this->initialState,
+			$this->config,
+			$userSession,
+			$appManager,
+			$this->openProjectService,
+			'testUser'
+		);
+	}
+
+	/**
+	 * @return array<mixed>
+	 */
+	public function dataTestHandle(): array {
+		return [
+			[
+				'authMethod' => OpenProjectAPIService::AUTH_METHOD_OAUTH,
+				'accessToken' => '',
+			],
+			[
+				'authMethod' => OpenProjectAPIService::AUTH_METHOD_OIDC,
+				'accessToken' => 'access-token',
+			],
+			[
+				'authMethod' => OpenProjectAPIService::AUTH_METHOD_OIDC,
+				'accessToken' => '',
+			],
+			[
+				'authMethod' => '',
+				'accessToken' => '',
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider dataTestHandle
+	 *
+	 * @param string $authMethod
+	 * @param string $accessToken
+	 *
+	 * @return void
+	 */
+	public function testHandle(string $authMethod, string $accessToken) {
+		$this->config
+			->method('getAppValue')
+			->willReturnMap([
+				[Application::APP_ID, 'authorization_method', '', $authMethod],
+			]);
+		$this->openProjectService->method('getOIDCToken')
+			->willReturn($accessToken);
+
+		if ($authMethod === OpenProjectAPIService::AUTH_METHOD_OIDC && $accessToken) {
+			$this->openProjectService->expects($this->once())
+			->method('setUserInfoForOidcBasedAuth')
+			->with('testUser');
+		} else {
+			$this->openProjectService->expects($this->never())
+				->method('setUserInfoForOidcBasedAuth');
+		}	
+
+		$this->listener->handle($this->createMock(Event::class));
+	}
+}


### PR DESCRIPTION
## Description
We were calling `get-user-info` method meant to be for OIDC auth-method only, even for OAuth2 auth-method. This led to an unnecessary API call to OpenProject. 

## Related Issue or Workpackage
- Fixes [64874](https://community.openproject.org/wp/64874)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [x] Updated `CHANGELOG.md` file
