### PR TITLE
feat: show error card if required apps are not enabled or supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Show form errors if required apps are not enabled or not supported [#868](https://github.com/nextcloud/integration_openproject/pull/868)
+
 ### Changed
 
 - Combine error messages for app not enabled and not supported [#865](https://github.com/nextcloud/integration_openproject/pull/865)

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -69,6 +69,7 @@ class OpenProjectAPIService {
 	public const AUTH_METHOD_OIDC = 'oidc';
 	public const MIN_SUPPORTED_USER_OIDC_APP_VERSION = '7.2.0';
 	public const MIN_SUPPORTED_OIDC_APP_VERSION = '1.6.0';
+	public const MIN_SUPPORTED_GROUPFOLDERS_APP_VERSION = '1.0.0';
 	public const NEXTCLOUD_HUB_PROVIDER = "nextcloud_hub";
 
 	/**
@@ -1188,6 +1189,17 @@ class OpenProjectAPIService {
 				'groupfolders',
 				$user
 			)
+		);
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function isGroupfoldersAppSupported(): bool {
+		$appVersion = $this->appManager->getAppVersion('groupfolders');
+		return (
+			$this->isGroupfoldersAppEnabled() &&
+			version_compare($appVersion, self::MIN_SUPPORTED_GROUPFOLDERS_APP_VERSION) >= 0
 		);
 	}
 

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -122,6 +122,11 @@ class Admin implements ISettings {
 					'supported' => $this->openProjectAPIService->isUserOIDCAppSupported(),
 					'minimum_version' => OpenProjectAPIService::MIN_SUPPORTED_USER_OIDC_APP_VERSION,
 				],
+				'groupfolders' => [
+					'enabled' => $this->openProjectAPIService->isGroupfoldersAppEnabled(),
+					'supported' => $this->openProjectAPIService->isGroupfoldersAppSupported(),
+					'minimum_version' => OpenProjectAPIService::MIN_SUPPORTED_GROUPFOLDERS_APP_VERSION,
+				],
 			],
 		];
 

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -122,7 +122,7 @@
 							v-model="authorizationSetting.currentTargetedAudienceClientIdSelected"
 							class="py-1"
 							is-required
-							:disabled="hasOidcAppErrorWithNextcloudHub"
+							:disabled="!hasEnabledSupportedUserOidcApp || hasOidcAppErrorWithNextcloudHub"
 							:place-holder="messages.opClientId"
 							:label="messages.opClientId"
 							:hint-text="messages.opClientIdHintText" />
@@ -303,24 +303,12 @@
 					<NcCheckboxRadioSwitch type="switch" :checked.sync="isProjectFolderSwitchEnabled" @update:checked="changeProjectFolderSetUpState">
 						<b>{{ t('integration_openproject', 'Automatically managed folders') }}</b>
 					</NcCheckboxRadioSwitch>
-					<div v-if="isProjectFolderSwitchEnabled === false" class="complete-without-groupfolders">
+					<div v-if="!isProjectFolderSwitchEnabled">
 						<p class="project-folder-description">
 							{{
 								t('integration_openproject', 'We recommend using this functionality but it is not mandatory. Please activate it in case you want to use the automatic creation and management of project folders.')
 							}}
 						</p>
-						<div class="form-actions">
-							<NcButton type="primary"
-								data-test-id="complete-without-project-folder-form-btn"
-								@click="completeIntegrationWithoutProjectFolderSetUp">
-								<template #icon>
-									<CheckBoldIcon fill-color="#FFFFFF" :size="20" />
-								</template>
-								{{
-									textLabelProjectFolderSetupButton
-								}}
-							</NcButton>
-						</div>
 					</div>
 					<div v-else>
 						<p class="project-folder-description">
@@ -338,26 +326,26 @@
 								t('integration_openproject', 'The app will never delete files or folders, even if you deactivate this later.')
 							}}
 						</p>
-						<NcNoteCard v-if="!hasGroupfoldersAppStateError && projectFolderSetupError" class="note-card" type="error">
-							<p class="note-card--title">
-								<b>{{ projectFolderSetupError }}</b>
-							</p>
-							<p class="note-card--error-description" v-html="projectFolderSetUpErrorMessageDescription" /> <!-- eslint-disable-line vue/no-v-html -->
-						</NcNoteCard>
-						<div class="form-actions">
-							<NcButton
-								type="primary"
-								:disabled="hasGroupfoldersAppStateError"
-								data-test-id="complete-with-project-folders-form-btn"
-								@click="setUpProjectGroupFolders">
-								<template #icon>
-									<NcLoadingIcon v-if="loadingProjectFolderSetup" class="loading-spinner" :size="20" />
-									<RestoreIcon v-else-if="projectFolderSetupError" fill-color="#FFFFFF" :size="20" />
-									<CheckBoldIcon v-else fill-color="#FFFFFF" :size="20" />
-								</template>
-								{{ getProjectFoldersButtonLabel }}
-							</NcButton>
-						</div>
+					</div>
+					<NcNoteCard v-if="!hasGroupfoldersAppStateError && projectFolderSetupError" class="note-card" type="error">
+						<p class="note-card--title">
+							<b>{{ projectFolderSetupError }}</b>
+						</p>
+						<p class="note-card--error-description" v-html="projectFolderSetUpErrorMessageDescription" /> <!-- eslint-disable-line vue/no-v-html -->
+					</NcNoteCard>
+					<div class="form-actions">
+						<NcButton
+							type="primary"
+							:disabled="hasGroupfoldersAppStateError"
+							data-test-id="save-project-folders-form-btn"
+							@click="setUpProjectGroupFolders">
+							<template #icon>
+								<NcLoadingIcon v-if="loadingProjectFolderSetup" class="loading-spinner" :size="20" />
+								<RestoreIcon v-else-if="projectFolderSetupError" fill-color="#FFFFFF" :size="20" />
+								<CheckBoldIcon v-else fill-color="#FFFFFF" :size="20" />
+							</template>
+							{{ getProjectFoldersButtonLabel }}
+						</NcButton>
 					</div>
 				</div>
 				<div v-else class="project-folder-status">
@@ -829,9 +817,9 @@ export default {
 			return this.authorizationSetting.enableTokenExchange
 		},
 		getProjectFoldersButtonLabel() {
-			if (!this.state.app_password_set && this.isProjectFolderSwitchEnabled) {
+			if (!this.isManagedGroupFolderSetUpComplete && this.isProjectFolderSwitchEnabled) {
 				return this.buttonTextLabel.completeWithProjectFolderSetup
-			} else if (!this.state.app_password_set && !this.isProjectFolderSwitchEnabled) {
+			} else if (!this.isManagedGroupFolderSetUpComplete && !this.isProjectFolderSwitchEnabled) {
 				return this.buttonTextLabel.completeWithoutProjectFolderSetup
 			} else if (this.isProjectFolderSwitchEnabled && this.projectFolderSetupError) {
 				return this.buttonTextLabel.retrySetupWithProjectFolder
@@ -1050,8 +1038,31 @@ export default {
 				this.textLabelProjectFolderSetupButton = this.buttonTextLabel.completeWithoutProjectFolderSetup
 			}
 		},
+		async setupWithoutProjectFolderSetUp() {
+			this.textLabelProjectFolderSetupButton = this.buttonTextLabel.keepCurrentChange
+			const success = await this.saveOPOptions()
+			if (success) {
+				// also make password form disable and complete as false
+				if (this.opUserAppPassword) {
+					this.isFormCompleted.opUserAppPassword = false
+					this.formMode.opUserAppPassword = F_MODES.DISABLE
+				}
+				this.state.app_password_set = false
+				this.currentProjectFolderState = this.isProjectFolderSwitchEnabled
+				this.isFormCompleted.projectFolderSetUp = true
+				this.formMode.projectFolderSetUp = F_MODES.VIEW
+			}
+			// we want to show the error only when project folder form is in edit mode
+			if (this.formMode.projectFolderSetUp === F_MODES.VIEW) {
+				this.projectFolderSetupError = null
+			}
+		},
 		async setUpProjectGroupFolders() {
 			this.isFormStep = FORM.GROUP_FOLDER
+			if (this.isProjectFolderSwitchEnabled === false) {
+				return this.setupWithoutProjectFolderSetUp()
+			}
+
 			this.loadingProjectFolderSetup = true
 			this.isProjectFolderAlreadySetup = await this.checkIfProjectFolderIsAlreadyReadyForSetup()
 			if (this.isProjectFolderAlreadySetup) {
@@ -1334,26 +1345,6 @@ export default {
 				},
 				true,
 			)
-		},
-		async completeIntegrationWithoutProjectFolderSetUp() {
-			this.isFormStep = FORM.GROUP_FOLDER
-			this.textLabelProjectFolderSetupButton = this.buttonTextLabel.keepCurrentChange
-			const success = await this.saveOPOptions()
-			if (success) {
-				// also make password form disable and complete as false
-				if (this.opUserAppPassword) {
-					this.isFormCompleted.opUserAppPassword = false
-					this.formMode.opUserAppPassword = F_MODES.DISABLE
-				}
-				this.state.app_password_set = false
-				this.currentProjectFolderState = this.isProjectFolderSwitchEnabled
-				this.isFormCompleted.projectFolderSetUp = true
-				this.formMode.projectFolderSetUp = F_MODES.VIEW
-			}
-			// we want to show the error only when project folder form is in edit mode
-			if (this.formMode.projectFolderSetUp === F_MODES.VIEW) {
-				this.projectFolderSetupError = null
-			}
 		},
 		resetOPUserAppPassword() {
 			OC.dialogs.confirmDestructive(

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -282,16 +282,23 @@
 				:is-project-folder-setup-heading="true"
 				:title="t('integration_openproject', 'Project folders (recommended)')"
 				:is-setup-complete-without-project-folders="isSetupCompleteWithoutProjectFolders"
-				:has-error="isThereErrorAfterProjectFolderAndAppPasswordSetup || hasGroupfoldersAppStateError"
+				:has-error="isThereErrorAfterProjectFolderAndAppPasswordSetup || showGroupfoldersAppError"
 				:show-encryption-warning-for-group-folders="showEncryptionWarningForGroupFolders"
 				:is-complete="isProjectFolderSetupCompleted"
 				:is-disabled="isProjectFolderSetUpInDisableMode"
 				:is-dark-theme="isDarkTheme" />
 			<ErrorNote
-				v-if="hasGroupfoldersAppStateError"
+				v-if="showGroupfoldersAppError"
 				:error-title="messagesFmt.appNotEnabledOrUnsupported('groupfolders', getMinSupportedGroupfoldersVersion)"
 				:error-link="appLinks.groupfolders.installLink"
 				:error-link-label="messages.installLatestVersionNow" />
+			<NcNoteCard v-else-if="projectFolderSetupError || isThereErrorAfterProjectFolderAndAppPasswordSetup" class="note-card" type="error">
+				<p class="note-card--title">
+					<b v-if="isThereErrorAfterProjectFolderAndAppPasswordSetup">{{ state.project_folder_info.errorMessage }}</b>
+					<b v-else>{{ projectFolderSetupError }}</b>
+				</p>
+				<p class="note-card--error-description" v-html="projectFolderSetUpErrorMessageDescription" /> <!-- eslint-disable-line vue/no-v-html -->
+			</NcNoteCard>
 			<NcNoteCard v-else-if="showEncryptionWarningForGroupFolders" class="note-card" type="warning">
 				<p class="note-card--title">
 					<b>{{ t('integration_openproject', 'Encryption for the Team Folders App is not enabled.') }}</b>
@@ -338,16 +345,10 @@
 								t('integration_openproject', 'The app will never delete files or folders, even if you deactivate this later.')
 							}}
 						</p>
-						<NcNoteCard v-if="!hasGroupfoldersAppStateError && projectFolderSetupError" class="note-card" type="error">
-							<p class="note-card--title">
-								<b>{{ projectFolderSetupError }}</b>
-							</p>
-							<p class="note-card--error-description" v-html="projectFolderSetUpErrorMessageDescription" /> <!-- eslint-disable-line vue/no-v-html -->
-						</NcNoteCard>
 						<div class="form-actions">
 							<NcButton
 								type="primary"
-								:disabled="hasGroupfoldersAppStateError"
+								:disabled="showGroupfoldersAppError"
 								data-test-id="complete-with-project-folders-form-btn"
 								@click="setUpProjectGroupFolders">
 								<template #icon>
@@ -809,7 +810,7 @@ export default {
 		hasOidcAppErrorWithNextcloudHub() {
 			return !this.hasEnabledSupportedOIDCApp && this.authorizationSetting.SSOProviderType === SSO_PROVIDER_TYPE.nextcloudHub
 		},
-		hasGroupfoldersAppStateError() {
+		showGroupfoldersAppError() {
 			return this.isProjectFolderSwitchEnabled && !this.hasEnabledSupportedGroupfoldersApp
 		},
 		disableNCHubUnsupportedHint() {

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -859,8 +859,8 @@ export default {
 						this.isProjectFolderAlreadySetup = true
 					}
 				}
-				if (this.state.fresh_project_folder_setup === true) {
-					this.currentProjectFolderState = false
+				if (this.state.fresh_project_folder_setup === true && this.formMode.projectFolderSetUp === F_MODES.DISABLE) {
+					this.currentProjectFolderState = true
 					this.textLabelProjectFolderSetupButton = this.buttonTextLabel.completeWithProjectFolderSetup
 				} else {
 					this.textLabelProjectFolderSetupButton = this.buttonTextLabel.keepCurrentChange

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -27,11 +27,16 @@
 				:is-complete="isAuthorizationSettingFormComplete"
 				:is-disabled="isAuthorizationSettingFormInDisabledMode"
 				:is-dark-theme="isDarkTheme"
-				:has-error="!hasEnabledSupportedUserOidcApp" />
+				:has-error="!hasEnabledSupportedUserOidcApp || hasOidcAppErrorWithNextcloudHub" />
 			<ErrorNote
 				v-if="!hasEnabledSupportedUserOidcApp"
 				:error-title="messagesFmt.appNotEnabledOrUnsupported('user_oidc', getMinSupportedUserOidcVersion)"
 				:error-link="appLinks.user_oidc.installLink"
+				:error-link-label="messages.installLatestVersionNow" />
+			<ErrorNote
+				v-if="hasEnabledSupportedUserOidcApp && hasOidcAppErrorWithNextcloudHub"
+				:error-title="messagesFmt.appNotEnabledOrUnsupported('oidc', getMinSupportedOidcVersion)"
+				:error-link="appLinks.oidc.installLink"
 				:error-link-label="messages.installLatestVersionNow" />
 			<div class="authorization-settings--content">
 				<FieldValue v-if="isAuthorizationSettingsInViewMode"
@@ -53,7 +58,7 @@
 					<div class="error-container">
 						<ErrorLabel
 							v-if="!hasEnabledSupportedOIDCApp"
-							:error="messagesFmt.appNotEnabledOrUnsupported('oidc', getMinSupportedOIDCVersion)"
+							:error="messagesFmt.appNotEnabledOrUnsupported('oidc', getMinSupportedOidcVersion)"
 							:disabled="disableNCHubUnsupportedHint" />
 					</div>
 					<NcCheckboxRadioSwitch
@@ -117,7 +122,7 @@
 							v-model="authorizationSetting.currentTargetedAudienceClientIdSelected"
 							class="py-1"
 							is-required
-							:disabled="!hasEnabledSupportedUserOidcApp"
+							:disabled="hasOidcAppErrorWithNextcloudHub"
 							:place-holder="messages.opClientId"
 							:label="messages.opClientId"
 							:hint-text="messages.opClientIdHintText" />
@@ -797,11 +802,14 @@ export default {
 		hasEnabledSupportedOIDCApp() {
 			return this.state.apps.oidc.enabled && this.state.apps.oidc.supported
 		},
-		getMinSupportedOIDCVersion() {
+		getMinSupportedOidcVersion() {
 			return this.state.apps.oidc.minimum_version
 		},
 		isExternalSSOProvider() {
 			return this.authorizationSetting.SSOProviderType === SSO_PROVIDER_TYPE.external
+		},
+		hasOidcAppErrorWithNextcloudHub() {
+			return !this.hasEnabledSupportedOIDCApp && this.authorizationSetting.SSOProviderType === SSO_PROVIDER_TYPE.nextcloudHub
 		},
 		disableNCHubUnsupportedHint() {
 			if (!this.hasEnabledSupportedOIDCApp) {

--- a/src/components/admin/FormAuthMethod.vue
+++ b/src/components/admin/FormAuthMethod.vue
@@ -12,9 +12,9 @@
 			:is-complete="isFormComplete"
 			:is-disabled="!showSettings"
 			:is-dark-theme="isDarkTheme"
-			:has-error="!hasEnabledSupportedUserOidcApp" />
+			:has-error="showUserOidcAppError" />
 		<ErrorNote
-			v-if="!hasEnabledSupportedUserOidcApp"
+			v-if="showUserOidcAppError"
 			:error-title="messagesFmt.appNotEnabledOrUnsupported('user_oidc', getMinSupportedUserOidcVersion)"
 			:error-link="appLinks.user_oidc.installLink"
 			:error-link-label="messages.installLatestVersionNow" />
@@ -163,6 +163,9 @@ export default {
 		},
 		hasEnabledSupportedUserOidcApp() {
 			return this.apps.user_oidc.enabled && this.apps.user_oidc.supported
+		},
+		showUserOidcAppError() {
+			return !this.disableErrorLabel && !this.hasEnabledSupportedUserOidcApp
 		},
 		getMinSupportedUserOidcVersion() {
 			return this.apps.user_oidc.minimum_version

--- a/src/components/admin/FormAuthMethod.vue
+++ b/src/components/admin/FormAuthMethod.vue
@@ -11,7 +11,13 @@
 			:title="t('integration_openproject', 'Authentication method')"
 			:is-complete="isFormComplete"
 			:is-disabled="!showSettings"
-			:is-dark-theme="isDarkTheme" />
+			:is-dark-theme="isDarkTheme"
+			:has-error="!hasEnabledSupportedUserOidcApp" />
+		<ErrorNote
+			v-if="!hasEnabledSupportedUserOidcApp"
+			:error-title="messagesFmt.appNotEnabledOrUnsupported('user_oidc', getMinSupportedUserOidcVersion)"
+			:error-link="appLinks.user_oidc.installLink"
+			:error-link-label="messages.installLatestVersionNow" />
 		<div v-if="showSettings" class="auth-method">
 			<div v-if="isEditMode">
 				<div class="auth-method--hint">
@@ -89,9 +95,11 @@ import CheckBoldIcon from 'vue-material-design-icons/CheckBold.vue'
 import PencilIcon from 'vue-material-design-icons/Pencil.vue'
 import FormHeading from './FormHeading.vue'
 import ErrorLabel from '../ErrorLabel.vue'
+import ErrorNote from '../settings/ErrorNote.vue'
 import { F_MODES, AUTH_METHOD, AUTH_METHOD_LABEL, ADMIN_SETTINGS_FORM } from '../../utils.js'
-import { messages, messagesFmt } from '../../constants/messages.js'
 import { saveAdminConfig } from '../../api/settings.js'
+import { messages, messagesFmt } from '../../constants/messages.js'
+import { appLinks } from '../../constants/links.js'
 
 export default {
 	name: 'FormAuthMethod',
@@ -103,6 +111,7 @@ export default {
 		PencilIcon,
 		FormHeading,
 		ErrorLabel,
+		ErrorNote,
 	},
 	props: {
 		apps: {
@@ -136,6 +145,7 @@ export default {
 			selectedAuthMethod: AUTH_METHOD.OAUTH2,
 			// state that holds the saved (to server) auth method
 			savedAuthMethod: null,
+			appLinks,
 		}
 	},
 	computed: {

--- a/src/components/settings/ErrorNote.vue
+++ b/src/components/settings/ErrorNote.vue
@@ -40,7 +40,7 @@ export default {
 		},
 		errorLinkLabel: {
 			type: String,
-			default: '',
+			default: 'Link',
 		},
 	},
 }

--- a/src/constants/links.js
+++ b/src/constants/links.js
@@ -14,4 +14,8 @@ export const appLinks = {
 		installLink: generateUrl('settings/apps/files/oidc'),
 		settingsLink: generateUrl('settings/admin/oidc_provider'),
 	},
+	groupfolders: {
+		installLink: generateUrl('settings/apps/files/groupfolders'),
+		settingsLink: generateUrl('settings/admin/groupfolders'),
+	},
 }

--- a/src/constants/links.js
+++ b/src/constants/links.js
@@ -7,15 +7,15 @@ import { generateUrl } from '@nextcloud/router'
 
 export const appLinks = {
 	user_oidc: {
-		installLink: generateUrl('settings/apps/files/user_oidc'),
-		settingsLink: generateUrl('settings/admin/user_oidc'),
+		installLink: generateUrl('/settings/apps/files/user_oidc'),
+		settingsLink: generateUrl('/settings/admin/user_oidc'),
 	},
 	oidc: {
-		installLink: generateUrl('settings/apps/files/oidc'),
-		settingsLink: generateUrl('settings/admin/oidc_provider'),
+		installLink: generateUrl('/settings/apps/files/oidc'),
+		settingsLink: generateUrl('/settings/admin/oidc_provider'),
 	},
 	groupfolders: {
-		installLink: generateUrl('settings/apps/files/groupfolders'),
-		settingsLink: generateUrl('settings/admin/groupfolders'),
+		installLink: generateUrl('/settings/apps/files/groupfolders'),
+		settingsLink: generateUrl('/settings/admin/groupfolders'),
 	},
 }

--- a/src/constants/links.js
+++ b/src/constants/links.js
@@ -6,5 +6,12 @@
 import { generateUrl } from '@nextcloud/router'
 
 export const appLinks = {
-	user_oidc: { installLink: generateUrl('/settings/apps/files/user_oidc'), settingsLink: generateUrl('settings/admin/user_oidc') },
+	user_oidc: {
+		installLink: generateUrl('settings/apps/files/user_oidc'),
+		settingsLink: generateUrl('settings/admin/user_oidc'),
+	},
+	oidc: {
+		installLink: generateUrl('settings/apps/files/oidc'),
+		settingsLink: generateUrl('settings/admin/oidc_provider'),
+	},
 }

--- a/tests/jest/components/AdminSettings.spec.js
+++ b/tests/jest/components/AdminSettings.spec.js
@@ -11,7 +11,7 @@ import * as dialogs from '@nextcloud/dialogs'
 import { createLocalVue, shallowMount, mount } from '@vue/test-utils'
 import flushPromises from 'flush-promises' // eslint-disable-line n/no-unpublished-import
 import AdminSettings from '../../../src/components/AdminSettings.vue'
-import { F_MODES, AUTH_METHOD, ADMIN_SETTINGS_FORM, FORM } from '../../../src/utils.js'
+import { F_MODES, AUTH_METHOD, ADMIN_SETTINGS_FORM } from '../../../src/utils.js'
 import { appLinks } from '../../../src/constants/links.js'
 import { messagesFmt, messages } from '../../../src/constants/messages.js'
 

--- a/tests/jest/components/AdminSettings.spec.js
+++ b/tests/jest/components/AdminSettings.spec.js
@@ -11,9 +11,9 @@ import * as dialogs from '@nextcloud/dialogs'
 import { createLocalVue, shallowMount, mount } from '@vue/test-utils'
 import flushPromises from 'flush-promises' // eslint-disable-line n/no-unpublished-import
 import AdminSettings from '../../../src/components/AdminSettings.vue'
-import { F_MODES, AUTH_METHOD, ADMIN_SETTINGS_FORM } from '../../../src/utils.js'
+import { F_MODES, AUTH_METHOD, ADMIN_SETTINGS_FORM, FORM } from '../../../src/utils.js'
 import { appLinks } from '../../../src/constants/links.js'
-import { messagesFmt } from '../../../src/constants/messages.js'
+import { messagesFmt, messages } from '../../../src/constants/messages.js'
 
 jest.mock('@nextcloud/axios', () => {
 	const originalModule = jest.requireActual('@nextcloud/axios')
@@ -102,8 +102,8 @@ const selectors = {
 	defaultUserConfigurationsForm: '.default-prefs',
 	defaultEnableNavigation: '#default-prefs--link',
 	projectFolderSetupSwitch: '[type="checkbox"]',
-	completeProjectFolderSetupWithGroupFolderButton: '[data-test-id="complete-with-project-folders-form-btn"]',
-	completeWithoutProjectFolderSetupButton: '[data-test-id="complete-without-project-folder-form-btn"]',
+	completeProjectFolderSetupWithGroupFolderButton: '[data-test-id="save-project-folders-form-btn"]',
+	completeWithoutProjectFolderSetupButton: '[data-test-id="save-project-folders-form-btn"]',
 	editProjectFolderSetup: '[data-test-id="edit-project-folder-setup"]',
 	projectFolderStatus: '.project-folder-status-value',
 	projectFolderErrorMessage: '.note-card--title',
@@ -145,6 +145,11 @@ const appState = {
 			enabled: true,
 			supported: true,
 			minimum_version: '2.0.0',
+		},
+		groupfolders: {
+			enabled: true,
+			supported: true,
+			minimum_version: '1.0.0',
 		},
 	},
 }
@@ -681,6 +686,7 @@ describe('AdminSettings.vue', () => {
 
 					expect(formHeader.exists()).toBe(true)
 					expect(formHeader.attributes().haserror).toBe('true')
+					expect(wrapper.findAll(errorNoteSelector)).toHaveLength(1)
 					expect(errorNote.exists()).toBe(true)
 					expect(errorNote.attributes().errortitle).toBe(messagesFmt.appNotEnabledOrUnsupported())
 					expect(errorNote.attributes().errorlink).toBe(appLinks.user_oidc.installLink)
@@ -723,6 +729,7 @@ describe('AdminSettings.vue', () => {
 
 					expect(formHeader.exists()).toBe(true)
 					expect(formHeader.attributes().haserror).toBe('true')
+					expect(wrapper.findAll(errorNoteSelector)).toHaveLength(1)
 					expect(errorNote.exists()).toBe(true)
 					expect(errorNote.attributes().errortitle).toBe(messagesFmt.appNotEnabledOrUnsupported())
 					expect(errorNote.attributes().errorlink).toBe(appLinks.user_oidc.installLink)
@@ -1043,7 +1050,7 @@ describe('AdminSettings.vue', () => {
 							apps: {
 								...appState.apps,
 								oidc: {
-									enabled: false,
+									enabled: true,
 									supported: false,
 									minimum_version: appState.apps.oidc.minimum_version,
 								},
@@ -1067,12 +1074,17 @@ describe('AdminSettings.vue', () => {
 					const errorLabel = wrapper.find(errorLabelSelector)
 					const ncProviderRadio = wrapper.find(NCProviderTypeSelector)
 					const externalProviderRadio = wrapper.find(externalProviderTypeSelector)
+					const errorNote = wrapper.find(errorNoteSelector)
 
 					expect(ncProviderRadio.attributes().disabled).toBe('true')
 					expect(ncProviderRadio.attributes().checked).toBe('nextcloud_hub')
 					expect(externalProviderRadio.attributes().disabled).toBe(undefined)
 					expect(errorLabel.attributes().error).toBe(messagesFmt.appNotEnabledOrUnsupported('oidc'))
 					expect(errorLabel.attributes().disabled).toBe(undefined)
+					expect(wrapper.findAll(errorNoteSelector)).toHaveLength(1)
+					expect(errorNote.attributes().errortitle).toBe(messagesFmt.appNotEnabledOrUnsupported())
+					expect(errorNote.attributes().errorlink).toBe(appLinks.oidc.installLink)
+					expect(errorNote.attributes().errorlinklabel).toBe(messages.installLatestVersionNow)
 				})
 			})
 		})
@@ -1394,6 +1406,7 @@ describe('AdminSettings.vue', () => {
 
 					expect(formHeaderError.exists()).toBe(true)
 					expect(formHeaderError.attributes().haserror).toBe('true')
+					expect(wrapper.findAll(errorNoteSelector)).toHaveLength(1)
 					expect(errorNote.exists()).toBe(true)
 					expect(errorNote.attributes().errortitle).toBe(messagesFmt.appNotEnabledOrUnsupported())
 					expect(errorNote.attributes().errorlink).toBe(appLinks.user_oidc.installLink)
@@ -1442,6 +1455,7 @@ describe('AdminSettings.vue', () => {
 
 					expect(formHeaderError.exists()).toBe(true)
 					expect(formHeaderError.attributes().haserror).toBe('true')
+					expect(wrapper.findAll(errorNoteSelector)).toHaveLength(1)
 					expect(errorNote.exists()).toBe(true)
 					expect(errorNote.attributes().errortitle).toBe(messagesFmt.appNotEnabledOrUnsupported())
 					expect(errorNote.attributes().errorlink).toBe(appLinks.user_oidc.installLink)
@@ -1471,7 +1485,7 @@ describe('AdminSettings.vue', () => {
 							apps: {
 								...appState.apps,
 								oidc: {
-									enabled: false,
+									enabled: true,
 									supported: false,
 									minimum_version: appState.apps.oidc.minimum_version,
 								},
@@ -1488,12 +1502,14 @@ describe('AdminSettings.vue', () => {
 					const errorLabel = wrapper.find(errorLabelSelector)
 					const ncProviderRadio = wrapper.find(NCProviderTypeSelector)
 					const externalProviderRadio = wrapper.find(externalProviderTypeSelector)
+					const errorNote = wrapper.find(errorNoteSelector)
 
 					expect(ncProviderRadio.attributes().disabled).toBe('true')
 					expect(ncProviderRadio.attributes().checked).toBe('external')
 					expect(externalProviderRadio.attributes().disabled).toBe(undefined)
 					expect(errorLabel.attributes().error).toBe(messagesFmt.appNotEnabledOrUnsupported('oidc'))
 					expect(errorLabel.attributes().disabled).toBe('true')
+					expect(errorNote.exists()).toBe(false)
 				})
 			})
 		})
@@ -2628,19 +2644,12 @@ describe('AdminSettings.vue', () => {
 		})
 	})
 
-	describe('error after project folder is already setup', () => {
+	describe.only('error after project folder is already setup', () => {
 		beforeEach(async () => {
 			axios.put.mockReset()
 			axios.get.mockReset()
 		})
 		it.each([
-			[
-				'should set the project folder error message and error details when team folders app is not enabled',
-				{
-					error: 'The "groupfolders" app is not installed',
-					expectedErrorDetailsMessage: 'Please install the "groupfolders" app to be able to use automatically managed folders. {htmlLink}',
-				},
-			],
 			[
 				'should set the user already exists error message and error details when user already exists',
 				{
@@ -2649,7 +2658,7 @@ describe('AdminSettings.vue', () => {
 				},
 			],
 		])('%s', async (name, expectedErrorDetails) => {
-			const wrapper = getMountedWrapper({
+			const wrapper = getWrapper({
 				state: {
 					openproject_instance_url: 'http://openproject.com',
 					authorization_method: AUTH_METHOD.OAUTH2,
@@ -2670,6 +2679,12 @@ describe('AdminSettings.vue', () => {
 					app_password_set: true,
 				},
 			})
+			await wrapper.setData({
+				formMode: {
+					projectFolderSetUp: F_MODES.EDIT,
+				},
+			})
+			console.log(wrapper.html())
 			expect(wrapper.vm.isFormCompleted.opUserAppPassword).toBe(true)
 			const projectFolderErrorMessage = wrapper.find(selectors.projectFolderErrorMessage)
 			const projectFolderErrorMessageDetails = wrapper.find(selectors.projectFolderErrorMessageDetails)

--- a/tests/jest/components/admin/__snapshots__/FormAuthMethod.spec.js.snap
+++ b/tests/jest/components/admin/__snapshots__/FormAuthMethod.spec.js.snap
@@ -3,6 +3,7 @@
 exports[`Component: FormAuthMethod completed form edit mode disabled user_oidc app should show disabled error message and disabled sso button when oauth2 is selected 1`] = `
 "<div class="authentication-method">
   <formheading-stub index="2" title="Authentication method" iscomplete="true"></formheading-stub>
+  <!---->
   <div class="auth-method">
     <div>
       <div class="auth-method--hint">
@@ -41,7 +42,8 @@ exports[`Component: FormAuthMethod completed form edit mode disabled user_oidc a
 
 exports[`Component: FormAuthMethod completed form edit mode disabled user_oidc app should show error message and disabled sso button when oidc is selected 1`] = `
 "<div class="authentication-method">
-  <formheading-stub index="2" title="Authentication method" iscomplete="true"></formheading-stub>
+  <formheading-stub index="2" title="Authentication method" iscomplete="true" haserror="true"></formheading-stub>
+  <errornote-stub errortitle="This feature requires version {version} (or higher) of {app}. Please install or update the app." errormessage="" errorlink="http://localhost/settings/apps/files/user_oidc" errorlinklabel="Install latest version now"></errornote-stub>
   <div class="auth-method">
     <div>
       <div class="auth-method--hint">
@@ -81,6 +83,7 @@ exports[`Component: FormAuthMethod completed form edit mode disabled user_oidc a
 exports[`Component: FormAuthMethod completed form edit mode should show form fields 1`] = `
 "<div class="authentication-method">
   <formheading-stub index="2" title="Authentication method" iscomplete="true"></formheading-stub>
+  <!---->
   <div class="auth-method">
     <div>
       <div class="auth-method--hint">
@@ -120,6 +123,7 @@ exports[`Component: FormAuthMethod completed form edit mode should show form fie
 exports[`Component: FormAuthMethod completed form edit mode unsupported user_oidc app should show disabled error message and disabled sso button when oauth2 is selected 1`] = `
 "<div class="authentication-method">
   <formheading-stub index="2" title="Authentication method" iscomplete="true"></formheading-stub>
+  <!---->
   <div class="auth-method">
     <div>
       <div class="auth-method--hint">
@@ -158,7 +162,8 @@ exports[`Component: FormAuthMethod completed form edit mode unsupported user_oid
 
 exports[`Component: FormAuthMethod completed form edit mode unsupported user_oidc app should show error message and disabled sso button when oidc is selected 1`] = `
 "<div class="authentication-method">
-  <formheading-stub index="2" title="Authentication method" iscomplete="true"></formheading-stub>
+  <formheading-stub index="2" title="Authentication method" iscomplete="true" haserror="true"></formheading-stub>
+  <errornote-stub errortitle="This feature requires version {version} (or higher) of {app}. Please install or update the app." errormessage="" errorlink="http://localhost/settings/apps/files/user_oidc" errorlinklabel="Install latest version now"></errornote-stub>
   <div class="auth-method">
     <div>
       <div class="auth-method--hint">
@@ -195,9 +200,48 @@ exports[`Component: FormAuthMethod completed form edit mode unsupported user_oid
 </div>"
 `;
 
-exports[`Component: FormAuthMethod completed form should show set form label 1`] = `
+exports[`Component: FormAuthMethod completed form should show set form label in view mode 1`] = `
 "<div class="authentication-method">
   <formheading-stub index="2" title="Authentication method" iscomplete="true"></formheading-stub>
+  <!---->
+  <div class="auth-method">
+    <p class="auth-method--label">
+      Single-Sign-On through OpenID Connect Identity Provider
+    </p>
+    <div class="form-actions">
+      <ncbutton-stub alignment="center" type="secondary" nativetype="button" data-test-id="edit-auth-method">
+        Edit authentication method
+      </ncbutton-stub>
+      <!---->
+      <!---->
+    </div>
+  </div>
+</div>"
+`;
+
+exports[`Component: FormAuthMethod completed form view mode: disabled user_oidc app should not show form errors if setup with oauth 1`] = `
+"<div class="authentication-method">
+  <formheading-stub index="2" title="Authentication method" iscomplete="true"></formheading-stub>
+  <!---->
+  <div class="auth-method">
+    <p class="auth-method--label">
+      Two-way OAuth 2.0 authorization code flow
+    </p>
+    <div class="form-actions">
+      <ncbutton-stub alignment="center" type="secondary" nativetype="button" data-test-id="edit-auth-method">
+        Edit authentication method
+      </ncbutton-stub>
+      <!---->
+      <!---->
+    </div>
+  </div>
+</div>"
+`;
+
+exports[`Component: FormAuthMethod completed form view mode: disabled user_oidc app should show form errors if setup with oidc 1`] = `
+"<div class="authentication-method">
+  <formheading-stub index="2" title="Authentication method" iscomplete="true" haserror="true"></formheading-stub>
+  <errornote-stub errortitle="This feature requires version {version} (or higher) of {app}. Please install or update the app." errormessage="" errorlink="http://localhost/settings/apps/files/user_oidc" errorlinklabel="Install latest version now"></errornote-stub>
   <div class="auth-method">
     <p class="auth-method--label">
       Single-Sign-On through OpenID Connect Identity Provider
@@ -216,6 +260,7 @@ exports[`Component: FormAuthMethod completed form should show set form label 1`]
 exports[`Component: FormAuthMethod initial incomplete form current setting: authentication-method should save the setting on submit 1`] = `
 "<div class="authentication-method">
   <formheading-stub index="2" title="Authentication method" iscomplete="true"></formheading-stub>
+  <!---->
   <div class="auth-method">
     <p class="auth-method--label">
       Single-Sign-On through OpenID Connect Identity Provider
@@ -234,6 +279,7 @@ exports[`Component: FormAuthMethod initial incomplete form current setting: auth
 exports[`Component: FormAuthMethod initial incomplete form current setting: authentication-method should show error on save failure 1`] = `
 "<div class="authentication-method">
   <formheading-stub index="2" title="Authentication method"></formheading-stub>
+  <!---->
   <div class="auth-method">
     <div>
       <div class="auth-method--hint">
@@ -271,6 +317,7 @@ exports[`Component: FormAuthMethod initial incomplete form current setting: auth
 exports[`Component: FormAuthMethod initial incomplete form current setting: authentication-method should show the required form fields 1`] = `
 "<div class="authentication-method">
   <formheading-stub index="2" title="Authentication method"></formheading-stub>
+  <!---->
   <div class="auth-method">
     <div>
       <div class="auth-method--hint">
@@ -309,12 +356,14 @@ exports[`Component: FormAuthMethod initial incomplete form current setting: othe
 "<div class="authentication-method">
   <formheading-stub index="2" title="Authentication method" isdisabled="true"></formheading-stub>
   <!---->
+  <!---->
 </div>"
 `;
 
 exports[`Component: FormAuthMethod initial incomplete form disabled user_oidc app should show disabled error message and disabled sso button 1`] = `
 "<div class="authentication-method">
   <formheading-stub index="2" title="Authentication method"></formheading-stub>
+  <!---->
   <div class="auth-method">
     <div>
       <div class="auth-method--hint">
@@ -352,6 +401,7 @@ exports[`Component: FormAuthMethod initial incomplete form disabled user_oidc ap
 exports[`Component: FormAuthMethod initial incomplete form unsupported user_oidc app should show disabled error message and disabled sso button 1`] = `
 "<div class="authentication-method">
   <formheading-stub index="2" title="Authentication method"></formheading-stub>
+  <!---->
   <div class="auth-method">
     <div>
       <div class="auth-method--hint">


### PR DESCRIPTION
## Description
Show form errors on the respective section if the dependent app is not enabled or not supported.


## Related Issue or Workpackage
- Resolves https://community.openproject.org/wp/64267

## Screenshots (if appropriate):
<img width="961" height="784" alt="Screenshot from 2025-08-25 16-18-39" src="https://github.com/user-attachments/assets/04b4cc94-0428-425f-85ae-8e8befae72cb" />


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [x] Updated `CHANGELOG.md` file
