### PR TITLE
Remove override usage from  migration file

### DIFF
--- a/lib/Migration/Version2900Date20250718065820.php
+++ b/lib/Migration/Version2900Date20250718065820.php
@@ -16,7 +16,6 @@ use OCP\DB\ISchemaWrapper;
 use OCP\IConfig;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
-use Override;
 
 class Version2900Date20250718065820 extends SimpleMigrationStep {
 	public function __construct(private IConfig $config) {
@@ -28,7 +27,6 @@ class Version2900Date20250718065820 extends SimpleMigrationStep {
 	 * @param array $options
 	 * @return null|ISchemaWrapper
 	 */
-	#[Override]
 	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
 		// set 'authorization_method' to Oauth2 if authorization_method is not set
 		// and there is existing complete Oauth2 setup


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR fixes the Psalm error on CI.

```console
Error: lib/Migration/Version2900Date20250718065820.php:31:4: InvalidAttribute: Attribute Override cannot be used on a function (see https://psalm.dev/242)
```

The `#[Override] `attribute has been removed from this migration file. It is not used in other migration files for the same function, and its removal does not affect functionality.

## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
