### PR TITLE
CI: fix error by using user_oidc v7.2.0

### DIFF
--- a/.github/workflows/shared_workflow.yml
+++ b/.github/workflows/shared_workflow.yml
@@ -187,6 +187,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: nextcloud/user_oidc
+          ref: v7.2.0
+          fetch-tags: true
           path: user_oidc
 
       - name: Checkout oidc app


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Previously, we were using the `main` branch of the `user_oidc` app in CI.
This recently failed CI with an error due to a breaking change in the `psr/log` library:

```json
Declaration of Psr\\Log\\AbstractLogger::emergency($message, array $context = []) must be compatible with Psr\\Log\\LoggerInterface::emergency(Stringable|string $message, array $context = []): void at /home/nabin/www/stable31/apps/user_oidc/vendor/psr/log/Psr/Log/AbstractLogger.php#22
```
This error appeared during WebDAV requests and caused CI to fail.

So, in this PR, there sets the `user_oidc` app to a stable version (v7.2.0) in CI to fix compatibility issues.

## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
