### PR TITLE
ci: replace removed getUserManager in phpunit test

### DIFF
--- a/tests/lib/Controller/ConfigControllerTest.php
+++ b/tests/lib/Controller/ConfigControllerTest.php
@@ -513,7 +513,7 @@ class ConfigControllerTest extends TestCase {
 	 * @dataProvider setAdminConfigStatusDataProviderForOauth2
 	 */
 	public function testSetAdminConfigForDifferentAdminConfigStatusForOauth2($credsToUpdate, $adminConfigStatus) {
-		$userManager = \OC::$server->getUserManager();
+		$userManager = \OC::$server->get(IUserManager::class);
 
 		$configMock = $this->getMockBuilder(IConfig::class)->getMock();
 		$configMock
@@ -610,7 +610,7 @@ class ConfigControllerTest extends TestCase {
 	 * @dataProvider setAdminConfigStatusDataProviderForOIDC
 	 */
 	public function testSetAdminConfigForDifferentAdminConfigStatusForOIDC($credsToUpdate, $adminConfigStatus) {
-		$userManager = \OC::$server->getUserManager();
+		$userManager = \OC::$server->get(IUserManager::class);
 
 		$configMock = $this->getMockBuilder(IConfig::class)->getMock();
 		$configMock
@@ -875,7 +875,7 @@ class ConfigControllerTest extends TestCase {
 		$apiService = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$userManager = \OC::$server->getUserManager();
+		$userManager = \OC::$server->get(IUserManager::class);
 		$configMock = $this->getMockBuilder(IConfig::class)->getMock();
 		$oauthServiceMock = $this->createMock(OauthService::class);
 
@@ -905,7 +905,7 @@ class ConfigControllerTest extends TestCase {
 	 * @throws \Exception
 	 */
 	public function checkForUsersCountBeforeTest($expectedCount = 1): IUserManager {
-		$userManager = \OC::$server->getUserManager();
+		$userManager = \OC::$server->get(IUserManager::class);
 
 		$actualCount = 0;
 		$function = function () use (&$actualCount) {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
getUserManager()  was removed as part of the server changes https://github.com/nextcloud/server/pull/58808

## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
