### PR TITLE
fix: provide a default app name if the app is not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix: Each request to OpenProject gets new token when setup with external SSO with token-exchange [#867](https://github.com/nextcloud/integration_openproject/pull/867)
 - Improve translation support and fix grammar in the authentication method switch confirmation message [#875](https://github.com/nextcloud/integration_openproject/pull/875)
 - Do not show app error if the form is in disabled state [#880](https://github.com/nextcloud/integration_openproject/pull/880)
+- Fix: Empty app name if app is not available [#876](https://github.com/nextcloud/integration_openproject/pull/876)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix: Each request to OpenProject gets new token when setup with external SSO with token-exchange [#867](https://github.com/nextcloud/integration_openproject/pull/867)
 - Improve translation support and fix grammar in the authentication method switch confirmation message [#875](https://github.com/nextcloud/integration_openproject/pull/875)
 - Do not show app error if the form is in disabled state [#880](https://github.com/nextcloud/integration_openproject/pull/880)
-- Fix: Empty app name if app is not available [#876](https://github.com/nextcloud/integration_openproject/pull/876)
+- Fix: Empty app name if the app is not available [#886](https://github.com/nextcloud/integration_openproject/pull/886)
 
 ### Removed
 

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -60,6 +60,16 @@ class Application extends App implements IBootstrap {
 	public const OPENPROJECT_ALL_GROUP_NAME = 'OpenProjectSuspended';
 	public const  OPENPROJECT_API_SCOPES = ['api_v3'];
 
+	// default app name
+	private const DEFAULT_APP_NAMES = [
+		'activity' => 'Activity',
+		'admin_audit' => 'Auditing / Logging',
+		'groupfolders' => 'Group folders',
+		'integration_openproject' => 'OpenProject Integration',
+		'oidc' => 'OIDC Identity Provider',
+		'user_oidc' => 'OpenID Connect user backend',
+	];
+
 	/**
 	 * @var mixed
 	 */
@@ -75,6 +85,19 @@ class Application extends App implements IBootstrap {
 
 		$container = $this->getContainer();
 		$this->config = $container->get(IConfig::class);
+	}
+
+	/**
+	 * @param string $appId
+	 *
+	 * @return string
+	 */
+	public static function getDefaultAppName(string $appId): string {
+		if (isset(self::DEFAULT_APP_NAMES[$appId])) {
+			return self::DEFAULT_APP_NAMES[$appId];
+		}
+
+		return $appId;
 	}
 
 	public function register(IRegistrationContext $context): void {

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -68,6 +68,7 @@ class Application extends App implements IBootstrap {
 		'integration_openproject' => 'OpenProject Integration',
 		'oidc' => 'OIDC Identity Provider',
 		'user_oidc' => 'OpenID Connect user backend',
+		'terms_of_service' => 'Terms of service',
 	];
 
 	/**

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -64,7 +64,7 @@ class Application extends App implements IBootstrap {
 	private const DEFAULT_APP_NAMES = [
 		'activity' => 'Activity',
 		'admin_audit' => 'Auditing / Logging',
-		'groupfolders' => 'Group folders',
+		'groupfolders' => 'Team folders',
 		'integration_openproject' => 'OpenProject Integration',
 		'oidc' => 'OIDC Identity Provider',
 		'user_oidc' => 'OpenID Connect user backend',

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -1853,12 +1853,12 @@ class OpenProjectAPIService {
 
 		if ($appInfo === null) {
 			$this->logger->debug("App not found using appId: $appId", ['app' => $this->appName]);
-			return '';
+			return $appId;
 		}
 
 		if (!array_key_exists('name', $appInfo)) {
 			$this->logger->debug("Missing 'name' property for app: $appId", ['app' => $this->appName]);
-			return '';
+			return $appId;
 		}
 
 		return $appInfo['name'];

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -1853,12 +1853,12 @@ class OpenProjectAPIService {
 
 		if ($appInfo === null) {
 			$this->logger->debug("App not found using appId: $appId", ['app' => $this->appName]);
-			return $appId;
+			return Application::getDefaultAppName($appId);
 		}
 
 		if (!array_key_exists('name', $appInfo)) {
 			$this->logger->debug("Missing 'name' property for app: $appId", ['app' => $this->appName]);
-			return $appId;
+			return Application::getDefaultAppName($appId);
 		}
 
 		return $appInfo['name'];

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -4874,15 +4874,20 @@ class OpenProjectAPIServiceTest extends TestCase {
 				'appInfo' => ['name' => 'Group folders'],
 				'expected' => 'Group folders',
 			],
-			'app is not enabled' => [
+			'disabled existing app' => [
+				'appId' => 'oidc',
+				'appInfo' => null,
+				'expected' => Application::getDefaultAppName('oidc'),
+			],
+			'non-existing app' => [
 				'appId' => 'nonexistent_app',
 				'appInfo' => null,
 				'expected' => 'nonexistent_app',
 			],
 			'app info missing name field' => [
-				'appId' => 'incomplete_app',
+				'appId' => 'user_oidc',
 				'appInfo' => ['description' => 'An app without name'],
-				'expected' => 'incomplete_app',
+				'expected' => Application::getDefaultAppName('user_oidc'),
 			],
 		];
 	}

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -4869,20 +4869,20 @@ class OpenProjectAPIServiceTest extends TestCase {
 	 */
 	public function getAppsNameDataProvider(): array {
 		return [
-			'groupfolders' => [
+			'enabled app' => [
 				'appId' => 'groupfolders',
 				'appInfo' => ['name' => 'Group folders'],
 				'expected' => 'Group folders',
 			],
-			'app info is null' => [
+			'app is not enabled' => [
 				'appId' => 'nonexistent_app',
 				'appInfo' => null,
-				'expected' => '',
+				'expected' => 'nonexistent_app',
 			],
 			'app info missing name field' => [
 				'appId' => 'incomplete_app',
 				'appInfo' => ['description' => 'An app without name'],
-				'expected' => '',
+				'expected' => 'incomplete_app',
 			],
 		];
 	}


### PR DESCRIPTION
## Description
Provide a default app name if the app is not available.


## Related Issue or Workpackage
- Fixes [67366](https://community.openproject.org/wp/67366)

## Screenshots (if appropriate):
<img width="755" height="229" alt="Screenshot from 2025-09-12 16-08-28" src="https://github.com/user-attachments/assets/de056122-4d15-40c8-a149-da334e6fe0d6" />


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Updated `CHANGELOG.md` file
