### PR TITLE
fix: return owner as a modifier for uploaded files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fix: No modifier for the first file upload [#877](https://github.com/nextcloud/integration_openproject/pull/877)
 - Fix: Each request to OpenProject gets new token when setup with external SSO with token-exchange [#867](https://github.com/nextcloud/integration_openproject/pull/867)
 - Improve translation support and fix grammar in the authentication method switch confirmation message [#875](https://github.com/nextcloud/integration_openproject/pull/875)
 - Do not show app error if the form is in disabled state [#880](https://github.com/nextcloud/integration_openproject/pull/880)

--- a/lib/Controller/FilesController.php
+++ b/lib/Controller/FilesController.php
@@ -234,15 +234,14 @@ class FilesController extends OCSController {
 	}
 
 	private function getLastModifier(string $ownerId, int $fileId, int $since = 0): ?IUser {
-		if (class_exists('\OCA\Activity\Data') &&
-			class_exists('\OCA\Activity\GroupHelperDisabled') &&
-			class_exists('\OCA\Activity\UserSettings')
+		if (!class_exists('\OCA\Activity\Data') ||
+			!class_exists('\OCA\Activity\GroupHelperDisabled') ||
+			!class_exists('\OCA\Activity\UserSettings')
 		) {
-			$activityData = Server::get(Data::class);
-		} else {
 			return null;
 		}
 
+		$activityData = Server::get(Data::class);
 		$groupHelper = Server::get(GroupHelperDisabled::class);
 		$userSettings = Server::get(UserSettings::class);
 		if (!method_exists($activityData, 'get') ||
@@ -272,7 +271,7 @@ class FilesController extends OCSController {
 				}
 				// rename and move events are also of type `file_changed` but don't have `changed_*` in the subject
 				// sadly we only get the localized subject from the `get()` request and need to do an other request.
-				// get modifier for created and changed (content changed) events only.
+				// Get modifier for created and changed (content changed) events only.
 				if (str_starts_with($activityDetails->getSubject(), 'created')
 					|| str_starts_with($activityDetails->getSubject(), 'changed')) {
 					return $this->userManager->get($activity['user']);

--- a/lib/Controller/FilesController.php
+++ b/lib/Controller/FilesController.php
@@ -261,15 +261,20 @@ class FilesController extends OCSController {
 			'files',
 			$fileId
 		);
+
+		// activities are in descending order
+		// so the first event in the list is the most recent one
 		foreach ($activities['data'] as $activity) {
-			if ($activity['type'] === 'file_changed') {
+			if (in_array($activity['type'], ['file_changed', 'file_created'])) {
 				$activityDetails = $activityData->getById($activity['activity_id']);
-				// rename and move events are also of type `file_changed` but don't have `changed_*` in the subject
-				// sadly we only get the localized subject from the `get()` request and need to do an other request
 				if (!method_exists($activityDetails, 'getSubject')) {
 					return null;
 				}
-				if (str_starts_with($activityDetails->getSubject(), 'changed')) {
+				// rename and move events are also of type `file_changed` but don't have `changed_*` in the subject
+				// sadly we only get the localized subject from the `get()` request and need to do an other request.
+				// get modifier for created and changed (content changed) events only.
+				if (str_starts_with($activityDetails->getSubject(), 'created')
+					|| str_starts_with($activityDetails->getSubject(), 'changed')) {
 					return $this->userManager->get($activity['user']);
 				}
 			}

--- a/tests/acceptance/features/api/getFileinfoByFileIDAPI.feature
+++ b/tests/acceptance/features/api/getFileinfoByFileIDAPI.feature
@@ -44,8 +44,8 @@ Feature: retrieve file information of a single file, using the file ID
       "mimetype": {"type": "string", "pattern": "^text\/plain$"},
       "owner_id": {"type": "string", "pattern": "^Carol$"},
       "owner_name": {"type": "string", "pattern": "^Carol$"},
-      "modifier_id": {"type": "null"},
-      "modifier_name": {"type": "null"},
+      "modifier_id": {"type": "string", "pattern": "^Carol$"},
+      "modifier_name": {"type": "string", "pattern": "^Carol$"},
       "dav_permissions": {"type": "string", "pattern":"^RGDNVW$"},
       "path": {"type": "string", "pattern":"^files/file.txt$"}
       }
@@ -94,8 +94,8 @@ Feature: retrieve file information of a single file, using the file ID
       "mimetype": {"type": "string", "pattern": "^text\/plain$"},
       "owner_id": {"type": "string", "pattern": "^Carol$"},
       "owner_name": {"type": "string", "pattern": "^Carol$"},
-      "modifier_id": {"type": "null"},
-      "modifier_name": {"type": "null"},
+      "modifier_id": {"type": "string", "pattern": "^Carol$"},
+      "modifier_name": {"type": "string", "pattern": "^Carol$"},
       "dav_permissions": {"type": "string", "pattern":"^RGDNVW"},
       "path": {"type": "string", "pattern":"^files\/subfolder\/file.txt$"}
       }
@@ -286,8 +286,8 @@ Feature: retrieve file information of a single file, using the file ID
       "name": {"type": "string", "pattern": "^file.txt$"},
       "owner_id": {"type": "string", "pattern": "^Carol$"},
       "owner_name": {"type": "string", "pattern": "^Carol$"},
-      "modifier_id": {"type": "null"},
-      "modifier_name": {"type": "null"},
+      "modifier_id": {"type": "string", "pattern": "^Carol$"},
+      "modifier_name": {"type": "string", "pattern": "^Carol$"},
       "dav_permissions": {"type": "string", "pattern":"^SRGNVW$"},
       "path": {"type": "string", "pattern":"^files/file.txt$"}
       }
@@ -328,8 +328,8 @@ Feature: retrieve file information of a single file, using the file ID
       "name": {"type": "string", "pattern": "^file.txt$"},
       "owner_id": {"type": "string", "pattern": "^Carol$"},
       "owner_name": {"type": "string", "pattern": "^Carol$"},
-      "modifier_id": {"type": "null"},
-      "modifier_name": {"type": "null"},
+      "modifier_id": {"type": "string", "pattern": "^Carol$"},
+      "modifier_name": {"type": "string", "pattern": "^Carol$"},
       "dav_permissions": {"type": "string", "pattern":"^SRGDNVW$"},
       "path": {"type": "string", "pattern":"^files\/to-share\/file.txt$"}
       }
@@ -371,8 +371,8 @@ Feature: retrieve file information of a single file, using the file ID
       "name": {"type": "string", "pattern": "^file.txt$"},
       "owner_id": {"type": "string", "pattern": "^Carol$"},
       "owner_name": {"type": "string", "pattern": "^Carol$"},
-      "modifier_id": {"type": "null"},
-      "modifier_name": {"type": "null"},
+      "modifier_id": {"type": "string", "pattern": "^Carol$"},
+      "modifier_name": {"type": "string", "pattern": "^Carol$"},
       "dav_permissions": {"type": "string", "pattern":"^SRGDNVW$"},
       "path": {"type": "string", "pattern":"^files\/to-share\/file.txt$"}
       }
@@ -413,8 +413,8 @@ Feature: retrieve file information of a single file, using the file ID
       "name": {"type": "string", "pattern": "^file.txt$"},
       "owner_id": {"type": "string", "pattern": "^Carol$"},
       "owner_name": {"type": "string", "pattern": "^Carol$"},
-      "modifier_id": {"type": "null"},
-      "modifier_name": {"type": "null"},
+      "modifier_id": {"type": "string", "pattern": "^Carol$"},
+      "modifier_name": {"type": "string", "pattern": "^Carol$"},
       "dav_permissions": {"type": "string", "pattern":"^SRGNVW$"},
       "path": {"type": "string", "pattern":"^files\/renamed.txt$"}
       }
@@ -456,8 +456,8 @@ Feature: retrieve file information of a single file, using the file ID
       "name": {"type": "string", "pattern": "^renamed.txt$"},
       "owner_id": {"type": "string", "pattern": "^Carol$"},
       "owner_name": {"type": "string", "pattern": "^Carol$"},
-      "modifier_id": {"type": "null"},
-      "modifier_name": {"type": "null"},
+      "modifier_id": {"type": "string", "pattern": "^Carol$"},
+      "modifier_name": {"type": "string", "pattern": "^Carol$"},
       "dav_permissions": {"type": "string", "pattern":"^SRGDNVW$"},
       "path": {"type": "string", "pattern":"^files\/to-share\/renamed.txt$"}
       }
@@ -946,8 +946,8 @@ Feature: retrieve file information of a single file, using the file ID
       "mimetype": {"type": "string", "pattern": "^application\/x-op-directory$"},
       "owner_id": {"type": "string", "pattern": "^Carol$"},
       "owner_name": {"type": "string", "pattern": "^Carol Hansen$"},
-      "modifier_id": {"type": "null"},
-      "modifier_name": {"type": "null"},
+      "modifier_id": {"type": "string", "pattern": "^Carol$"},
+      "modifier_name": {"type": "string", "pattern": "^Carol Hansen$"},
       "dav_permissions": {"type": "string", "pattern":"^RGDNVCK$"},
       "path": {"type": "string", "pattern":"^files\/folder\/$"}
       }
@@ -1156,8 +1156,8 @@ Feature: retrieve file information of a single file, using the file ID
       "name": {"type": "string", "pattern": "^file.txt$"},
       "owner_id": {"type": "string", "pattern": "^Carol$"},
       "owner_name": {"type": "string", "pattern": "^Carol Hansen$"},
-      "modifier_id": {"type": "null"},
-      "modifier_name": {"type": "null"},
+      "modifier_id": {"type": "string", "pattern": "^Carol$"},
+      "modifier_name": {"type": "string", "pattern": "^Carol Hansen$"},
       "dav_permissions": {"type": "string", "pattern":"^<requester-dav-permissions>$"},
       "path": {"type": "string", "pattern":"^files\/file.txt$"}
       }
@@ -1193,8 +1193,8 @@ Feature: retrieve file information of a single file, using the file ID
       "name": {"type": "string", "pattern": "^file.txt$"},
       "owner_id": {"type": "string", "pattern": "^Carol$"},
       "owner_name": {"type": "string", "pattern": "^Carol Hansen$"},
-      "modifier_id": {"type": "null"},
-      "modifier_name": {"type": "null"},
+      "modifier_id": {"type": "string", "pattern": "^Carol$"},
+      "modifier_name": {"type": "string", "pattern": "^Carol Hansen$"},
       "dav_permissions": {"type": "string", "pattern":"^<owner-dav-permissions>$"},
       "path": {"type": "string", "pattern":"^files\/file.txt$"}
       }
@@ -1247,8 +1247,8 @@ Feature: retrieve file information of a single file, using the file ID
       "name": {"type": "string", "pattern": "^folder$"},
       "owner_id": {"type": "string", "pattern": "^Carol$"},
       "owner_name": {"type": "string", "pattern": "^Carol Hansen$"},
-      "modifier_id": {"type": "null"},
-      "modifier_name": {"type": "null"},
+      "modifier_id": {"type": "string", "pattern": "^Carol$"},
+      "modifier_name": {"type": "string", "pattern": "^Carol Hansen$"},
       "dav_permissions": {"type": "string", "pattern":"^<requester-dav-permissions>$"},
       "path": {"type": "string", "pattern":"^files\/folder\/$"}
       }
@@ -1284,8 +1284,8 @@ Feature: retrieve file information of a single file, using the file ID
       "name": {"type": "string", "pattern": "^folder$"},
       "owner_id": {"type": "string", "pattern": "^Carol$"},
       "owner_name": {"type": "string", "pattern": "^Carol Hansen$"},
-      "modifier_id": {"type": "null"},
-      "modifier_name": {"type": "null"},
+      "modifier_id": {"type": "string", "pattern": "^Carol$"},
+      "modifier_name": {"type": "string", "pattern": "^Carol Hansen$"},
       "dav_permissions": {"type": "string", "pattern":"^<owner-dav-permissions>$"},
       "path": {"type": "string", "pattern":"^files\/folder\/$"}
       }
@@ -1344,8 +1344,8 @@ Feature: retrieve file information of a single file, using the file ID
       "name": {"type": "string", "pattern": "^groupFolder$"},
       "owner_id": {"type": "string", "pattern": "^Carol$"},
       "owner_name": {"type": "string", "pattern": "^Carol$"},
-      "modifier_id": {"type": "null"},
-      "modifier_name": {"type": "null"},
+      "modifier_id": null,
+      "modifier_name": null,
       "dav_permissions": {"type": "string", "pattern":"^RMGDNVCK$"},
       "path": {"type": "string", "pattern":"^files\/groupFolder\/$"}
       }

--- a/tests/acceptance/features/api/getFileinfoByFileIDAPI.feature
+++ b/tests/acceptance/features/api/getFileinfoByFileIDAPI.feature
@@ -1344,8 +1344,8 @@ Feature: retrieve file information of a single file, using the file ID
       "name": {"type": "string", "pattern": "^groupFolder$"},
       "owner_id": {"type": "string", "pattern": "^Carol$"},
       "owner_name": {"type": "string", "pattern": "^Carol$"},
-      "modifier_id": null,
-      "modifier_name": null,
+      "modifier_id": {"type": "null"},
+      "modifier_name": {"type": "null"},
       "dav_permissions": {"type": "string", "pattern":"^RMGDNVCK$"},
       "path": {"type": "string", "pattern":"^files\/groupFolder\/$"}
       }

--- a/tests/acceptance/features/api/getFilesinfoByFileIDsAPI.feature
+++ b/tests/acceptance/features/api/getFilesinfoByFileIDsAPI.feature
@@ -64,8 +64,8 @@ Feature: retrieve information of multiple files using the file IDs
               "mimetype": {"type": "string", "pattern": "^text\/plain$"},
               "owner_id": {"type": "string", "pattern": "^Carol$"},
               "owner_name": {"type": "string", "pattern": "^Carol$"},
-              "modifier_id": {"type": "null"},
-              "modifier_name": {"type": "null"},
+              "modifier_id": {"type": "string", "pattern": "^Carol$"},
+              "modifier_name": {"type": "string", "pattern": "^Carol$"},
               "dav_permissions": {"type": "string", "pattern":"^RGDNVW$"},
               "path": {"type": "string", "pattern":"^files\/file.txt$"}
             }
@@ -99,8 +99,8 @@ Feature: retrieve information of multiple files using the file IDs
               "mimetype": {"type": "string", "pattern": "^text\/plain$"},
               "owner_id": {"type": "string", "pattern": "^Brian$"},
               "owner_name": {"type": "string", "pattern": "^Brian Adams$"},
-              "modifier_id": {"type": "null"},
-              "modifier_name": {"type": "null"},
+              "modifier_id": {"type": "string", "pattern": "^Brian$"},
+              "modifier_name": {"type": "string", "pattern": "^Brian Adams$"},
               "dav_permissions": {"type": "string", "pattern":"^SRGNVW$"},
               "path": {"type": "string", "pattern":"^files\/renamedByCarol.txt$"}
             }
@@ -215,8 +215,8 @@ Feature: retrieve information of multiple files using the file IDs
               "mimetype": {"type": "string", "pattern": "^application\/x-op-directory$"},
               "owner_id": {"type": "string", "pattern": "^Carol$"},
               "owner_name": {"type": "string", "pattern": "^Carol$"},
-              "modifier_id": {"type": "null"},
-              "modifier_name": {"type": "null"},
+              "modifier_id": null,
+              "modifier_name": null,
               "dav_permissions": {"type": "string", "pattern":"^RMGDNVCK"},
               "path": {"type": "string", "pattern":"^files/groupFolder\/$"}
             }

--- a/tests/acceptance/features/api/getFilesinfoByFileIDsAPI.feature
+++ b/tests/acceptance/features/api/getFilesinfoByFileIDsAPI.feature
@@ -215,8 +215,8 @@ Feature: retrieve information of multiple files using the file IDs
               "mimetype": {"type": "string", "pattern": "^application\/x-op-directory$"},
               "owner_id": {"type": "string", "pattern": "^Carol$"},
               "owner_name": {"type": "string", "pattern": "^Carol$"},
-              "modifier_id": null,
-              "modifier_name": null,
+              "modifier_id": {"type": "null"},
+              "modifier_name": {"type": "null"},
               "dav_permissions": {"type": "string", "pattern":"^RMGDNVCK"},
               "path": {"type": "string", "pattern":"^files/groupFolder\/$"}
             }

--- a/tests/lib/Controller/FilesControllerTest.php
+++ b/tests/lib/Controller/FilesControllerTest.php
@@ -8,31 +8,27 @@
 
 namespace OCA\OpenProject\Controller;
 
+use OCA\Activity\Data;
+use OCA\Activity\GroupHelperDisabled;
+use OCA\Activity\UserSettings;
 use OCP\Activity\IManager;
 use OCP\Files\Config\ICachedMountFileInfo;
+use OCP\Files\Config\IUserMountCache;
 use OCP\Files\DavUtil;
+use OCP\Files\Folder;
 use OCP\Files\Node;
 use OCP\IDBConnection;
 use OCP\IRequest;
+use OCP\IUser;
 use OCP\IUserManager;
+use phpmock\phpunit\PHPMock;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use function PHPUnit\Framework\assertSame;
 
-/**
- * overriding the class_exists method, so that the unit tests always pass,
- * no matter if the activity app is enabled or not
- */
-function class_exists(string $className): bool {
-	if ($className === '\OCA\Activity\Data') {
-		return false;
-	} else {
-		return \class_exists($className);
-	}
-}
-
 class FilesControllerTest extends TestCase {
+	use PHPMock;
 
 	/**
 	 * @return array<mixed>
@@ -110,7 +106,7 @@ class FilesControllerTest extends TestCase {
 		$expectedMimeType,
 		$expectedPath
 	) {
-		$folderMock = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$folderMock = $this->getMockBuilder(Folder::class)->getMock();
 		$folderMock->method('getById')->willReturn($nodeMocks);
 
 		$mountCacheMock = $this->getSimpleMountCacheMock($internalPath);
@@ -142,7 +138,7 @@ class FilesControllerTest extends TestCase {
 	}
 
 	public function testGetFileInfoFileNotFound(): void {
-		$folderMock = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$folderMock = $this->getMockBuilder(Folder::class)->getMock();
 		$folderMock->method('getById')->willReturn([]);
 
 		$filesController = $this->createFilesController($folderMock);
@@ -153,9 +149,9 @@ class FilesControllerTest extends TestCase {
 	}
 
 	public function testGetFileInfoFileExistingButNotReadable(): void {
-		$folderMock = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$folderMock = $this->getMockBuilder(Folder::class)->getMock();
 		$folderMock->method('getById')->willReturn([]);
-		$mountCacheMock = $this->getMockBuilder('\OCP\Files\Config\IUserMountCache')->getMock();
+		$mountCacheMock = $this->getMockBuilder(IUserMountCache::class)->getMock();
 		$mountCacheMock->method('getMountsForFileId')
 			->willReturn(
 				[$this->createMock(ICachedMountFileInfo::class)]
@@ -171,12 +167,12 @@ class FilesControllerTest extends TestCase {
 	}
 
 	public function testGetFileInfoFileExistingButCannotGetNameInContextOfOwner(): void {
-		$folderMock = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$folderMock = $this->getMockBuilder(Folder::class)->getMock();
 		$folderMock->method('getById')->willReturn(
 			[$this->getNodeMock('image/png', 586, 'file', '/testUser/files/name-in-the-context-of-requester')]
 		);
 
-		$mountCacheMock = $this->getMockBuilder('\OCP\Files\Config\IUserMountCache')->getMock();
+		$mountCacheMock = $this->getMockBuilder(IUserMountCache::class)->getMock();
 		$mountCacheMock->method('getMountsForFileId')
 			->willReturn(
 				[null]
@@ -192,7 +188,7 @@ class FilesControllerTest extends TestCase {
 	}
 
 	public function testGetFilesInfoFourIdsRequestedOneExistsOneInTrashOneNotExisitingOneForbidden(): void {
-		$folderMock = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$folderMock = $this->getMockBuilder(Folder::class)->getMock();
 		$folderMock->method('getById')
 			->withConsecutive([123], [759], [365], [956])
 			->willReturnOnConsecutiveCalls(
@@ -204,7 +200,7 @@ class FilesControllerTest extends TestCase {
 			);
 
 		$cachedMountFileInfoMock = $this->getMockBuilder(
-			'\OCP\Files\Config\ICachedMountFileInfo'
+			ICachedMountFileInfo::class
 		)->getMock();
 		$cachedMountFileInfoMock->method('getInternalPath')
 			->willReturnOnConsecutiveCalls(
@@ -213,12 +209,12 @@ class FilesControllerTest extends TestCase {
 				'/anotherUser/files/logo.png'
 			);
 
-		$ownerMock = $this->getMockBuilder('\OCP\IUser')->getMock();
+		$ownerMock = $this->getMockBuilder(Iuser::class)->getMock();
 		$ownerMock->method('getUID')->willReturn('3df8ff78-49cb-4d60-8d8b-171b29591fd3');
 		$cachedMountFileInfoMock->method('getUser')
 			->willReturn($ownerMock);
 
-		$mountCacheMock = $this->getMockBuilder('\OCP\Files\Config\IUserMountCache')->getMock();
+		$mountCacheMock = $this->getMockBuilder(IUserMountCache::class)->getMock();
 		$mountCacheMock->method('getMountsForFileId')
 			->withConsecutive([123], [759], [365], [956])
 			->willReturnOnConsecutiveCalls(
@@ -248,7 +244,7 @@ class FilesControllerTest extends TestCase {
 	}
 
 	public function testGetFilesInfoOneIdRequestedFileExistsReturnsOneResult(): void {
-		$folderMock = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$folderMock = $this->getMockBuilder(Folder::class)->getMock();
 		$folderMock->method('getById')
 			->willReturn(
 				[
@@ -273,7 +269,7 @@ class FilesControllerTest extends TestCase {
 	}
 
 	public function testGetFilesInfoThreeIdsRequestedOneFileExistsReturnsOneResult(): void {
-		$folderMock = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$folderMock = $this->getMockBuilder(Folder::class)->getMock();
 		$folderMock->method('getById')
 			->withConsecutive([123], [256], [365])
 			->willReturnOnConsecutiveCalls(
@@ -285,15 +281,15 @@ class FilesControllerTest extends TestCase {
 			);
 
 		$cachedMountFileInfoMock = $this->getMockBuilder(
-			'\OCP\Files\Config\ICachedMountFileInfo'
+			ICachedMountFileInfo::class
 		)->getMock();
 		$cachedMountFileInfoMock->method('getInternalPath')
 			->willReturn('files/logo.png');
-		$ownerMock = $this->getMockBuilder('\OCP\IUser')->getMock();
+		$ownerMock = $this->getMockBuilder(Iuser::class)->getMock();
 		$ownerMock->method('getUID')->willReturn('3df8ff78-49cb-4d60-8d8b-171b29591fd3');
 		$cachedMountFileInfoMock->method('getUser')
 			->willReturn($ownerMock);
-		$mountCacheMock = $this->getMockBuilder('\OCP\Files\Config\IUserMountCache')
+		$mountCacheMock = $this->getMockBuilder(IUserMountCache::class)
 			->getMock();
 		$mountCacheMock->method('getMountsForFileId')
 			->willReturnOnConsecutiveCalls(
@@ -318,7 +314,7 @@ class FilesControllerTest extends TestCase {
 	}
 
 	public function testGetFilesInfoTwoIdsRequestedAllFilesExistsEachReturnsOneResult(): void {
-		$folderMock = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$folderMock = $this->getMockBuilder(Folder::class)->getMock();
 		$folderMock->method('getById')
 			->withConsecutive([123], [365])
 			->willReturnOnConsecutiveCalls(
@@ -330,18 +326,18 @@ class FilesControllerTest extends TestCase {
 				]
 			);
 		$cachedMountFileInfoMock = $this->getMockBuilder(
-			'\OCP\Files\Config\ICachedMountFileInfo'
+			ICachedMountFileInfo::class
 		)->getMock();
 		$cachedMountFileInfoMock->method('getInternalPath')
 			->willReturnOnConsecutiveCalls(
 				'files/logo.png',
 				'files/inFolder/image.png',
 			);
-		$ownerMock = $this->getMockBuilder('\OCP\IUser')->getMock();
+		$ownerMock = $this->getMockBuilder(Iuser::class)->getMock();
 		$ownerMock->method('getUID')->willReturn('3df8ff78-49cb-4d60-8d8b-171b29591fd3');
 		$cachedMountFileInfoMock->method('getUser')
 			->willReturn($ownerMock);
-		$mountCacheMock = $this->getMockBuilder('\OCP\Files\Config\IUserMountCache')
+		$mountCacheMock = $this->getMockBuilder(IUserMountCache::class)
 			->getMock();
 		$mountCacheMock->method('getMountsForFileId')
 			->willReturn(
@@ -364,7 +360,7 @@ class FilesControllerTest extends TestCase {
 	}
 
 	public function testGetFilesInfoTwoIdsRequestedAllFilesExistsEachReturnsMultipleResults(): void {
-		$folderMock = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$folderMock = $this->getMockBuilder(Folder::class)->getMock();
 		$folderMock->method('getById')
 			->withConsecutive([123], [365])
 			->willReturnOnConsecutiveCalls(
@@ -377,18 +373,18 @@ class FilesControllerTest extends TestCase {
 			);
 
 		$cachedMountFileInfoMock = $this->getMockBuilder(
-			'\OCP\Files\Config\ICachedMountFileInfo'
+			ICachedMountFileInfo::class
 		)->getMock();
 		$cachedMountFileInfoMock->method('getInternalPath')
 			->willReturnOnConsecutiveCalls(
 				'files/logo.png',
 				'files/inFolder/image.png',
 			);
-		$ownerMock = $this->getMockBuilder('\OCP\IUser')->getMock();
+		$ownerMock = $this->getMockBuilder(Iuser::class)->getMock();
 		$ownerMock->method('getUID')->willReturn('3df8ff78-49cb-4d60-8d8b-171b29591fd3');
 		$cachedMountFileInfoMock->method('getUser')
 			->willReturn($ownerMock);
-		$mountCacheMock = $this->getMockBuilder('\OCP\Files\Config\IUserMountCache')
+		$mountCacheMock = $this->getMockBuilder(IUserMountCache::class)
 			->getMock();
 		$mountCacheMock->method('getMountsForFileId')
 			->willReturn(
@@ -412,7 +408,7 @@ class FilesControllerTest extends TestCase {
 	}
 
 	public function testGetFilesInfoTwoIdsRequestedEachReturnsOneFolder(): void {
-		$folderMock = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$folderMock = $this->getMockBuilder(Folder::class)->getMock();
 		$folderMock->method('getById')
 			->withConsecutive([2], [3])
 			->willReturnOnConsecutiveCalls(
@@ -435,18 +431,18 @@ class FilesControllerTest extends TestCase {
 			);
 
 		$cachedMountFileInfoMock = $this->getMockBuilder(
-			'\OCP\Files\Config\ICachedMountFileInfo'
+			ICachedMountFileInfo::class
 		)->getMock();
 		$cachedMountFileInfoMock->method('getInternalPath')
 			->willReturnOnConsecutiveCalls(
 				'files/myFolder/a-sub-folder',
 				'files'
 			);
-		$ownerMock = $this->getMockBuilder('\OCP\IUser')->getMock();
+		$ownerMock = $this->getMockBuilder(Iuser::class)->getMock();
 		$ownerMock->method('getUID')->willReturn('3df8ff78-49cb-4d60-8d8b-171b29591fd3');
 		$cachedMountFileInfoMock->method('getUser')
 			->willReturn($ownerMock);
-		$mountCacheMock = $this->getMockBuilder('\OCP\Files\Config\IUserMountCache')->getMock();
+		$mountCacheMock = $this->getMockBuilder(IUserMountCache::class)->getMock();
 		$mountCacheMock->method('getMountsForFileId')
 			->willReturn(
 				[$cachedMountFileInfoMock]
@@ -500,7 +496,7 @@ class FilesControllerTest extends TestCase {
 	}
 
 	public function testGetFilesInfoInvalidRequest(): void {
-		$folderMock = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$folderMock = $this->getMockBuilder(Folder::class)->getMock();
 		$filesController = $this->createFilesController($folderMock);
 
 		$result = $filesController->getFilesInfo(null);
@@ -512,7 +508,7 @@ class FilesControllerTest extends TestCase {
 	}
 
 	public function testGetFilesInfoSendStringIds(): void {
-		$folderMock = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$folderMock = $this->getMockBuilder(Folder::class)->getMock();
 		$folderMock->method('getById')
 			->withConsecutive([2], [3])
 			->willReturnOnConsecutiveCalls(
@@ -535,18 +531,18 @@ class FilesControllerTest extends TestCase {
 			);
 
 		$cachedMountFileInfoMock = $this->getMockBuilder(
-			'\OCP\Files\Config\ICachedMountFileInfo'
+			ICachedMountFileInfo::class
 		)->getMock();
 		$cachedMountFileInfoMock->method('getInternalPath')
 			->willReturnOnConsecutiveCalls(
 				'files/myFolder/a-sub-folder',
 				''
 			);
-		$ownerMock = $this->getMockBuilder('\OCP\IUser')->getMock();
+		$ownerMock = $this->getMockBuilder(Iuser::class)->getMock();
 		$ownerMock->method('getUID')->willReturn('3df8ff78-49cb-4d60-8d8b-171b29591fd3');
 		$cachedMountFileInfoMock->method('getUser')
 			->willReturn($ownerMock);
-		$mountCacheMock = $this->getMockBuilder('\OCP\Files\Config\IUserMountCache')->getMock();
+		$mountCacheMock = $this->getMockBuilder(IUserMountCache::class)->getMock();
 		$mountCacheMock->method('getMountsForFileId')
 			->willReturn(
 				[$cachedMountFileInfoMock]
@@ -597,6 +593,41 @@ class FilesControllerTest extends TestCase {
 			$result->getData()
 		);
 		assertSame(200, $result->getStatus());
+	}
+
+	public function testGetFileInfoWithLastModifier() {
+		$classExistsMock = $this->getFunctionMock(__NAMESPACE__, "class_exists");
+		$classExistsMock->expects($this->any())->willReturn(false);
+
+		$folderMock = $this->getMockBuilder(Folder::class)->getMock();
+		$folderMock->method('getById')
+			->willReturn([
+				$this->getNodeMock('image/png', 1, 'file', '/testUser/files/inFolder/image.png')
+			]);
+		$cachedMountFileInfoMock = $this->getMockBuilder(ICachedMountFileInfo::class)->getMock();
+		$cachedMountFileInfoMock
+			->method('getInternalPath')
+			->willReturn('files/inFolder/image.png');
+		$ownerMock = $this->getMockBuilder(IUser::class)->getMock();
+		$ownerMock->method('getUID')->willReturn('3df8ff78-49cb-4d60-8d8b-171b29591fd3');
+		$cachedMountFileInfoMock
+			->method('getUser')
+			->willReturn($ownerMock);
+		$mountCacheMock = $this->getMockBuilder(IUserMountCache::class)->getMock();
+		$mountCacheMock->method('getMountsForFileId')
+			->willReturn(
+				[$cachedMountFileInfoMock]
+			);
+		$filesController = $this->getFilesControllerMock(
+			['getDavPermissions'], $folderMock, $mountCacheMock
+		);
+		$filesController
+			->method('getDavPermissions')
+			->willReturn('RGDNVCK');
+
+		$result = $filesController->getFileInfo(1);
+		$this->assertNull($result->getData()['modifier_name']);
+		$this->assertNull($result->getData()['modifier_id']);
 	}
 
 	/**
@@ -724,7 +755,7 @@ class FilesControllerTest extends TestCase {
 		$name,
 		$path
 	): void {
-		$folderMock = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$folderMock = $this->getMockBuilder(Folder::class)->getMock();
 		$folderMock->method('getById')->willReturn($nodeMocks);
 
 		$mountCacheMock = $this->getSimpleMountCacheMock($path);
@@ -756,7 +787,6 @@ class FilesControllerTest extends TestCase {
 		);
 		assertSame(200, $result->getStatus());
 	}
-
 
 	/**
 	 * @var array<mixed>
@@ -846,14 +876,14 @@ class FilesControllerTest extends TestCase {
 		$storageMock = $this->getMockBuilder('\OCP\Files\IRootFolder')->getMock();
 		$storageMock->method('getUserFolder')->willReturn($folderMock);
 
-		$userMock = $this->getMockBuilder('\OCP\IUser')->getMock();
+		$userMock = $this->getMockBuilder(Iuser::class)->getMock();
 		$userMock->method('getUID')->willReturn('testUser');
 
 		$userSessionMock = $this->getMockBuilder('\OCP\IUserSession')->getMock();
 		$userSessionMock->method('getUser')->willReturn($userMock);
 
 		if ($mountCacheMock === null) {
-			$mountCacheMock = $this->getMockBuilder('\OCP\Files\Config\IUserMountCache')->getMock();
+			$mountCacheMock = $this->getMockBuilder(IUserMountCache::class)->getMock();
 			$mountCacheMock->method('getMountsForFileId')->willReturn([]);
 		}
 
@@ -893,14 +923,14 @@ class FilesControllerTest extends TestCase {
 		$storageMock = $this->getMockBuilder('\OCP\Files\IRootFolder')->getMock();
 		$storageMock->method('getUserFolder')->willReturn($folderMock);
 
-		$userMock = $this->getMockBuilder('\OCP\IUser')->getMock();
+		$userMock = $this->getMockBuilder(Iuser::class)->getMock();
 		$userMock->method('getUID')->willReturn('testUser');
 
 		$userSessionMock = $this->getMockBuilder('\OCP\IUserSession')->getMock();
 		$userSessionMock->method('getUser')->willReturn($userMock);
 
 		if ($mountCacheMock === null) {
-			$mountCacheMock = $this->getMockBuilder('\OCP\Files\Config\IUserMountCache')->getMock();
+			$mountCacheMock = $this->getMockBuilder(IUserMountCache::class)->getMock();
 			$mountCacheMock->method('getMountsForFileId')->willReturn([]);
 		}
 		if ($davUtilsMock === null) {
@@ -945,7 +975,7 @@ class FilesControllerTest extends TestCase {
 		bool $isUpdateable = true,
 		bool $isCreatable = true
 	): Node {
-		$ownerMock = $this->getMockBuilder('\OCP\IUser')->getMock();
+		$ownerMock = $this->getMockBuilder(Iuser::class)->getMock();
 		$ownerMock->method('getDisplayName')->willReturn('Test User');
 		$ownerMock->method('getUID')->willReturn('3df8ff78-49cb-4d60-8d8b-171b29591fd3');
 
@@ -972,16 +1002,16 @@ class FilesControllerTest extends TestCase {
 	}
 
 	private function getSimpleMountCacheMock(string $internalPath): MockObject {
-		$ownerMock = $this->getMockBuilder('\OCP\IUser')->getMock();
+		$ownerMock = $this->getMockBuilder(Iuser::class)->getMock();
 		$ownerMock->method('getUID')->willReturn('3df8ff78-49cb-4d60-8d8b-171b29591fd3');
 		$cachedMountFileInfoMock = $this->getMockBuilder(
-			'\OCP\Files\Config\ICachedMountFileInfo'
+			ICachedMountFileInfo::class
 		)->getMock();
 		$cachedMountFileInfoMock->method('getInternalPath')
 			->willReturn($internalPath);
 		$cachedMountFileInfoMock->method('getUser')
 			->willReturn($ownerMock);
-		$mountCacheMock = $this->getMockBuilder('\OCP\Files\Config\IUserMountCache')
+		$mountCacheMock = $this->getMockBuilder(IUserMountCache::class)
 			->getMock();
 		$mountCacheMock->method('getMountsForFileId')
 			->willReturn(

--- a/tests/lib/Controller/FilesControllerTest.php
+++ b/tests/lib/Controller/FilesControllerTest.php
@@ -8,9 +8,6 @@
 
 namespace OCA\OpenProject\Controller;
 
-use OCA\Activity\Data;
-use OCA\Activity\GroupHelperDisabled;
-use OCA\Activity\UserSettings;
 use OCP\Activity\IManager;
 use OCP\Files\Config\ICachedMountFileInfo;
 use OCP\Files\Config\IUserMountCache;
@@ -209,7 +206,7 @@ class FilesControllerTest extends TestCase {
 				'/anotherUser/files/logo.png'
 			);
 
-		$ownerMock = $this->getMockBuilder(Iuser::class)->getMock();
+		$ownerMock = $this->getMockBuilder(IUser::class)->getMock();
 		$ownerMock->method('getUID')->willReturn('3df8ff78-49cb-4d60-8d8b-171b29591fd3');
 		$cachedMountFileInfoMock->method('getUser')
 			->willReturn($ownerMock);
@@ -285,7 +282,7 @@ class FilesControllerTest extends TestCase {
 		)->getMock();
 		$cachedMountFileInfoMock->method('getInternalPath')
 			->willReturn('files/logo.png');
-		$ownerMock = $this->getMockBuilder(Iuser::class)->getMock();
+		$ownerMock = $this->getMockBuilder(IUser::class)->getMock();
 		$ownerMock->method('getUID')->willReturn('3df8ff78-49cb-4d60-8d8b-171b29591fd3');
 		$cachedMountFileInfoMock->method('getUser')
 			->willReturn($ownerMock);
@@ -333,7 +330,7 @@ class FilesControllerTest extends TestCase {
 				'files/logo.png',
 				'files/inFolder/image.png',
 			);
-		$ownerMock = $this->getMockBuilder(Iuser::class)->getMock();
+		$ownerMock = $this->getMockBuilder(IUser::class)->getMock();
 		$ownerMock->method('getUID')->willReturn('3df8ff78-49cb-4d60-8d8b-171b29591fd3');
 		$cachedMountFileInfoMock->method('getUser')
 			->willReturn($ownerMock);
@@ -380,7 +377,7 @@ class FilesControllerTest extends TestCase {
 				'files/logo.png',
 				'files/inFolder/image.png',
 			);
-		$ownerMock = $this->getMockBuilder(Iuser::class)->getMock();
+		$ownerMock = $this->getMockBuilder(IUser::class)->getMock();
 		$ownerMock->method('getUID')->willReturn('3df8ff78-49cb-4d60-8d8b-171b29591fd3');
 		$cachedMountFileInfoMock->method('getUser')
 			->willReturn($ownerMock);
@@ -438,7 +435,7 @@ class FilesControllerTest extends TestCase {
 				'files/myFolder/a-sub-folder',
 				'files'
 			);
-		$ownerMock = $this->getMockBuilder(Iuser::class)->getMock();
+		$ownerMock = $this->getMockBuilder(IUser::class)->getMock();
 		$ownerMock->method('getUID')->willReturn('3df8ff78-49cb-4d60-8d8b-171b29591fd3');
 		$cachedMountFileInfoMock->method('getUser')
 			->willReturn($ownerMock);
@@ -538,7 +535,7 @@ class FilesControllerTest extends TestCase {
 				'files/myFolder/a-sub-folder',
 				''
 			);
-		$ownerMock = $this->getMockBuilder(Iuser::class)->getMock();
+		$ownerMock = $this->getMockBuilder(IUser::class)->getMock();
 		$ownerMock->method('getUID')->willReturn('3df8ff78-49cb-4d60-8d8b-171b29591fd3');
 		$cachedMountFileInfoMock->method('getUser')
 			->willReturn($ownerMock);
@@ -876,7 +873,7 @@ class FilesControllerTest extends TestCase {
 		$storageMock = $this->getMockBuilder('\OCP\Files\IRootFolder')->getMock();
 		$storageMock->method('getUserFolder')->willReturn($folderMock);
 
-		$userMock = $this->getMockBuilder(Iuser::class)->getMock();
+		$userMock = $this->getMockBuilder(IUser::class)->getMock();
 		$userMock->method('getUID')->willReturn('testUser');
 
 		$userSessionMock = $this->getMockBuilder('\OCP\IUserSession')->getMock();
@@ -923,7 +920,7 @@ class FilesControllerTest extends TestCase {
 		$storageMock = $this->getMockBuilder('\OCP\Files\IRootFolder')->getMock();
 		$storageMock->method('getUserFolder')->willReturn($folderMock);
 
-		$userMock = $this->getMockBuilder(Iuser::class)->getMock();
+		$userMock = $this->getMockBuilder(IUser::class)->getMock();
 		$userMock->method('getUID')->willReturn('testUser');
 
 		$userSessionMock = $this->getMockBuilder('\OCP\IUserSession')->getMock();
@@ -975,7 +972,7 @@ class FilesControllerTest extends TestCase {
 		bool $isUpdateable = true,
 		bool $isCreatable = true
 	): Node {
-		$ownerMock = $this->getMockBuilder(Iuser::class)->getMock();
+		$ownerMock = $this->getMockBuilder(IUser::class)->getMock();
 		$ownerMock->method('getDisplayName')->willReturn('Test User');
 		$ownerMock->method('getUID')->willReturn('3df8ff78-49cb-4d60-8d8b-171b29591fd3');
 
@@ -1002,7 +999,7 @@ class FilesControllerTest extends TestCase {
 	}
 
 	private function getSimpleMountCacheMock(string $internalPath): MockObject {
-		$ownerMock = $this->getMockBuilder(Iuser::class)->getMock();
+		$ownerMock = $this->getMockBuilder(IUser::class)->getMock();
 		$ownerMock->method('getUID')->willReturn('3df8ff78-49cb-4d60-8d8b-171b29591fd3');
 		$cachedMountFileInfoMock = $this->getMockBuilder(
 			ICachedMountFileInfo::class


### PR DESCRIPTION
## Description
Return owner as the modifier for the first upload.

#### Steps
1. Enable [activity](https://github.com/nextcloud/activity) app
2. Setup the integration_openproject app
3. Upload a file (note the file id)
4. Check file info for modifier (uploader should be as the modifier)
```
curl https://nextcloud.local/ocs/v1.php/apps/integration_openproject/fileinfo/{file_id} \
-H "Accept: application/json" -H "OCS-APIRequest: true" -u admin:admin
```

## Related Issue or Workpackage
- Fixes [56323](https://community.openproject.org/wp/56323)

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [x] Updated `CHANGELOG.md` file
