### PR TITLE
fix: wrong message `Unauthorized to connect to Openproject` shown with valid SSO connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fix: Shown wrong message "Unauthorized to connect to Openproject" on Single-Sign-On setup [#1018](https://github.com/nextcloud/integration_openproject/pull/1018)
+
 ### Changed
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Fix: Shown wrong message "Unauthorized to connect to Openproject" on Single-Sign-On setup [#1018](https://github.com/nextcloud/integration_openproject/pull/1018)
+- Fix: Wrong message "Unauthorized to connect to OpenProject" shown with valid SSO connection [#1018](https://github.com/nextcloud/integration_openproject/pull/1018)
 
 ### Changed
 

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -155,7 +155,7 @@ class ConfigController extends Controller {
 
 		if (isset($values['token'])) {
 			if ($values['token']) {
-				$result = $this->openprojectAPIService->initUserInfo($this->userId);
+				$result = $this->openprojectAPIService->initUserInfo($this->userId, $values['token']);
 			} else {
 				$this->clearUserInfo();
 				$result = [
@@ -536,7 +536,7 @@ class ConfigController extends Controller {
 			);
 			if (isset($result['access_token']) && isset($result['refresh_token'])) {
 				// set user info
-				$userInfo = $this->openprojectAPIService->initUserInfo($this->userId);
+				$userInfo = $this->openprojectAPIService->initUserInfo($this->userId, $result['access_token']);
 				if (isset($userInfo['user_name'])) {
 					$this->config->setUserValue(
 						$this->userId, Application::APP_ID, 'oauth_connection_result', 'success'

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -419,7 +419,7 @@ class OpenProjectAPIService {
 		string $method = 'GET',
 		array $options = []
 	) {
-		$url = $openprojectUrl . '/api/v3/' . ltrim($endPoint, '/');
+		$url = rtrim($openprojectUrl, '/') . '/api/v3/' . ltrim($endPoint, '/');
 		if (!isset($options['headers']['Authorization'])) {
 			$options['headers']['Authorization'] = 'Bearer ' . $accessToken;
 		}
@@ -1756,8 +1756,10 @@ class OpenProjectAPIService {
 		if ($token) {
 			$this->logger->debug('Token has expired.', ['app' => $this->appName]);
 			$this->logger->debug('Refreshing access token.', ['app' => $this->appName]);
-			$this->config->deleteUserValue($userId, Application::APP_ID, 'user_name');
-			$this->config->deleteUserValue($userId, Application::APP_ID, 'user_id');
+			if ($authMethod === SettingsService::AUTH_METHOD_OIDC) {
+				$this->config->deleteUserValue($userId, Application::APP_ID, 'user_name');
+				$this->config->deleteUserValue($userId, Application::APP_ID, 'user_id');
+			}
 		}
 
 		// For OAuth2 setup, only try to refresh the expired token.
@@ -1795,9 +1797,9 @@ class OpenProjectAPIService {
 
 	/**
 	 * @param string $userId
+	 * @param string $accessToken
 	 *
 	 * @return array<mixed>
-	 * @throws PreConditionNotMetException
 	 */
 	public function initUserInfo(string $userId, string $accessToken): array {
 		$savedUserId = $this->config->getUserValue($userId, Application::APP_ID, 'user_id');
@@ -1807,6 +1809,9 @@ class OpenProjectAPIService {
 		}
 		try {
 			$openprojectUrl = $this->config->getAppValue(Application::APP_ID, 'openproject_instance_url');
+			if (!$openprojectUrl || !OpenProjectAPIService::validateURL($openprojectUrl)) {
+				return ['error' => 'OpenProject URL is invalid', 'statusCode' => 500];
+			}
 			$response = $this->rawRequest($accessToken, $openprojectUrl, '/users/me');
 			$info = json_decode($response->getBody(), true);
 		} catch (Exception $e) {

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -419,7 +419,7 @@ class OpenProjectAPIService {
 		string $method = 'GET',
 		array $options = []
 	) {
-		$url = $openprojectUrl . '/api/v3/' . $endPoint;
+		$url = $openprojectUrl . '/api/v3/' . ltrim($endPoint, '/');
 		if (!isset($options['headers']['Authorization'])) {
 			$options['headers']['Authorization'] = 'Bearer ' . $accessToken;
 		}
@@ -1716,13 +1716,6 @@ class OpenProjectAPIService {
 		$this->config->setUserValue($userId, Application::APP_ID, 'token', $token->getAccessToken());
 		$this->config->setUserValue($userId, Application::APP_ID, 'token_expires_at', $tokenExpiresAt);
 
-		$savedUserId = $this->config->getUserValue($userId, Application::APP_ID, 'user_id');
-		$savedUsername = $this->config->getUserValue($userId, Application::APP_ID, 'user_name');
-		if (!$savedUserId || !$savedUsername) {
-			// get user info
-			$this->initUserInfo($userId);
-		}
-
 		return $token->getAccessToken();
 	}
 
@@ -1751,16 +1744,22 @@ class OpenProjectAPIService {
 			return '';
 		}
 		$token = $this->config->getUserValue($userId, Application::APP_ID, 'token', '');
+		$authMethod = $this->config->getAppValue(Application::APP_ID, 'authorization_method');
+
 		if ($token && !$this->isAccessTokenExpired($userId)) {
+			if ($authMethod === SettingsService::AUTH_METHOD_OIDC) {
+				$this->initUserInfo($userId, $token);
+			}
 			return $token;
 		}
 
 		if ($token) {
 			$this->logger->debug('Token has expired.', ['app' => $this->appName]);
 			$this->logger->debug('Refreshing access token.', ['app' => $this->appName]);
+			$this->config->deleteUserValue($userId, Application::APP_ID, 'user_name');
+			$this->config->deleteUserValue($userId, Application::APP_ID, 'user_id');
 		}
 
-		$authMethod = $this->config->getAppValue(Application::APP_ID, 'authorization_method');
 		// For OAuth2 setup, only try to refresh the expired token.
 		// Token exchange needs to be initiated from the UI.
 		if ($authMethod === SettingsService::AUTH_METHOD_OAUTH && $token) {
@@ -1784,7 +1783,11 @@ class OpenProjectAPIService {
 			}
 			return $result['access_token'];
 		} elseif ($authMethod === SettingsService::AUTH_METHOD_OIDC) {
-			return $this->getOIDCToken($userId);
+			$token = $this->getOIDCToken($userId);
+			if ($token) {
+				$this->initUserInfo($userId, $token);
+			}
+			return $token;
 		}
 
 		return '';
@@ -1796,8 +1799,20 @@ class OpenProjectAPIService {
 	 * @return array<mixed>
 	 * @throws PreConditionNotMetException
 	 */
-	public function initUserInfo(string $userId): array {
-		$info = $this->request($userId, '/users/me');
+	public function initUserInfo(string $userId, string $accessToken): array {
+		$savedUserId = $this->config->getUserValue($userId, Application::APP_ID, 'user_id');
+		$savedUsername = $this->config->getUserValue($userId, Application::APP_ID, 'user_name');
+		if ($savedUserId && $savedUsername) {
+			return ['user_name' => $savedUsername];
+		}
+		try {
+			$openprojectUrl = $this->config->getAppValue(Application::APP_ID, 'openproject_instance_url');
+			$response = $this->rawRequest($accessToken, $openprojectUrl, '/users/me');
+			$info = json_decode($response->getBody(), true);
+		} catch (Exception $e) {
+			$this->logger->error('OpenProject error : ' . $e->getMessage(), ['app' => $this->appName]);
+			return ['error' => $e->getMessage()];
+		}
 		if (isset($info['lastName'], $info['firstName'], $info['id'])) {
 			$fullName = $info['firstName'] . ' ' . $info['lastName'];
 			$this->config->setUserValue($userId, Application::APP_ID, 'user_id', $info['id']);

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -783,18 +783,14 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$tokenExpiryTime = $oAuth2OrOidcToken === 'expired' ? 0 : time() + 7200;
 		$this->defaultConfigMock
 			->method('getUserValue')
-			->withConsecutive(
-				[$userId, 'integration_openproject', 'token'],
-				[$userId, 'integration_openproject', 'token_expires_at'],
-				[$userId, 'integration_openproject', 'refresh_token'],
-				[$userId, 'integration_openproject', 'token'],
-			)
-			->willReturnOnConsecutiveCalls(
-				$oAuth2OrOidcToken,
-				$tokenExpiryTime,
-				'oAuthRefreshToken',
-				'new-Token'
-			);
+			->willReturnMap([
+				[$userId, 'integration_openproject', 'token', $oAuth2OrOidcToken],
+				[$userId, 'integration_openproject', 'token_expires_at', $tokenExpiryTime],
+				[$userId, 'integration_openproject', 'refresh_token', 'oAuthRefreshToken'],
+				[$userId, 'integration_openproject', 'token', 'new-Token'],
+				[$userId, 'integration_openproject', 'user_id', 'some-user-id'],
+				[$userId, 'integration_openproject', 'user_name', 'some-user-name'],
+			]);
 		if ($authMethod === OpenProjectAPIService::AUTH_METHOD_OIDC) {
 			$tokenMock = $this->getMockBuilder(Token::class)->disableOriginalConstructor()->getMock();
 			$exchangeTokenMock->method('getEvent')->willReturn($exchangedTokenRequestedEventMock);
@@ -4565,12 +4561,6 @@ class OpenProjectAPIServiceTest extends TestCase {
 			->willReturnMap($this->getAppValues([
 				'authorization_method' => OpenProjectAPIService::AUTH_METHOD_OIDC
 			]));
-		$configMock
-			->method('getUserValue')
-			->willReturnMap([
-				['testUser', Application::APP_ID, 'user_id', null],
-				['testUser', Application::APP_ID, 'user_name', null],
-			]);
 		$calls = [];
 		$configMock
 			->method('setUserValue')
@@ -4587,7 +4577,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$eventMock->method('getToken')->willReturn($tokenMock);
 		$tokenMock->method('getAccessToken')->willReturn('exchanged-access-token');
 		$service = $this->getOpenProjectAPIServiceMock(
-			['initUserInfo'],
+			[],
 			[
 				'appManager' => $iAppManagerMock,
 				'config' => $configMock,
@@ -4595,7 +4585,6 @@ class OpenProjectAPIServiceTest extends TestCase {
 				'tokenEventFactory' => $exchangeTokenEvent,
 			],
 		);
-		$service->expects($this->once())->method('initUserInfo')->with('testUser');
 		$result = $service->getOIDCToken('testUser');
 		$this->assertEquals('exchanged-access-token', $result);
 		$expectedCalls = [
@@ -4815,7 +4804,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 				['testUser', Application::APP_ID, 'refresh_token', '', 'refresh-token'],
 			]);
 		$service = $this->getOpenProjectAPIServiceMock(
-			['isAccessTokenExpired', 'getOIDCToken', 'requestOAuthAccessToken'],
+			['isAccessTokenExpired', 'getOIDCToken', 'requestOAuthAccessToken', 'initUserInfo'],
 			[
 				'config' => $configMock,
 			],
@@ -4825,6 +4814,25 @@ class OpenProjectAPIServiceTest extends TestCase {
 			->method('isAccessTokenExpired')
 			->with('testUser')
 			->willReturn($expired);
+		}
+
+		if ($token && $expired) {
+			$configMock
+				->expects($this->exactly(2))
+				->method("deleteUserValue")
+				->withConsecutive(
+					['testUser', 'integration_openproject', 'user_name'],
+					['testUser', 'integration_openproject', 'user_id'],
+				);
+		}
+
+		if ($token && $authMethod === SettingsService::AUTH_METHOD_OIDC && (!$expired || $expectedToken)) {
+			$expectedTokenForInitUserInfo = $expired ? $expectedToken : $token;
+			$service->expects($this->once())
+				->method('initUserInfo')
+				->with('testUser', $expectedTokenForInitUserInfo);
+		} else {
+			$service->expects($this->never())->method('initUserInfo');
 		}
 
 		if ($authMethod === SettingsService::AUTH_METHOD_OAUTH && $expired) {

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -5247,4 +5247,103 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$baseUrl = $service->getNCBaseUrl();
 		$this->assertEquals($expected, $baseUrl);
 	}
+
+	/**
+	 * Data provider for testInitUserInfo
+	 */
+	public function initUserInfoDataProvider(): array {
+		return [
+			'user info already saved' => [
+				'savedUserId' => 'testUserID',
+				'savedUsername' => 'test User',
+				'expectedResult' => ['user_name' => 'test User'],
+				'expectRawRequestCalled' => false,
+				'apiResponse' => null,
+				'expectedExpection' => null
+			],
+			'user info missing and API succeeds' => [
+				'savedUserId' => '',
+				'savedUsername' => '',
+				'expectedResult' => ['user_name' => 'test User'],
+				'expectRawRequestCalled' => true,
+				'apiResponse' => [
+					'id' => 'testUserID',
+					'firstName' => 'test',
+					'lastName' => 'User',
+				],
+				'expectedExpection' => null
+			],
+			'user info missing and API throws exception' => [
+				'savedUserId' => '',
+				'savedUsername' => '',
+				'expectedResult' => ['error' => 'OpenProject error'],
+				'expectRawRequestCalled' => true,
+				'apiResponse' => null,
+				'expectedExpection' => new \Exception('OpenProject error')
+			],
+			'user info missing and API returns incomplete data' => [
+				'savedUserId' => '',
+				'savedUsername' => '',
+				'expectedResult' => ['id' => 'testUserID', 'error' => 'Failed to get user profile'],
+				'expectRawRequestCalled' => true,
+				'apiResponse' => [
+					'id' => 'testUserID',
+				],
+				'expectedExpection' => null
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider initUserInfoDataProvider
+	 * @param string $savedUserId
+	 * @param string $savedUsername
+	 * @param array $expectedResult
+	 * @param bool $expectRawRequestCalled
+	 * @param array|null $apiResponse
+	 * @param \Exception|null $expectedExpection
+	 * @return void
+	 */
+	public function testInitUserInfo(string $savedUserId, string $savedUsername, array $expectedResult, bool $expectRawRequestCalled, ?array $apiResponse, ?\Exception $expectedExpection): void {
+		$configMock = $this->getMockBuilder(IConfig::class)->getMock();
+		$configMock->method('getAppValue')
+			->willReturnMap($this->getAppValues([
+				'openproject_instance_url' => 'http://test.local',
+			]));
+		$configMock
+			->method('getUserValue')
+			->willReturnMap([
+				['testUser', Application::APP_ID, 'user_id', '', $savedUserId],
+				['testUser', Application::APP_ID, 'user_name','', $savedUsername]
+			]);
+
+		$calls = [];
+		$configMock
+			->method('setUserValue')
+			->willReturnCallback(function ($uid, $app, $key, $value) use (&$calls) {
+				$calls[] = [$uid, $app, $key, $value];
+			});
+
+		$service = $this->getOpenProjectAPIServiceMock(['rawRequest'], [ 'config' => $configMock ]);
+
+		if (!$expectRawRequestCalled) {
+			$service->expects($this->never())->method('rawRequest');
+		} elseif ($expectedExpection !== null) {
+			$service->expects($this->once())->method('rawRequest')->willThrowException($expectedExpection);
+		} else {
+			$mockResponse = $this->createMock(Response::class);
+			$mockResponse->method('getBody')->willReturn(json_encode($apiResponse));
+			$service->expects($this->once())->method('rawRequest')->willReturn(
+				$mockResponse
+			);
+		}
+
+		$result = $service->initUserInfo('testUser', 'token');
+		$this->assertSame($expectedResult, $result);
+
+		if ($expectedResult === ['user_name' => 'test User'] && $expectRawRequestCalled) {
+			$this->assertContains(['testUser', Application::APP_ID, 'user_id', 'testUserID'], $calls);
+			$this->assertContains(['testUser', Application::APP_ID, 'user_name', 'test User'], $calls);
+		}
+	}
 }

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -781,16 +781,25 @@ class OpenProjectAPIServiceTest extends TestCase {
 			]));
 
 		$tokenExpiryTime = $oAuth2OrOidcToken === 'expired' ? 0 : time() + 7200;
-		$this->defaultConfigMock
-			->method('getUserValue')
-			->willReturnMap([
-				[$userId, 'integration_openproject', 'token', $oAuth2OrOidcToken],
-				[$userId, 'integration_openproject', 'token_expires_at', $tokenExpiryTime],
-				[$userId, 'integration_openproject', 'refresh_token', 'oAuthRefreshToken'],
-				[$userId, 'integration_openproject', 'token', 'new-Token'],
-				[$userId, 'integration_openproject', 'user_id', 'some-user-id'],
-				[$userId, 'integration_openproject', 'user_name', 'some-user-name'],
-			]);
+		if ($authMethod === OpenProjectAPIService::AUTH_METHOD_OIDC) {
+			$this->defaultConfigMock
+				->method('getUserValue')
+				->willReturnMap([
+					[$userId, 'integration_openproject', 'token', $oAuth2OrOidcToken],
+					[$userId, 'integration_openproject', 'token_expires_at', $tokenExpiryTime],
+					[$userId, 'integration_openproject', 'user_id', 'some-user-id'],
+					[$userId, 'integration_openproject', 'user_name', 'some-user-name'],
+				]);
+		} else {
+			$this->defaultConfigMock
+				->method('getUserValue')
+				->willReturnMap([
+					[$userId, 'integration_openproject', 'token', $oAuth2OrOidcToken],
+					[$userId, 'integration_openproject', 'token_expires_at', $tokenExpiryTime],
+					[$userId, 'integration_openproject', 'refresh_token', 'oAuthRefreshToken'],
+					[$userId, 'integration_openproject', 'token','new-Token'],
+				]);
+		}
 		if ($authMethod === OpenProjectAPIService::AUTH_METHOD_OIDC) {
 			$tokenMock = $this->getMockBuilder(Token::class)->disableOriginalConstructor()->getMock();
 			$exchangeTokenMock->method('getEvent')->willReturn($exchangedTokenRequestedEventMock);
@@ -4816,14 +4825,16 @@ class OpenProjectAPIServiceTest extends TestCase {
 			->willReturn($expired);
 		}
 
-		if ($token && $expired) {
+		if ($token && $expired && $authMethod === SettingsService::AUTH_METHOD_OIDC) {
 			$configMock
 				->expects($this->exactly(2))
 				->method("deleteUserValue")
-				->withConsecutive(
-					['testUser', 'integration_openproject', 'user_name'],
-					['testUser', 'integration_openproject', 'user_id'],
-				);
+				->willReturnMap([
+					['testUser', 'integration_openproject', 'user_name', ''],
+					['testUser', 'integration_openproject', 'user_id', ''],
+				]);
+		} else {
+			$configMock->expects($this->never())->method("deleteUserValue");
 		}
 
 		if ($token && $authMethod === SettingsService::AUTH_METHOD_OIDC && (!$expired || $expectedToken)) {
@@ -5259,7 +5270,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 				'expectedResult' => ['user_name' => 'test User'],
 				'expectRawRequestCalled' => false,
 				'apiResponse' => null,
-				'expectedExpection' => null
+				'expectedException' => null
 			],
 			'user info missing and API succeeds' => [
 				'savedUserId' => '',
@@ -5271,7 +5282,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 					'firstName' => 'test',
 					'lastName' => 'User',
 				],
-				'expectedExpection' => null
+				'expectedException' => null
 			],
 			'user info missing and API throws exception' => [
 				'savedUserId' => '',
@@ -5279,7 +5290,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 				'expectedResult' => ['error' => 'OpenProject error'],
 				'expectRawRequestCalled' => true,
 				'apiResponse' => null,
-				'expectedExpection' => new \Exception('OpenProject error')
+				'expectedException' => new \Exception('OpenProject error')
 			],
 			'user info missing and API returns incomplete data' => [
 				'savedUserId' => '',
@@ -5289,7 +5300,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 				'apiResponse' => [
 					'id' => 'testUserID',
 				],
-				'expectedExpection' => null
+				'expectedException' => null
 			],
 		];
 	}
@@ -5301,10 +5312,17 @@ class OpenProjectAPIServiceTest extends TestCase {
 	 * @param array $expectedResult
 	 * @param bool $expectRawRequestCalled
 	 * @param array|null $apiResponse
-	 * @param \Exception|null $expectedExpection
+	 * @param \Exception|null $expectedException
 	 * @return void
 	 */
-	public function testInitUserInfo(string $savedUserId, string $savedUsername, array $expectedResult, bool $expectRawRequestCalled, ?array $apiResponse, ?\Exception $expectedExpection): void {
+	public function testInitUserInfo(
+		string $savedUserId,
+		string $savedUsername,
+		array $expectedResult,
+		bool $expectRawRequestCalled,
+		?array $apiResponse,
+		?\Exception $expectedException,
+	): void {
 		$configMock = $this->getMockBuilder(IConfig::class)->getMock();
 		$configMock->method('getAppValue')
 			->willReturnMap($this->getAppValues([
@@ -5328,8 +5346,8 @@ class OpenProjectAPIServiceTest extends TestCase {
 
 		if (!$expectRawRequestCalled) {
 			$service->expects($this->never())->method('rawRequest');
-		} elseif ($expectedExpection !== null) {
-			$service->expects($this->once())->method('rawRequest')->willThrowException($expectedExpection);
+		} elseif ($expectedException !== null) {
+			$service->expects($this->once())->method('rawRequest')->willThrowException($expectedException);
 		} else {
 			$mockResponse = $this->createMock(Response::class);
 			$mockResponse->method('getBody')->willReturn(json_encode($apiResponse));
@@ -5341,9 +5359,11 @@ class OpenProjectAPIServiceTest extends TestCase {
 		$result = $service->initUserInfo('testUser', 'token');
 		$this->assertSame($expectedResult, $result);
 
-		if ($expectedResult === ['user_name' => 'test User'] && $expectRawRequestCalled) {
+		if (isset($expectedResult['user_name']) && $expectRawRequestCalled) {
 			$this->assertContains(['testUser', Application::APP_ID, 'user_id', 'testUserID'], $calls);
 			$this->assertContains(['testUser', Application::APP_ID, 'user_name', 'test User'], $calls);
+		} else {
+			$this->assertEmpty($calls);
 		}
 	}
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

### Problem
On first Nextcloud login, `getOIDCToken` fetches a valid token, saves `token_expires_at`, then calls `initUserInfo` which fails with `401` because the user hasn't SSO'd into OpenProject yet. Since `token_expires_at` is already saved, all subsequent requests return the cached token and skip `getOIDCToken` entirely, so `initUserInfo` is never retried until the token naturally expires (~15 min).

### Fix
- Moved `initUserInfo` out of `getOIDCToken` -> `getOIDCToken` is now only responsible for fetching and returning the token.
- `initUserInfo` now takes `accessToken` directly and calls `rawRequest` instead of `request` -> breaking the circular dependency completely. 
- `getAccessToken` calls `initUserInfo` on every request (for OIDC) until `user_id` and `user_name` are saved -> both in the cached token path and the expired token path

## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://community.openproject.org/projects/nextcloud-integration/work_packages/74159

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [x] Updated `CHANGELOG.md` file
