### PR TITLE
fix: add migration file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Prevent unnecessary API calls when the account is setup via OAuth2 but not connected[#856](https://github.com/nextcloud/integration_openproject/pull/856)
 - Fix next form not being loaded after saving OpenProject client settings [#857](https://github.com/nextcloud/integration_openproject/pull/857)
 - Avoid checking user_oidc app when set up with OAuth2 [#855](https://github.com/nextcloud/integration_openproject/pull/855)
+- Fix missing "Connect to OpenProject" button after upgrading from 2.8 [#858](https://github.com/nextcloud/integration_openproject/pull/858)
 
 ## 2.9.1 - 2025-06-13
 

--- a/lib/Migration/Version2900Date20250718065820.php
+++ b/lib/Migration/Version2900Date20250718065820.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\OpenProject\Migration;
+
+use Closure;
+use OCA\OpenProject\AppInfo\Application;
+use OCA\OpenProject\Service\OpenProjectAPIService;
+use OCP\DB\ISchemaWrapper;
+use OCP\IConfig;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+use Override;
+
+class Version2900Date20250718065820 extends SimpleMigrationStep {
+	public function __construct(private IConfig $config) {
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	#[Override]
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		// set 'authorization_method' to Oauth2 if authorization_method is not set
+		// and there is existing complete Oauth2 setup
+		$authenticationMethod = $this->config->getAppValue(Application::APP_ID, 'authorization_method', '');
+		$opClientId = $this->config->getAppValue(Application::APP_ID, 'openproject_client_id');
+		$opClientSecret = $this->config->getAppValue(Application::APP_ID, 'openproject_client_secret');
+		$ncClientId = $this->config->getAppValue(Application::APP_ID, 'nc_oauth_client_id');
+
+		$hasCompleteOAuthSetup = OpenProjectAPIService::isCommonAdminConfigOk($this->config) &&
+			!(empty($opClientId) || empty($opClientSecret) || empty($ncClientId));
+
+		if (!$authenticationMethod && $hasCompleteOAuthSetup) {
+			$this->config->setAppValue(Application::APP_ID, 'authorization_method', OpenProjectAPIService::AUTH_METHOD_OAUTH);
+		}
+
+		return null;
+	}
+}

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -915,7 +915,9 @@ class OpenProjectAPIService {
 		}
 
 		$authMethod = $config->getAppValue(Application::APP_ID, 'authorization_method');
-		if ($authMethod !== self::AUTH_METHOD_OAUTH) {
+		// NOTE: For backwards compability, check the auth method only if provided
+		// version: 2.8 -> 2.9
+		if ($authMethod && $authMethod !== self::AUTH_METHOD_OAUTH) {
 			return false;
 		}
 

--- a/tests/lib/Controller/ConfigControllerTest.php
+++ b/tests/lib/Controller/ConfigControllerTest.php
@@ -999,18 +999,49 @@ class ConfigControllerTest extends TestCase {
 		$oauthServiceMock = $this->createMock(OauthService::class);
 		$oauthSettingsControllerMock = $this->createMock('OCA\OAuth2\Controller\SettingsController');
 
-		$configMock
-			->method('getAppValue')
-			->willReturnMap([
-				[Application::APP_ID, 'openproject_instance_url', '', $oldAdminConfig['openproject_instance_url']],
-				[Application::APP_ID, 'authorization_method', '', $oldAdminConfig['authorization_method']],
-				[Application::APP_ID, 'openproject_client_id', '', $oldAdminConfig['openproject_client_id']],
-				[Application::APP_ID, 'openproject_client_secret', '', $oldAdminConfig['openproject_client_secret']],
-				[Application::APP_ID, 'oidc_provider', '', ''],
-				[Application::APP_ID, 'targeted_audience_client_id', '', ''],
-				[Application::APP_ID, 'nc_oauth_client_id', '', 'nc-client-id'],
-				[Application::APP_ID, 'oPOAuthTokenRevokeStatus', '', ''],
-			]);
+		if ($mode === "reset") {
+			$configMock
+				->expects($this->exactly(3))
+				->method('deleteAppValue')
+				->withConsecutive(
+					['integration_openproject', 'nc_oauth_client_id'],
+					['integration_openproject', 'oPOAuthTokenRevokeStatus'],
+					['integration_openproject', 'oPOAuthTokenRevokeStatus'],
+				);
+			$configMock
+				->method('getAppValue')
+				->willReturnMap([
+					[Application::APP_ID, 'openproject_instance_url', '', $oldAdminConfig['openproject_instance_url']],
+					[Application::APP_ID, 'authorization_method', '', ''],
+					[Application::APP_ID, 'openproject_client_id', '', $oldAdminConfig['openproject_client_id']],
+					[Application::APP_ID, 'openproject_client_secret', '', $oldAdminConfig['openproject_client_secret']],
+					[Application::APP_ID, 'oidc_provider', '', ''],
+					[Application::APP_ID, 'targeted_audience_client_id', '', ''],
+					[Application::APP_ID, 'nc_oauth_client_id', '', 'nc-client-id'],
+					[Application::APP_ID, 'oPOAuthTokenRevokeStatus', '', ''],
+				]);
+		} else {
+			$configMock
+				->expects($this->exactly(2))
+				->method('deleteAppValue')
+				->withConsecutive(
+					['integration_openproject', 'oPOAuthTokenRevokeStatus'],
+					['integration_openproject', 'oPOAuthTokenRevokeStatus'],
+				);
+			$configMock
+				->method('getAppValue')
+				->willReturnMap([
+					[Application::APP_ID, 'openproject_instance_url', '', $oldAdminConfig['openproject_instance_url']],
+					[Application::APP_ID, 'authorization_method', '', $oldAdminConfig['authorization_method']],
+					[Application::APP_ID, 'openproject_client_id', '', $oldAdminConfig['openproject_client_id']],
+					[Application::APP_ID, 'openproject_client_secret', '', $oldAdminConfig['openproject_client_secret']],
+					[Application::APP_ID, 'oidc_provider', '', ''],
+					[Application::APP_ID, 'targeted_audience_client_id', '', ''],
+					[Application::APP_ID, 'nc_oauth_client_id', '', 'nc-client-id'],
+					[Application::APP_ID, 'oPOAuthTokenRevokeStatus', '', ''],
+				]);
+		}
+
 		$configMock
 			->method('setAppValue')
 			->withConsecutive(
@@ -1056,14 +1087,6 @@ class ConfigControllerTest extends TestCase {
 				[$this->user1->getUID(), 'integration_openproject', 'user_name'],
 				[$this->user1->getUID(), 'integration_openproject', 'refresh_token'],
 			);
-		$configMock
-			->expects($this->exactly(2))
-			->method('deleteAppValue')
-			->withConsecutive(
-				['integration_openproject', 'oPOAuthTokenRevokeStatus'],
-				['integration_openproject', 'oPOAuthTokenRevokeStatus'],
-			);
-
 
 		$constructArgs = $this->getConfigControllerConstructArgs([
 			'config' => $configMock,

--- a/tests/lib/Controller/ConfigControllerTest.php
+++ b/tests/lib/Controller/ConfigControllerTest.php
@@ -517,32 +517,14 @@ class ConfigControllerTest extends TestCase {
 			);
 		$configMock
 			->method('getAppValue')
-			->withConsecutive(
-				['integration_openproject', 'openproject_instance_url', ''],
-				['integration_openproject', 'authorization_method', ''],
-				['integration_openproject', 'openproject_client_id'],
-				['integration_openproject', 'openproject_client_secret'],
-				['integration_openproject', 'nc_oauth_client_id', ''],
-				['integration_openproject', 'oPOAuthTokenRevokeStatus', ''],
-				['integration_openproject', 'authorization_method'],
-				['integration_openproject', 'openproject_instance_url'],
-				['integration_openproject', 'fresh_project_folder_setup'],
-				['integration_openproject', 'openproject_client_id'],
-				['integration_openproject', 'openproject_client_secret'],
-			)
-			->willReturnOnConsecutiveCalls(
-				'http://localhost:3000',
-				OpenProjectAPIService::AUTH_METHOD_OAUTH,
-				'',
-				'',
-				'123',
-				'',
-				OpenProjectAPIService::AUTH_METHOD_OAUTH,
-				$credsToUpdate['openproject_instance_url'],
-				false,
-				$credsToUpdate['openproject_client_id'],
-				$credsToUpdate['openproject_client_secret'],
-			);
+			->willReturnMap([
+				[Application::APP_ID, 'openproject_instance_url', '', $credsToUpdate['openproject_instance_url']],
+				[Application::APP_ID, 'authorization_method', '', OpenProjectAPIService::AUTH_METHOD_OAUTH],
+				[Application::APP_ID, 'openproject_client_id', '', $credsToUpdate['openproject_client_id']],
+				[Application::APP_ID, 'openproject_client_secret', '', $credsToUpdate['openproject_client_secret']],
+				[Application::APP_ID, 'nc_oauth_client_id', '', '123'],
+				[Application::APP_ID, 'oPOAuthTokenRevokeStatus', '', ''],
+			]);
 		$apiService = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -632,39 +614,14 @@ class ConfigControllerTest extends TestCase {
 			);
 		$configMock
 			->method('getAppValue')
-			->withConsecutive(
-				['integration_openproject', 'openproject_instance_url', ''],
-				['integration_openproject', 'authorization_method', ''],
-				['integration_openproject', 'oidc_provider'],
-				['integration_openproject', 'targeted_audience_client_id'],
-				['integration_openproject', 'nc_oauth_client_id', ''],
-				['integration_openproject', 'oPOAuthTokenRevokeStatus', ''],
-				['integration_openproject', 'authorization_method'],
-				['integration_openproject', 'openproject_instance_url'],
-				['integration_openproject', 'fresh_project_folder_setup'],
-				['integration_openproject', 'oidc_provider'],
-				['integration_openproject', 'sso_provider_type'],
-				['integration_openproject', 'targeted_audience_client_id'],
-				['integration_openproject', 'token_exchange'],
-				['integration_openproject', 'openproject_instance_url']
-			)
-			->willReturnOnConsecutiveCalls(
-				'http://localhost:3000',
-				OpenProjectAPIService::AUTH_METHOD_OAUTH,
-				'',
-				'',
-				'123',
-				'',
-				OpenProjectAPIService::AUTH_METHOD_OIDC,
-				$credsToUpdate['openproject_instance_url'],
-				false,
-				$credsToUpdate['oidc_provider'],
-				SettingsService::NEXTCLOUDHUB_OIDC_PROVIDER_TYPE,
-				$credsToUpdate['targeted_audience_client_id'],
-				true,
-				$credsToUpdate['openproject_instance_url']
-
-			);
+			->willReturnMap([
+				[Application::APP_ID, 'openproject_instance_url', '', $credsToUpdate['openproject_instance_url']],
+				[Application::APP_ID, 'authorization_method', '', OpenProjectAPIService::AUTH_METHOD_OIDC],
+				[Application::APP_ID, 'oidc_provider', '', $credsToUpdate['oidc_provider']],
+				[Application::APP_ID, 'sso_provider_type', '', SettingsService::NEXTCLOUDHUB_OIDC_PROVIDER_TYPE],
+				[Application::APP_ID, 'targeted_audience_client_id', '', $credsToUpdate['targeted_audience_client_id']],
+				[Application::APP_ID, 'oPOAuthTokenRevokeStatus', '', ''],
+			]);
 		$apiService = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -1042,75 +999,18 @@ class ConfigControllerTest extends TestCase {
 		$oauthServiceMock = $this->createMock(OauthService::class);
 		$oauthSettingsControllerMock = $this->createMock('OCA\OAuth2\Controller\SettingsController');
 
-		if ($mode === 'reset') {
-			$configMock
-				->method('getAppValue')
-				->withConsecutive(
-					['integration_openproject', 'openproject_instance_url', ''],
-					['integration_openproject', 'authorization_method', ''],
-					['integration_openproject', 'openproject_client_id', ''],
-					['integration_openproject', 'openproject_client_secret', ''],
-					['integration_openproject', 'nc_oauth_client_id', ''],
-					['integration_openproject', 'oPOAuthTokenRevokeStatus', ''], // for user
-					['integration_openproject', 'oPOAuthTokenRevokeStatus', ''], // for user
-					['integration_openproject', 'oPOAuthTokenRevokeStatus', ''], // for the last check
-					['integration_openproject', 'authorization_method', ''],
-					['integration_openproject', 'openproject_instance_url'],
-					['integration_openproject', 'fresh_project_folder_setup'],
-					['integration_openproject', 'openproject_client_id'],
-					['integration_openproject', 'openproject_client_secret'],
-					['integration_openproject', 'openproject_instance_url'],
-				)
-				->willReturnOnConsecutiveCalls(
-					$oldAdminConfig['openproject_instance_url'],
-					$oldAdminConfig['authorization_method'],
-					$oldAdminConfig['openproject_client_id'],
-					$oldAdminConfig['openproject_client_secret'],
-					'',
-					'',
-					'',
-					'',
-					OpenProjectAPIService::AUTH_METHOD_OAUTH,
-					$newConfig['openproject_instance_url'],
-					false,
-					$newConfig['openproject_client_id'],
-					$newConfig['openproject_client_secret'],
-					$newConfig['openproject_instance_url'],
-				);
-		} else {
-			$configMock
-				->method('getAppValue')
-				->withConsecutive(
-					['integration_openproject', 'openproject_instance_url', ''],
-					['integration_openproject', 'authorization_method', ''],
-					['integration_openproject', 'openproject_client_id', ''],
-					['integration_openproject', 'openproject_client_secret', ''],
-					['integration_openproject', 'oPOAuthTokenRevokeStatus', ''],
-					['integration_openproject', 'oPOAuthTokenRevokeStatus', ''],
-					['integration_openproject', 'oPOAuthTokenRevokeStatus', ''],
-					['integration_openproject', 'authorization_method', ''],
-					['integration_openproject', 'openproject_instance_url'],
-					['integration_openproject', 'fresh_project_folder_setup'],
-					['integration_openproject', 'openproject_client_id'],
-					['integration_openproject', 'openproject_client_secret'],
-					['integration_openproject', 'openproject_instance_url'],
-				)
-				->willReturnOnConsecutiveCalls(
-					$oldAdminConfig['openproject_instance_url'],
-					$oldAdminConfig['authorization_method'],
-					$oldAdminConfig['openproject_client_id'],
-					$oldAdminConfig['openproject_client_secret'],
-					'',
-					'',
-					'',
-					OpenProjectAPIService::AUTH_METHOD_OAUTH,
-					$newConfig['openproject_instance_url'],
-					false,
-					$newConfig['openproject_client_id'],
-					$newConfig['openproject_client_secret'],
-					$newConfig['openproject_instance_url'],
-				);
-		}
+		$configMock
+			->method('getAppValue')
+			->willReturnMap([
+				[Application::APP_ID, 'openproject_instance_url', '', $oldAdminConfig['openproject_instance_url']],
+				[Application::APP_ID, 'authorization_method', '', $oldAdminConfig['authorization_method']],
+				[Application::APP_ID, 'openproject_client_id', '', $oldAdminConfig['openproject_client_id']],
+				[Application::APP_ID, 'openproject_client_secret', '', $oldAdminConfig['openproject_client_secret']],
+				[Application::APP_ID, 'oidc_provider', '', ''],
+				[Application::APP_ID, 'targeted_audience_client_id', '', ''],
+				[Application::APP_ID, 'nc_oauth_client_id', '', 'nc-client-id'],
+				[Application::APP_ID, 'oPOAuthTokenRevokeStatus', '', ''],
+			]);
 		$configMock
 			->method('setAppValue')
 			->withConsecutive(
@@ -1426,26 +1326,12 @@ class ConfigControllerTest extends TestCase {
 		$configMock = $this->getMockBuilder(IConfig::class)->getMock();
 		$configMock
 			->method('getAppValue')
-			->withConsecutive(
-				['integration_openproject', 'openproject_instance_url', ''],
-				['integration_openproject', 'authorization_method', ''],
-				['integration_openproject', 'oPOAuthTokenRevokeStatus', ''],
-				['integration_openproject', 'authorization_method', ''],
-				['integration_openproject', 'openproject_instance_url'],
-				['integration_openproject', 'fresh_project_folder_setup'],
-				['integration_openproject', 'openproject_client_id'],
-				['integration_openproject', 'openproject_client_secret'],
-			)
-			->willReturnOnConsecutiveCalls(
-				'http://localhost:3000',
-				OpenProjectAPIService::AUTH_METHOD_OAUTH,
-				'',
-				OpenProjectAPIService::AUTH_METHOD_OAUTH,
-				'http://localhost:3000',
-				false,
-				'some_cilent_id',
-				'some_cilent_secret',
-			);
+			->willReturnMap([
+				[Application::APP_ID, 'openproject_instance_url', '', 'http://localhost:3000'],
+				[Application::APP_ID, 'authorization_method', '', OpenProjectAPIService::AUTH_METHOD_OAUTH],
+				[Application::APP_ID, 'openproject_client_id', '', 'some_cilent_id'],
+				[Application::APP_ID, 'openproject_client_secret', '', 'some_cilent_secret'],
+			]);
 		$secureRandomMock = $this->getMockBuilder(ISecureRandom::class)->getMock();
 		$secureRandomMock
 			->method('generate')

--- a/tests/lib/Controller/OpenProjectControllerTest.php
+++ b/tests/lib/Controller/OpenProjectControllerTest.php
@@ -14,6 +14,7 @@ use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Exception\ServerException;
 use GuzzleHttp\Psr7\Utils;
+use OCA\OpenProject\AppInfo\Application;
 use OCA\OpenProject\Service\OpenProjectAPIService;
 use OCP\Http\Client\IResponse;
 use OCP\Http\Client\LocalServerException;
@@ -283,23 +284,14 @@ class OpenProjectControllerTest extends TestCase {
 		$configMock = $this->getMockBuilder(IConfig::class)->getMock();
 		$configMock
 			->method('getAppValue')
-			->withConsecutive(
-				['integration_openproject', 'authorization_method'],
-				['integration_openproject', 'openproject_instance_url'],
-				['integration_openproject', 'fresh_project_folder_setup'],
-				['integration_openproject', 'openproject_client_id'],
-				['integration_openproject', 'openproject_client_secret'],
-				['integration_openproject', 'openproject_client_id'],
-				['integration_openproject', 'openproject_instance_url'],
-			)->willReturnOnConsecutiveCalls(
-				OpenProjectAPIService::AUTH_METHOD_OAUTH,
-				'http://openproject.org',
-				false,
-				'myClientID',
-				'myClientSecret',
-				'myClientID',
-				'http://openproject.org',
-			);
+			->willReturnMap([
+				[Application::APP_ID, 'authorization_method', '', OpenProjectAPIService::AUTH_METHOD_OAUTH],
+				[Application::APP_ID, 'openproject_instance_url', '', 'http://openproject.org'],
+				[Application::APP_ID, 'openproject_client_id', '', 'myClientID'],
+				[Application::APP_ID, 'openproject_client_secret', '', 'myClientSecret'],
+				[Application::APP_ID, 'fresh_project_folder_setup', '', false],
+				[Application::APP_ID, 'nc_oauth_client_id', '', 'nc-client'],
+			]);
 		$configMock
 			->expects($this->exactly(2))
 			->method('setUserValue')

--- a/tests/lib/Settings/AdminTest.php
+++ b/tests/lib/Settings/AdminTest.php
@@ -58,6 +58,8 @@ class AdminTest extends TestCase {
 					"authorization_method" => "",
 					"openproject_client_id" => "openproject",
 					"openproject_client_secret" => "op-secret",
+					"nc_oauth_client_id" => "nc-client",
+					"fresh_project_folder_setup" => false,
 				],
 				"setupWithOauth" => true,
 			],

--- a/tests/lib/Settings/PersonalTest.php
+++ b/tests/lib/Settings/PersonalTest.php
@@ -7,6 +7,7 @@
 
 namespace OCA\OpenProject\Settings;
 
+use OCA\OpenProject\AppInfo\Application;
 use OCA\OpenProject\Service\OpenProjectAPIService;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
@@ -50,23 +51,32 @@ class PersonalTest extends TestCase {
 		return [
 			[
 				// valid dataset
-				"clientId" => 'some-client-id',
-				"clientSecret" => 'some-client-secret',
-				"oauthInstanceUrl" => 'http://some.url',
+				"config" => [
+					"clientId" => 'some-client-id',
+					"clientSecret" => 'some-client-secret',
+					"oauthInstanceUrl" => 'http://some.url',
+					"nc_oauth_client_id" => 'nc-client',
+					"authentication_method" => OpenProjectAPIService::AUTH_METHOD_OAUTH,
+					"fresh_project_folder_setup" => false,
+				],
 				"adminConfigStatus" => true,
 			],
 			[
 				// dataset with empty client secret
-				"clientId" => 'some-client-id',
-				"clientSecret" => '',
-				"oauthInstanceUrl" => 'http://some.url',
+				"config" => [
+					"clientId" => 'some-client-id',
+					"clientSecret" => '',
+					"oauthInstanceUrl" => 'http://some.url',
+				],
 				"adminConfigStatus" => false,
 			],
 			[
 				// dataset with invalid oauth instance url
-				"clientId" => 'some-client-id',
-				"clientSecret" => 'some-secret',
-				"oauthInstanceUrl" => 'http:/',
+				"config" => [
+					"clientId" => 'some-client-id',
+					"clientSecret" => 'some-secret',
+					"oauthInstanceUrl" => 'http:/',
+				],
 				"adminConfigStatus" => false,
 			],
 		];
@@ -75,14 +85,13 @@ class PersonalTest extends TestCase {
 	/**
 	 * @dataProvider dataTestGetForm
 	 *
-	 * @param string $clientId
-	 * @param string $clientSecret
-	 * @param string $oauthInstanceUrl
+	 * @param array $config
 	 * @param bool $adminConfigStatus
 	 * @return void
 	 */
 	public function testGetForm(
-		string $clientId, string $clientSecret, string $oauthInstanceUrl, bool $adminConfigStatus
+		array $config,
+		bool $adminConfigStatus,
 	) {
 		$this->config
 			->method('getUserValue')
@@ -99,31 +108,16 @@ class PersonalTest extends TestCase {
 			);
 		$this->config
 			->method('getAppValue')
-			->withConsecutive(
-				['integration_openproject', 'authorization_method'],
-				['integration_openproject', 'default_enable_unified_search'],
-				['integration_openproject', 'default_enable_navigation'],
-				['integration_openproject', 'authorization_method'],
-				['integration_openproject', 'openproject_instance_url'],
-				['integration_openproject', 'fresh_project_folder_setup'],
-				['integration_openproject', 'openproject_client_id'],
-				['integration_openproject', 'openproject_client_secret'],
-				['integration_openproject', 'openproject_instance_url'],
-				['integration_openproject', 'openproject_client_id'],
-			)
-			->willReturnOnConsecutiveCalls(
-				OpenProjectAPIService::AUTH_METHOD_OAUTH,
-				'0', '0',
-				OpenProjectAPIService::AUTH_METHOD_OAUTH,
-				$oauthInstanceUrl,
-				false,
-				$clientId,
-				$clientSecret,
-				$oauthInstanceUrl,
-				$clientId,
-			);
-
-
+			->willReturnMap([
+				[Application::APP_ID, 'authorization_method', '', OpenProjectAPIService::AUTH_METHOD_OAUTH],
+				[Application::APP_ID, 'openproject_instance_url', '', $config['oauthInstanceUrl']],
+				[Application::APP_ID, 'openproject_client_id', '', $config['clientId']],
+				[Application::APP_ID, 'openproject_client_secret', '', $config['clientSecret']],
+				[Application::APP_ID, 'fresh_project_folder_setup', '', false],
+				[Application::APP_ID, 'nc_oauth_client_id', '', 'nc-client'],
+				[Application::APP_ID, 'default_enable_unified_search', '0', '0'],
+				[Application::APP_ID, 'default_enable_navigation', '0', '0'],
+			]);
 
 		$this->initialState
 			->method('provideInitialState')
@@ -167,29 +161,16 @@ class PersonalTest extends TestCase {
 			);
 		$this->config
 			->method('getAppValue')
-			->withConsecutive(
-				['integration_openproject', 'authorization_method'],
-				['integration_openproject', 'default_enable_unified_search'],
-				['integration_openproject', 'default_enable_navigation'],
-				['integration_openproject', 'authorization_method'],
-				['integration_openproject', 'openproject_instance_url'],
-				['integration_openproject', 'fresh_project_folder_setup'],
-				['integration_openproject', 'openproject_client_id'],
-				['integration_openproject', 'openproject_client_secret'],
-				['integration_openproject', 'openproject_instance_url'],
-				['integration_openproject', 'openproject_client_id'],
-			)
-			->willReturnOnConsecutiveCalls(
-				OpenProjectAPIService::AUTH_METHOD_OAUTH,
-				'1', '1',
-				OpenProjectAPIService::AUTH_METHOD_OAUTH,
-				"http://localhost",
-				false,
-				"some-client-id",
-				"some-client-secret",
-				"http://localhost",
-				"some-client-id",
-			);
+			->willReturnMap([
+				[Application::APP_ID, 'authorization_method', '', OpenProjectAPIService::AUTH_METHOD_OAUTH],
+				[Application::APP_ID, 'openproject_instance_url', '', 'http://some.url'],
+				[Application::APP_ID, 'openproject_client_id', '', 'op-client'],
+				[Application::APP_ID, 'openproject_client_secret', '', 'op-secret'],
+				[Application::APP_ID, 'fresh_project_folder_setup', '', false],
+				[Application::APP_ID, 'nc_oauth_client_id', '', 'nc-client'],
+				[Application::APP_ID, 'default_enable_unified_search', '0', '1'],
+				[Application::APP_ID, 'default_enable_navigation', '0', '1'],
+			]);
 		$this->initialState
 			->method('provideInitialState')
 			->withConsecutive(


### PR DESCRIPTION
## Description
Added a migration to seed the `authorization_method` app-value if there is exisiting oauth2 setup while upgrading from `2.8` -> `2.9`
This way, wen can decide to set `authorization_method` when the upgrade happens preventing the need for setting it on other places.


## Related Issue or Workpackage
- Fixes [65873](https://community.openproject.org/wp/65873)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [x] Updated `CHANGELOG.md` file
