### PR TITLE
fix: use https NC url in OP API requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fix: Handle projects whose parent project is unknown [#985](https://github.com/nextcloud/integration_openproject/pull/985)
+- Fix: Force HTTPS on Nextcloud base URL for OpenProject API requests [#992](https://github.com/nextcloud/integration_openproject/pull/992)
 
 ### Added
 

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -249,8 +249,18 @@ class OpenProjectAPIService {
 	 * @return string
 	 */
 	public function getNCBaseUrl(): string {
+		$message = 'Invalid or missing "overwrite.cli.url" system configuration.';
 		$ncUrl = $this->config->getSystemValueString('overwrite.cli.url');
+		if (!$ncUrl) {
+			$this->logger->error($message, ['app' => $this->appName]);
+			return '';
+		}
+
 		$parsedUrl = parse_url($ncUrl);
+		if (!$parsedUrl || !isset($parsedUrl['scheme']) || !isset($parsedUrl['host'])) {
+			$this->logger->error($message, ['app' => $this->appName]);
+			return '';
+		}
 		if ($parsedUrl['scheme'] !== 'https') {
 			$ncUrl = str_replace('http://', 'https://', $ncUrl);
 		}

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -246,10 +246,15 @@ class OpenProjectAPIService {
 	}
 
 	/**
-	 * wrapper around IURLGenerator::getBaseUrl() to make it easier to mock in tests
+	 * @return string
 	 */
-	public function getBaseUrl(): string {
-		return $this->config->getSystemValueString('overwrite.cli.url');
+	public function getNCBaseUrl(): string {
+		$ncUrl = $this->config->getSystemValueString('overwrite.cli.url');
+		$parsedUrl = parse_url($ncUrl);
+		if ($parsedUrl['scheme'] !== 'https') {
+			$ncUrl = str_replace('http://', 'https://', $ncUrl);
+		}
+		return $ncUrl;
 	}
 
 	/**
@@ -303,7 +308,7 @@ class OpenProjectAPIService {
 		if ($onlyLinkableWorkPackages) {
 			$filters[] = [
 				'linkable_to_storage_url' =>
-					['operator' => '=', 'values' => [urlencode($this->getBaseUrl())]]
+					['operator' => '=', 'values' => [urlencode($this->getNCBaseUrl())]]
 			];
 		}
 
@@ -766,7 +771,7 @@ class OpenProjectAPIService {
 				],
 				'_links' => [
 					'storageUrl' => [
-						'href' => $this->getBaseUrl()
+						'href' => $this->getNCBaseUrl()
 					]
 				]
 			];
@@ -1520,7 +1525,7 @@ class OpenProjectAPIService {
 		}
 		$filters[] = [
 			'storageUrl' =>
-				['operator' => '=', 'values' => [$this->getBaseUrl()]],
+				['operator' => '=', 'values' => [$this->getNCBaseUrl()]],
 			'userAction' =>
 				['operator' => '&=', 'values' => ["file_links/manage", "work_packages/create"]]
 		];

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -803,10 +803,6 @@ class OpenProjectAPIServiceTest extends TestCase {
 			$appManagerMock->method('isInstalled')->willReturn(true);
 		}
 
-		$urlGeneratorMock = $this->getMockBuilder(IURLGenerator::class)->getMock();
-		$urlGeneratorMock
-			->method('getBaseUrl')
-			->willReturn($baseUrl);
 		$this->defaultConfigMock
 			->method('getSystemValueString')
 			->with($this->equalTo('overwrite.cli.url'))
@@ -817,7 +813,6 @@ class OpenProjectAPIServiceTest extends TestCase {
 			'config' => $this->defaultConfigMock,
 			'clientService' => $clientService,
 			'rootFolder' => $storageMock,
-			'urlGenerator' => $urlGeneratorMock,
 			'appManager' => $appManagerMock,
 			'tokenEventFactory' => $exchangeTokenMock,
 		]);
@@ -831,21 +826,27 @@ class OpenProjectAPIServiceTest extends TestCase {
 	 *
 	 * @param array<string> $mockMethods
 	 * @param array<string, object> $constructParams
+	 * @param bool $mockBaseUrl
 	 *
 	 * @return OpenProjectAPIService|MockObject
 	 */
 	private function getOpenProjectAPIServiceMock(
 		array $mockMethods = ['request'],
 		array $constructParams = [],
+		bool $mockBaseUrl = true
 	): OpenProjectAPIService|MockObject {
-		$mockMethods[] = 'getNCBaseUrl';
+		if ($mockBaseUrl) {
+			$mockMethods[] = 'getNCBaseUrl';
+		}
 		$constructArgs = $this->getOpenProjectAPIServiceConstructArgs($constructParams);
 
 		$mock = $this->getMockBuilder(OpenProjectAPIService::class)
 			->setConstructorArgs($constructArgs)
 			->onlyMethods($mockMethods)
 			->getMock();
-		$mock->method('getNCBaseUrl')->willReturn('https://nc.my-server.org');
+		if ($mockBaseUrl) {
+			$mock->method('getNCBaseUrl')->willReturn('https://nc.my-server.org');
+		}
 		return $mock;
 	}
 
@@ -3906,14 +3907,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 	 * @return void
 	 */
 	public function testGetAvailableOpenProjectProjectsQueryOnly() {
-		$iUrlGeneratorMock = $this->getMockBuilder(IURLGenerator::class)->disableOriginalConstructor()->getMock();
-		$iUrlGeneratorMock->method('getBaseUrl')->willReturn('https%3A%2F%2Fnc.my-server.org');
-		$service = $this->getOpenProjectAPIServiceMock(
-			['request'],
-			[
-				'urlGenerator' => $iUrlGeneratorMock,
-			],
-		);
+		$service = $this->getOpenProjectAPIServiceMock(['request']);
 		$service->method('request')
 			->with(
 				'user', 'work_packages/available_projects',
@@ -5197,4 +5191,52 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$this->assertSame($expected, $result);
 	}
 
+	/**
+	 * @return array<mixed>
+	 */
+	public function getNCBaseUrlDataProvider() {
+		return [
+			'HTTP url' => [
+				'url' => 'http://test.nc.local',
+				'expected' => 'https://test.nc.local',
+			],
+			'HTTPS url' => [
+				'url' => 'https://test.nc.local',
+				'expected' => 'https://test.nc.local',
+			],
+			'invalid url' => [
+				'url' => 'invalid_url',
+				'expected' => '',
+			],
+			'empty url' => [
+				'url' => '',
+				'expected' => '',
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider getNCBaseUrlDataProvider
+	 * @param string $url
+	 * @param string $expected
+	 * @return void
+	 */
+	public function testGetNCBaseUrl(string $url, string $expected): void {
+		$configMock = $this->createMock(IConfig::class);
+		$configMock
+			->method('getSystemValueString')
+			->with($this->equalTo('overwrite.cli.url'))
+			->willReturn($url);
+
+		$service = $this->getOpenProjectAPIServiceMock(
+			[],
+			[
+				'config' => $configMock,
+			],
+			false,
+		);
+
+		$baseUrl = $service->getNCBaseUrl();
+		$this->assertEquals($expected, $baseUrl);
+	}
 }

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -838,14 +838,14 @@ class OpenProjectAPIServiceTest extends TestCase {
 		array $mockMethods = ['request'],
 		array $constructParams = [],
 	): OpenProjectAPIService|MockObject {
-		$mockMethods[] = 'getBaseUrl';
+		$mockMethods[] = 'getNCBaseUrl';
 		$constructArgs = $this->getOpenProjectAPIServiceConstructArgs($constructParams);
 
 		$mock = $this->getMockBuilder(OpenProjectAPIService::class)
 			->setConstructorArgs($constructArgs)
 			->onlyMethods($mockMethods)
 			->getMock();
-		$mock->method('getBaseUrl')->willReturn('https://nc.my-server.org');
+		$mock->method('getNCBaseUrl')->willReturn('https://nc.my-server.org');
 		return $mock;
 	}
 


### PR DESCRIPTION
## Description
Force https on Nextcloud base url in OpenProject API requests as the integration only works with https scheme


## Related Issue or Workpackage
- Fixes https://community.openproject.org/wp/72847

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
