### PR TITLE
fix: show current latest stable OpenProject version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix: Each request to OpenProject gets new token when setup with external SSO with token-exchange [#867](https://github.com/nextcloud/integration_openproject/pull/867)
 - Improve translation support and fix grammar in the authentication method switch confirmation message [#875](https://github.com/nextcloud/integration_openproject/pull/875)
 - Do not show app error if the form is in disabled state [#880](https://github.com/nextcloud/integration_openproject/pull/880)
+- Fix: Show latest stable OpenProject version [#887](https://github.com/nextcloud/integration_openproject/pull/887)
 
 ### Removed
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -2,6 +2,7 @@
   - SPDX-FileCopyrightText: 2024-2025 Jankari Tech Pvt. Ltd.
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
+
 # Release Process
 
 ## 1. Release Preparation
@@ -20,9 +21,10 @@ On the release branch:
    - `package.json`
 4. Add the new release branch in `.tx/backport` to allow transifex commits.
 5. Update `CHANGELOG.md` with the changes and the version to be released.
-6. Update the new release branch in the [nightly CI](../.github/workflows/nighlty-ci-release-branch.yml).
-7. Perform confirmatory testing (Changelogs) - by the OpenProject team.
-8. Perform [smoke testing](testing/smoke_testing.md) - by the OpenProject team.
+6. Check and update the latest stable version of OpenProject in [OpenProjectVersion.js](../src/constants/OpenProjectVersion.js).
+7. Update the new release branch in the [nightly CI](../.github/workflows/nighlty-ci-release-branch.yml).
+8. Perform confirmatory testing (Changelogs) - by the OpenProject team.
+9. Perform [smoke testing](testing/smoke_testing.md) - by the OpenProject team.
 
 ### b. Patch Release
 
@@ -32,8 +34,9 @@ On the current release branch:
    - `appinfo/info.xml`
    - `package.json`
 2. Update `CHANGELOG.md` with the changes and the version to be released.
-3. Perform confirmatory testing (Changelogs) - by the OpenProject team.
-4. Perform [smoke testing](testing/smoke_testing.md) - by the OpenProject team.
+3. Check and update the latest stable version of OpenProject in [OpenProjectVersion.js](../src/constants/OpenProjectVersion.js).
+4. Perform confirmatory testing (Changelogs) - by the OpenProject team.
+5. Perform [smoke testing](testing/smoke_testing.md) - by the OpenProject team.
 
 ## 2. Publish Release
 

--- a/src/constants/OpenProjectVersion.js
+++ b/src/constants/OpenProjectVersion.js
@@ -1,0 +1,14 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Jankari Tech Pvt. Ltd.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+// Latest stable version of OpenProject.
+// Links to check for latest version:
+//   - https://www.openproject.org/docs/release-notes
+//   - https://github.com/opf/openproject/releases
+// NOTE: Update only when a new major or minor version of OpenProject is released.
+//  '<major>.<minor>'
+const OPENPROJECT_VERSION = '16.4'
+
+export default OPENPROJECT_VERSION

--- a/src/constants/messages.js
+++ b/src/constants/messages.js
@@ -5,6 +5,7 @@
 
 import { translate as t } from '@nextcloud/l10n'
 import APP_ID from './appID.js'
+import OPENPROJECT_VERSION from './OpenProjectVersion.js'
 
 export const messages = {
 	installLatestVersionNow: t(APP_ID, 'Install latest version now'),
@@ -18,7 +19,7 @@ export const messages = {
 	nextcloudHubProvider: t(APP_ID, 'Nextcloud Hub'),
 	externalOIDCProvider: t(APP_ID, 'External Provider'),
 	tokenExchangeHintText: t(APP_ID, 'When enabled, the app will try to obtain a token for the given audience from the identity provider. If disabled, it will use the access token obtained during the login process.'),
-	opRequiredVersionAndPlanHint: t(APP_ID, 'Requires OpenProject version 16.0 (or higher) and an active Corporate plan.'),
+	opRequiredVersionAndPlanHint: t(APP_ID, 'Requires OpenProject version {version} (or higher) and an active Corporate plan.', { version: OPENPROJECT_VERSION }),
 }
 
 export const messagesFmt = {

--- a/tests/jest/components/admin/__snapshots__/FormAuthMethod.spec.js.snap
+++ b/tests/jest/components/admin/__snapshots__/FormAuthMethod.spec.js.snap
@@ -21,7 +21,7 @@ exports[`Component: FormAuthMethod completed form edit mode disabled user_oidc a
         </nccheckboxradioswitch-stub>
         <div class="info-container">
           <p>
-            Requires OpenProject version 16.0 (or higher) and an active Corporate plan.
+            Requires OpenProject version {version} (or higher) and an active Corporate plan.
           </p>
           <errorlabel-stub error="This feature requires version {version} (or higher) of &quot;{app}&quot; app. Please install or update the app." disabled="true"></errorlabel-stub>
         </div>
@@ -61,7 +61,7 @@ exports[`Component: FormAuthMethod completed form edit mode disabled user_oidc a
         </nccheckboxradioswitch-stub>
         <div class="info-container">
           <p>
-            Requires OpenProject version 16.0 (or higher) and an active Corporate plan.
+            Requires OpenProject version {version} (or higher) and an active Corporate plan.
           </p>
           <errorlabel-stub error="This feature requires version {version} (or higher) of &quot;{app}&quot; app. Please install or update the app."></errorlabel-stub>
         </div>
@@ -101,7 +101,7 @@ exports[`Component: FormAuthMethod completed form edit mode should show form fie
         </nccheckboxradioswitch-stub>
         <div class="info-container">
           <p>
-            Requires OpenProject version 16.0 (or higher) and an active Corporate plan.
+            Requires OpenProject version {version} (or higher) and an active Corporate plan.
           </p>
           <!---->
         </div>
@@ -141,7 +141,7 @@ exports[`Component: FormAuthMethod completed form edit mode unsupported user_oid
         </nccheckboxradioswitch-stub>
         <div class="info-container">
           <p>
-            Requires OpenProject version 16.0 (or higher) and an active Corporate plan.
+            Requires OpenProject version {version} (or higher) and an active Corporate plan.
           </p>
           <errorlabel-stub error="This feature requires version {version} (or higher) of &quot;{app}&quot; app. Please install or update the app." disabled="true"></errorlabel-stub>
         </div>
@@ -181,7 +181,7 @@ exports[`Component: FormAuthMethod completed form edit mode unsupported user_oid
         </nccheckboxradioswitch-stub>
         <div class="info-container">
           <p>
-            Requires OpenProject version 16.0 (or higher) and an active Corporate plan.
+            Requires OpenProject version {version} (or higher) and an active Corporate plan.
           </p>
           <errorlabel-stub error="This feature requires version {version} (or higher) of &quot;{app}&quot; app. Please install or update the app."></errorlabel-stub>
         </div>
@@ -297,7 +297,7 @@ exports[`Component: FormAuthMethod initial incomplete form current setting: auth
         </nccheckboxradioswitch-stub>
         <div class="info-container">
           <p>
-            Requires OpenProject version 16.0 (or higher) and an active Corporate plan.
+            Requires OpenProject version {version} (or higher) and an active Corporate plan.
           </p>
           <!---->
         </div>
@@ -335,7 +335,7 @@ exports[`Component: FormAuthMethod initial incomplete form current setting: auth
         </nccheckboxradioswitch-stub>
         <div class="info-container">
           <p>
-            Requires OpenProject version 16.0 (or higher) and an active Corporate plan.
+            Requires OpenProject version {version} (or higher) and an active Corporate plan.
           </p>
           <!---->
         </div>
@@ -381,7 +381,7 @@ exports[`Component: FormAuthMethod initial incomplete form disabled user_oidc ap
         </nccheckboxradioswitch-stub>
         <div class="info-container">
           <p>
-            Requires OpenProject version 16.0 (or higher) and an active Corporate plan.
+            Requires OpenProject version {version} (or higher) and an active Corporate plan.
           </p>
           <errorlabel-stub error="This feature requires version {version} (or higher) of &quot;{app}&quot; app. Please install or update the app." disabled="true"></errorlabel-stub>
         </div>
@@ -419,7 +419,7 @@ exports[`Component: FormAuthMethod initial incomplete form unsupported user_oidc
         </nccheckboxradioswitch-stub>
         <div class="info-container">
           <p>
-            Requires OpenProject version 16.0 (or higher) and an active Corporate plan.
+            Requires OpenProject version {version} (or higher) and an active Corporate plan.
           </p>
           <errorlabel-stub error="This feature requires version {version} (or higher) of &quot;{app}&quot; app. Please install or update the app." disabled="true"></errorlabel-stub>
         </div>


### PR DESCRIPTION
## Description
Updated the latest stable OpenProject version and added a global config to update the OpenProject version in the future.

>[!IMPORTANT]
> On every **MAJOR** or **MINOR** OpenProject release, the version MUST be updated in this config file.
> `src/constants/OpenProjectVersion.js`

## Related Issue or Workpackage
- Fixes [67272](https://community.openproject.org/wp/67272)

## Screenshots (if appropriate):
<img width="575" height="189" alt="Screenshot from 2025-09-12 16-35-08" src="https://github.com/user-attachments/assets/bad13fbd-83df-4a7b-b375-e34e79a87248" />


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Updated `CHANGELOG.md` file
