### PR TITLE
fix: Improve grammar and use placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fix: Each request to OpenProject gets new token when setup with external SSO with token-exchange [#867](https://github.com/nextcloud/integration_openproject/pull/867)
+- Improve translation support and fix grammar in the authentication method switch confirmation message [#875](https://github.com/nextcloud/integration_openproject/pull/875)
 
 ### Removed
 

--- a/src/components/admin/FormAuthMethod.vue
+++ b/src/components/admin/FormAuthMethod.vue
@@ -223,15 +223,16 @@ export default {
 		async saveSettings() {
 			// open the confirmation dialog when only swithing back and forth between two authorization method
 			if (this.isEditMode && this.isFormComplete) {
+				const message = t(
+					'integration_openproject',
+					'If you proceed with this method, you will have an {selectedAuthMethod} based authentication configuration which will delete all the configuration setting for current {savedAuthMethod} based authentication. You can switch back to it anytime.',
+					{
+						selectedAuthMethod: this.selectedAuthMethod.toUpperCase(),
+						savedAuthMethod: this.savedAuthMethod.toUpperCase(),
+					},
+				)
 				await OC.dialogs.confirmDestructive(
-					t(
-						'integration_openproject',
-						'If you proceed this method, you will have an '
-							+ this.selectedAuthMethod.toUpperCase()
-							+ ' based authentication configuration which will delete all the configuration setting for current '
-							+ this.savedAuthMethod.toUpperCase()
-							+ ' based authentication. You can switch back to it anytime.',
-					),
+					message,
 					t('integration_openproject', 'Switch Authentication Method'),
 					{
 						type: OC.dialogs.YES_NO_BUTTONS,


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Refactored the authentication switch confirmation message to use proper translation placeholders and fixed grammar for better translation.

_Taken a references from [link](https://docs.nextcloud.com/server/latest/developer_manual/basics/translations.html#javascript-typescript-vue)_



## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://community.openproject.org/projects/nextcloud-integration/work_packages/65931/

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Updated `CHANGELOG.md` file
