### PR TITLE
chore: customize error message for groupfolder deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix: Each request to OpenProject gets new token when setup with external SSO with token-exchange [#867](https://github.com/nextcloud/integration_openproject/pull/867)
 - Improve translation support and fix grammar in the authentication method switch confirmation message [#875](https://github.com/nextcloud/integration_openproject/pull/875)
 - Do not show app error if the form is in disabled state [#880](https://github.com/nextcloud/integration_openproject/pull/880)
+- Show meaningful error message when deleting group folders [#884](https://github.com/nextcloud/integration_openproject/pull/884)
 
 ### Removed
 

--- a/lib/Listener/BeforeNodeInsideOpenProjectGroupfilderChangedListener.php
+++ b/lib/Listener/BeforeNodeInsideOpenProjectGroupfilderChangedListener.php
@@ -71,11 +71,11 @@ class BeforeNodeInsideOpenProjectGroupfilderChangedListener implements IEventLis
 		) {
 			if (!class_exists("\OCP\HintException")) {
 				throw new \OCP\HintException(
-					'project folders cannot be deleted or renamed'
+					'This is configured as a project folder on OpenProject and cannot be deleted or renamed.'
 				);
 			}
 			throw new \OC\HintException(
-				'project folders cannot be deleted or renamed'
+				'This is configured as a project folder on OpenProject and cannot be deleted or renamed.'
 			);
 		}
 	}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR replaced the generic error with a meaning message saying project folders cannot be deleted.

previous: `project folders cannot be deleted or renamed`
After: `This is configured as a project folder on OpenProject and cannot be deleted or renamed.`

## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://community.openproject.org/projects/nextcloud-integration/work_packages/67061

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
