### PR TITLE
test: fix content-disposition header assertion tests

### DIFF
--- a/tests/lib/Controller/OpenProjectAPIControllerTest.php
+++ b/tests/lib/Controller/OpenProjectAPIControllerTest.php
@@ -230,8 +230,8 @@ class OpenProjectAPIControllerTest extends TestCase {
 		]);
 		$response = $controller->getOpenProjectAvatar('id', 'name');
 		$this->assertSame('some image data', $response->render());
-		$this->assertSame(
-			"attachment; filename=\"avatar\"",
+		$this->assertMatchesRegularExpression(
+			'/attachment; filename="?avatar"?/',
 			$response->getHeaders()["Content-Disposition"]
 		);
 		$this->assertSame(
@@ -267,8 +267,8 @@ class OpenProjectAPIControllerTest extends TestCase {
 		]);
 		$response = $controller->getOpenProjectAvatar('id', 'name');
 		$this->assertSame('some image data', $response->render());
-		$this->assertSame(
-			"attachment; filename=\"avatar\"",
+		$this->assertMatchesRegularExpression(
+			'/attachment; filename="?avatar"?/',
 			$response->getHeaders()["Content-Disposition"]
 		);
 		$this->assertEmpty($response->getHeaders()["Content-Type"]);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The format of the Content-Disposition header [changed in Nextcloud](https://github.com/nextcloud/server/pull/59843) (>= 32).
Older versions(< 32) and newer versions(>= 32) generate slightly different header strings.

for example:

| Nexcloud version | Content-Disposition Header Example |
|--------|--------|
| >= 32 | attachment; filename=avatar |
| < 32| attachment; filename="avatar" | 

So, **in phpunit tests**, this PR replaced exact string checks with regex to support both quoted/unquoted filenames.

## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [ ] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
