### PR TITLE
build: enable bearer token check for the requests

### DIFF
--- a/dev/compose.yaml
+++ b/dev/compose.yaml
@@ -142,7 +142,8 @@ services:
       OPENPROJECT_EDITION: ${OPENPROJECT_EDITION:-standard}
       OPENPROJECT_SEED__ADMIN__USER__PASSWORD__RESET: false
       OPENPROJECT_APIV3__ENABLE__BASIC__AUTH: true
-      OPENPROJECT_AUTHENTICATION: '{"global_basic_auth":{"user": "admin", "password": "admin"}}'
+      OPENPROJECT_AUTHENTICATION_GLOBAL__BASIC__AUTH_USER: 'admin'
+      OPENPROJECT_AUTHENTICATION_GLOBAL__BASIC__AUTH_PASSWORD: 'admin'
     volumes:
       - ./openproject.sh:/openproject.sh
       - opdata:/var/openproject/assets

--- a/dev/nextcloud/hooks/after-install.sh
+++ b/dev/nextcloud/hooks/after-install.sh
@@ -15,3 +15,4 @@ occ user_oidc:provider Keycloak \
     -s 'nextcloud-secret' \
     -d 'https://keycloak.local/realms/opnc/.well-known/openid-configuration' \
     -o 'openid profile email api_v3'
+occ user_oidc:provider Keycloak --check-bearer 1


### PR DESCRIPTION
## Description
Enable bearer token check for the oidc provider during the Nextcloud setup.
```
occ user_oidc:provider Keycloak --check-bearer 1
```

## Related Issue or Workpackage


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
