### PR TITLE
refactor: split oauth2 settings form

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,8 @@
 
 module.exports = {
 	testMatch: ['**/tests/**/*.spec.{js,ts}'],
+	testPathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/server/'],
+	modulePathIgnorePatterns: ['<rootDir>/server/', '<rootDir>/dev/'],
 	moduleNameMapper: {
 		'\\.(scss)$': '<rootDir>/tests/jest/stubs/empty.js',
 		'@nextcloud/l10n/gettext': '<rootDir>/tests/jest/__mocks__/@nextcloud/l10n.js',

--- a/src/api/endpoints.js
+++ b/src/api/endpoints.js
@@ -8,4 +8,5 @@ import { generateUrl } from '@nextcloud/router'
 export default {
 	validateOPInstance: generateUrl('/apps/integration_openproject/is-valid-op-instance'),
 	adminConfig: generateUrl('/apps/integration_openproject/admin-config'),
+	nextcloudOAuth: generateUrl('/apps/integration_openproject/nc-oauth'),
 }

--- a/src/api/settings.js
+++ b/src/api/settings.js
@@ -14,6 +14,6 @@ export function saveAdminConfig(configs) {
 	return axios.put(endpoints.adminConfig, { values: configs })
 }
 
-export function createNextcloudOAuthClient(configs) {
+export function createNextcloudOAuthClient() {
 	return axios.post(endpoints.nextcloudOAuth)
 }

--- a/src/api/settings.js
+++ b/src/api/settings.js
@@ -13,3 +13,7 @@ export function validateOPInstance(url) {
 export function saveAdminConfig(configs) {
 	return axios.put(endpoints.adminConfig, { values: configs })
 }
+
+export function createNextcloudOAuthClient(configs) {
+	return axios.post(endpoints.nextcloudOAuth)
+}

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -28,125 +28,16 @@
 			:sso-providers="state.oidc_providers"
 			:apps="state.apps"
 			@formcomplete="markFormComplete" />
-		<div v-if="showOAuthSettings" class="openproject-oauth-values">
-			<FormHeading index="3"
-				:title="t('integration_openproject', 'OpenProject OAuth settings')"
-				:is-complete="isOPOAuthFormComplete"
-				:is-disabled="isOPOAuthFormInDisableMode"
-				:is-dark-theme="isDarkTheme" />
-			<div v-if="form.authenticationMethod.complete">
-				<FieldValue v-if="isOPOAuthFormInView"
-					is-required
-					:value="state.openproject_client_id"
-					title="OpenProject OAuth client ID" />
-				<TextInput v-else
-					id="openproject-oauth-client-id"
-					v-model="state.openproject_client_id"
-					class="py-1"
-					is-required
-					label="OpenProject OAuth client ID"
-					:hint-text="openProjectClientHint" />
-				<FieldValue v-if="isOPOAuthFormInView"
-					is-required
-					class="pb-1"
-					encrypt-value
-					title="OpenProject OAuth client secret"
-					:value="state.openproject_client_secret" />
-				<TextInput v-else
-					id="openproject-oauth-client-secret"
-					v-model="state.openproject_client_secret"
-					is-required
-					class="py-1"
-					label="OpenProject OAuth client secret"
-					:hint-text="openProjectClientHint" />
-				<div class="form-actions">
-					<NcButton v-if="isOPOAuthFormComplete && isOPOAuthFormInView"
-						data-test-id="reset-op-oauth-btn"
-						@click="resetOPOAuthClientValues">
-						<template #icon>
-							<AutoRenewIcon :size="20" />
-						</template>
-						{{ t('integration_openproject', 'Replace OpenProject OAuth values') }}
-					</NcButton>
-					<NcButton v-else
-						data-test-id="submit-op-oauth-btn"
-						type="primary"
-						:disabled="!state.openproject_client_id || !state.openproject_client_secret"
-						@click="saveOPOAuthClientValues">
-						<template #icon>
-							<NcLoadingIcon v-if="loadingOPOauthForm" class="loading-spinner" :size="20" />
-							<CheckBoldIcon v-else fill-color="#FFFFFF" :size="20" />
-						</template>
-						{{ t('integration_openproject', 'Save') }}
-					</NcButton>
-				</div>
-			</div>
-		</div>
-		<div v-if="showOAuthSettings" class="nextcloud-oauth-values">
-			<FormHeading index="4"
-				:title="t('integration_openproject', 'Nextcloud OAuth client')"
-				:is-complete="isNcOAuthFormComplete"
-				:is-disabled="isNcOAuthFormInDisableMode"
-				:is-dark-theme="isDarkTheme" />
-			<div v-if="state.nc_oauth_client">
-				<TextInput v-if="isNcOAuthFormInEdit"
-					id="nextcloud-oauth-client-id"
-					v-model="state.nc_oauth_client.nextcloud_client_id"
-					class="py-1"
-					read-only
-					is-required
-					with-copy-btn
-					label="Nextcloud OAuth client ID"
-					:hint-text="nextcloudClientHint" />
-				<FieldValue v-else
-					title="Nextcloud OAuth client ID"
-					:value="state.nc_oauth_client.nextcloud_client_id"
-					is-required />
-				<TextInput v-if="isNcOAuthFormInEdit"
-					id="nextcloud-oauth-client-secret"
-					v-model="state.nc_oauth_client.nextcloud_client_secret"
-					class="py-1"
-					read-only
-					is-required
-					with-copy-btn
-					label="Nextcloud OAuth client secret"
-					:hint-text="nextcloudClientHint" />
-				<FieldValue v-else
-					title="Nextcloud OAuth client secret"
-					is-required
-					encrypt-value
-					:value="ncClientSecret" />
-				<div class="form-actions">
-					<NcButton v-if="isNcOAuthFormInEdit"
-						type="primary"
-						:disabled="!ncClientId"
-						data-test-id="submit-nc-oauth-values-form-btn"
-						@click="setNCOAuthFormToViewMode">
-						<template #icon>
-							<CheckBoldIcon fill-color="#FFFFFF" :size="20" />
-						</template>
-						{{ t('integration_openproject', 'Yes, I have copied these values') }}
-					</NcButton>
-					<NcButton v-else
-						data-test-id="reset-nc-oauth-btn"
-						@click="resetNcOauthValues">
-						<template #icon>
-							<AutoRenewIcon :size="20" />
-						</template>
-						{{ t('integration_openproject', 'Replace Nextcloud OAuth values') }}
-					</NcButton>
-				</div>
-			</div>
-			<div v-if="!state.nc_oauth_client && isOPOAuthFormComplete && isOPOAuthFormInView && showDefaultManagedProjectFolders">
-				<NcButton data-test-id="reset-nc-oauth-btn"
-					@click="resetNcOauthValues">
-					<template #icon>
-						<AutoRenewIcon :size="20" />
-					</template>
-					{{ t('integration_openproject', 'Create Nextcloud OAuth values') }}
-				</NcButton>
-			</div>
-		</div>
+		<FormOAuthSettings
+			v-if="isOAuthMethod"
+			:is-dark-theme="isDarkTheme"
+			:form-state="form"
+			:oauth-settings="{
+				openproject_client_id: state.openproject_client_id,
+				openproject_client_secret: state.openproject_client_secret,
+				nc_oauth_client: state.nc_oauth_client
+			}"
+			@formcomplete="markFormComplete" />
 		<div class="project-folder-setup">
 			<FormHeading :index="isOidcMethod ? '4' : '5'"
 				:is-project-folder-setup-heading="true"
@@ -301,7 +192,7 @@
 			</template>
 			{{ t('integration_openproject', 'Reset') }}
 		</NcButton>
-		<div v-if="isIntegrationCompleteWithOauth2 || isIntegrationCompleteWithOIDC" class="default-prefs">
+		<div v-if="isSetupComplete" class="default-prefs">
 			<h2>{{ t('integration_openproject', 'Default user settings') }}</h2>
 			<p>
 				{{ t('integration_openproject', 'A new user will receive these defaults and they will be applied to the integration app till the user changes them.') }}
@@ -357,6 +248,7 @@ import { appLinks } from '../constants/links.js'
 import FormOpenProjectHost from './admin/FormOpenProjectHost.vue'
 import FormAuthMethod from './admin/FormAuthMethod.vue'
 import FormSSOSettings from './admin/FormSSOSettings.vue'
+import FormOAuthSettings from './admin/FormOAuthSettings.vue'
 
 export default {
 	name: 'AdminSettings',
@@ -379,6 +271,7 @@ export default {
 		FormOpenProjectHost,
 		FormAuthMethod,
 		FormSSOSettings,
+		FormOAuthSettings,
 	},
 	data() {
 		return {
@@ -386,13 +279,11 @@ export default {
 			formMode: {
 				// server host form is never disabled.
 				// it's either editable or view only
-				opOauth: F_MODES.DISABLE,
-				ncOauth: F_MODES.DISABLE,
 				opUserAppPassword: F_MODES.DISABLE,
 				projectFolderSetUp: F_MODES.DISABLE,
 			},
 			isFormCompleted: {
-				opOauth: false, ncOauth: false, opUserAppPassword: false, projectFolderSetUp: false,
+				opUserAppPassword: false, projectFolderSetUp: false,
 			},
 			buttonTextLabel: {
 				keepCurrentChange: t('integration_openproject', 'Keep current setup'),
@@ -401,10 +292,8 @@ export default {
 				retrySetupWithProjectFolder: t('integration_openproject', 'Retry setup OpenProject user, group and folder'),
 			},
 			loadingProjectFolderSetup: false,
-			loadingOPOauthForm: false,
 			state: loadState('integration_openproject', 'admin-settings-config'),
 			isAdminConfigOk: loadState('integration_openproject', 'admin-config-status'),
-			oPOAuthTokenRevokeStatus: null,
 			oPUserAppPassword: null,
 			isProjectFolderSwitchEnabled: null,
 			projectFolderSetupError: null,
@@ -437,13 +326,6 @@ export default {
 				|| this.state.openproject_client_secret
 			return formAdded || hasPreSEtup
 		},
-		ncClientId() {
-			return this.state.nc_oauth_client?.nextcloud_client_id
-		},
-		ncClientSecret() {
-			return '*******'
-
-		},
 		opUserAppPassword() {
 			return this.state.app_password_set
 		},
@@ -457,28 +339,13 @@ export default {
 			return this.form.authenticationMethod.complete
 		},
 		isAuthorizationSettingFormComplete() {
-			return this.form.ssoSettings.complete
-		},
-		isOPOAuthFormComplete() {
-			return this.isFormCompleted.opOauth
+			return (this.form.openprojectOauth.complete && this.form.nextcloudOauth.complete) || this.form.ssoSettings.complete
 		},
 		isManagedGroupFolderSetUpComplete() {
 			return this.isFormCompleted.projectFolderSetUp
 		},
 		isOPUserAppPasswordFormComplete() {
 			return this.isFormCompleted.opUserAppPassword
-		},
-		isNcOAuthFormComplete() {
-			return this.isFormCompleted.ncOauth
-		},
-		isOPOAuthFormInView() {
-			return this.formMode.opOauth === F_MODES.VIEW
-		},
-		isNcOAuthFormInEdit() {
-			return this.formMode.ncOauth === F_MODES.EDIT
-		},
-		isOPOAuthFormInDisableMode() {
-			return this.formMode.opOauth === F_MODES.DISABLE
 		},
 		isOPUserAppPasswordFormInEdit() {
 			return this.formMode.opUserAppPassword === F_MODES.EDIT
@@ -488,9 +355,6 @@ export default {
 		},
 		isProjectFolderFormInDisableMode() {
 			return this.formMode.projectFolderSetUp === F_MODES.DISABLE
-		},
-		isNcOAuthFormInDisableMode() {
-			return this.formMode.ncOauth === F_MODES.DISABLE
 		},
 		isOPUserAppPasswordInDisableMode() {
 			return this.formMode.opUserAppPassword === F_MODES.DISABLE
@@ -510,23 +374,10 @@ export default {
 		isOidcMethod() {
 			return this.getCurrentAuthMethod === AUTH_METHOD.OIDC
 		},
-		showOAuthSettings() {
-			return this.isOAuthMethod || !this.form.authenticationMethod.complete
-		},
 		adminFileStorageHref() {
 			const path = '%s/admin/settings/storages'
 			const host = this.form.serverHost.value
 			return util.format(path, host)
-		},
-		openProjectClientHint() {
-			const linkText = t('integration_openproject', 'Administration > File storages')
-			const htmlLink = `<a class="link" href="${this.adminFileStorageHref}" target="_blank" title="${linkText}">${linkText}</a>`
-			return t('integration_openproject', 'Go to your OpenProject {htmlLink} as an Administrator and start the setup and copy the values here.', { htmlLink }, null, { escape: false, sanitize: false })
-		},
-		nextcloudClientHint() {
-			const linkText = t('integration_openproject', 'Administration > File storages')
-			const htmlLink = `<a class="link" href="${this.adminFileStorageHref}" target="_blank" title="${linkText}">${linkText}</a>`
-			return t('integration_openproject', 'Copy the following values back into the OpenProject {htmlLink} as an Administrator.', { htmlLink }, null, { escape: false, sanitize: false })
 		},
 		userAppPasswordHint() {
 			const linkText = t('integration_openproject', 'Administration > File storages')
@@ -552,21 +403,12 @@ export default {
 			const htmlLink = `<a class="link" href="https://www.openproject.org/docs/system-admin-guide/integrations/nextcloud/#files-are-not-encrypted-when-using-nextcloud-server-side-encryption" target="_blank" title="${linkText}">${linkText}</a>`
 			return t('integration_openproject', 'Server-side encryption is active, but encryption for Team Folders is not yet enabled. To ensure secure storage of files in project folders, please follow the configuration steps in the {htmlLink}.', { htmlLink }, null, { escape: false, sanitize: false })
 		},
-		isIntegrationCompleteWithOauth2() {
+		isSetupComplete() {
 			return (this.isServerHostFormComplete
 				&& this.isAuthorizationMethodFormComplete
-				 && this.isOPOAuthFormComplete
-				 && this.isNcOAuthFormComplete
+				 && this.isAuthorizationSettingFormComplete
 				 && this.isManagedGroupFolderSetUpComplete
 				 && !this.isOPUserAppPasswordFormInEdit
-			)
-		},
-		isIntegrationCompleteWithOIDC() {
-			return (this.isServerHostFormComplete
-				&& this.isAuthorizationMethodFormComplete
-				&& this.isAuthorizationSettingFormComplete
-				&& this.isManagedGroupFolderSetUpComplete
-				&& !this.isOPUserAppPasswordFormInEdit
 			)
 		},
 		isSetupCompleteWithoutProjectFolders() {
@@ -603,7 +445,15 @@ export default {
 	},
 	watch: {
 		'form.ssoSettings.complete'() {
-			if (this.form.ssoSettings.complete && (!this.state.authorization_settings.sso_provider_type || this.formMode.projectFolderSetUp === F_MODES.DISABLE)) {
+			if (this.form.ssoSettings.complete && this.formMode.projectFolderSetUp === F_MODES.DISABLE) {
+				this.formMode.projectFolderSetUp = F_MODES.EDIT
+				this.showDefaultManagedProjectFolders = true
+				this.isProjectFolderSwitchEnabled = true
+				this.textLabelProjectFolderSetupButton = this.buttonTextLabel.completeWithProjectFolderSetup
+			}
+		},
+		'form.nextcloudOauth.complete'() {
+			if (this.form.nextcloudOauth.complete && this.formMode.projectFolderSetUp === F_MODES.DISABLE) {
 				this.formMode.projectFolderSetUp = F_MODES.EDIT
 				this.showDefaultManagedProjectFolders = true
 				this.isProjectFolderSwitchEnabled = true
@@ -636,30 +486,13 @@ export default {
 					this.textLabelProjectFolderSetupButton = this.buttonTextLabel.keepCurrentChange
 				}
 				// for oauth2 authorization
-				if (this.state.openproject_instance_url
-					&& this.state.openproject_client_id
-					&& this.state.openproject_client_secret
-					&& this.state.nc_oauth_client
-				) {
+				if (this.state.openproject_instance_url && this.isAuthorizationSettingFormComplete) {
 					this.showDefaultManagedProjectFolders = true
 				}
 				if (this.state.fresh_project_folder_setup === false) {
 					this.showDefaultManagedProjectFolders = true
 				}
-				if (!!this.state.openproject_client_id && !!this.state.openproject_client_secret) {
-					this.formMode.opOauth = F_MODES.VIEW
-					this.isFormCompleted.opOauth = true
-				}
-				if (this.state.authorization_method) {
-					if (!this.state.openproject_client_id && !this.state.openproject_client_secret) {
-						this.formMode.opOauth = F_MODES.EDIT
-					}
-				}
 
-				if (this.state.nc_oauth_client) {
-					this.formMode.ncOauth = F_MODES.VIEW
-					this.isFormCompleted.ncOauth = true
-				}
 				if (!this.state.nc_oauth_client
 					&& this.state.openproject_instance_url
 					&& this.state.openproject_client_id
@@ -668,9 +501,6 @@ export default {
 					this.showDefaultManagedProjectFolders = true
 					this.formMode.projectFolderSetUp = F_MODES.VIEW
 					this.isFormCompleted.projectFolderSetUp = true
-				}
-				if (this.formMode.ncOauth === F_MODES.VIEW || this.form.ssoSettings.complete) {
-					this.showDefaultManagedProjectFolders = true
 				}
 				if (this.showDefaultManagedProjectFolders) {
 					this.formMode.projectFolderSetUp = F_MODES.VIEW
@@ -700,16 +530,6 @@ export default {
 			this.isFormCompleted.projectFolderSetUp = true
 			this.formMode.projectFolderSetUp = F_MODES.VIEW
 			this.isProjectFolderSetupCorrect = true
-		},
-		async setNCOAuthFormToViewMode() {
-			this.formMode.ncOauth = F_MODES.VIEW
-			this.isFormCompleted.ncOauth = true
-			if (!this.isIntegrationCompleteWithOauth2 && this.formMode.projectFolderSetUp !== F_MODES.EDIT && this.formMode.opUserAppPassword !== F_MODES.EDIT) {
-				this.formMode.projectFolderSetUp = F_MODES.EDIT
-				this.showDefaultManagedProjectFolders = true
-				this.isProjectFolderSwitchEnabled = true
-				this.textLabelProjectFolderSetupButton = this.buttonTextLabel.completeWithProjectFolderSetup
-			}
 		},
 		setOPUserAppPasswordToViewMode() {
 			this.formMode.opUserAppPassword = F_MODES.VIEW
@@ -762,48 +582,6 @@ export default {
 				this.projectFolderSetupError = null
 			}
 		},
-		async saveOPOAuthClientValues() {
-			this.isFormStep = FORM.OP_OAUTH
-			if (await this.saveOPOptions()) {
-				this.formMode.opOauth = F_MODES.VIEW
-				this.isFormCompleted.opOauth = true
-
-				// if we do not have Nextcloud OAuth client yet, a new client is created
-				if (!this.state.nc_oauth_client) {
-					this.createNCOAuthClient()
-				}
-			}
-		},
-		resetOPOAuthClientValues() {
-			OC.dialogs.confirmDestructive(
-				t('integration_openproject', 'If you proceed you will need to update these settings with the new OpenProject OAuth credentials. Also, all users will need to reauthorize access to their OpenProject account.'),
-				t('integration_openproject', 'Replace OpenProject OAuth values'),
-				{
-					type: OC.dialogs.YES_NO_BUTTONS,
-					confirm: t('integration_openproject', 'Yes, replace'),
-					confirmClasses: 'error',
-					cancel: t('integration_openproject', 'Cancel'),
-				},
-				async (result) => {
-					if (result) {
-						await this.clearOPOAuthClientValues()
-					}
-				},
-				true,
-			)
-		},
-		async clearOPOAuthClientValues() {
-			this.isFormStep = FORM.OP_OAUTH
-			this.formMode.opOauth = F_MODES.EDIT
-			this.isFormCompleted.opOauth = false
-			this.state.openproject_client_id = null
-			this.state.openproject_client_secret = null
-			const saved = await this.saveOPOptions()
-			if (!saved) {
-				this.formMode.opOauth = F_MODES.VIEW
-				this.isFormCompleted.opOauth = true
-			}
-		},
 		resetAllAppValuesConfirmation() {
 			OC.dialogs.confirmDestructive(
 				t('integration_openproject', 'Are you sure that you want to reset this app and delete all settings and all connections of all Nextcloud users to OpenProject?'),
@@ -828,9 +606,6 @@ export default {
 			// also, form completeness should be set to false
 
 			// reset form states to default
-			this.isFormCompleted.opOauth = false
-			this.formMode.opOauth = F_MODES.EDIT
-
 			this.state.default_enable_navigation = false
 			this.state.default_enable_unified_search = false
 			this.oPUserAppPassword = null
@@ -901,13 +676,11 @@ export default {
 					this.state.app_password_set = true
 					this.oPUserAppPassword = response?.data?.oPUserAppPassword
 				}
-				this.oPOAuthTokenRevokeStatus = response?.data?.oPOAuthTokenRevokeStatus
 				showSuccess(t('integration_openproject', 'OpenProject admin options saved'))
 				success = true
 			} catch (error) {
 				console.error()
 				this.isAdminConfigOk = null
-				this.oPOAuthTokenRevokeStatus = null
 				if (error.response.data.error) {
 					this.projectFolderSetupError = error.response.data.error
 				}
@@ -915,7 +688,6 @@ export default {
 					t('integration_openproject', 'Failed to save OpenProject admin options'),
 				)
 			}
-			this.notifyAboutOPOAuthTokenRevoke()
 			return success
 		},
 		async checkIfProjectFolderIsAlreadyReadyForSetup() {
@@ -928,46 +700,6 @@ export default {
 				console.error(error)
 			}
 			return success
-		},
-		notifyAboutOPOAuthTokenRevoke() {
-			switch (this.oPOAuthTokenRevokeStatus) {
-			case 'connection_error':
-				showError(
-					t('integration_openproject', 'Failed to perform revoke request due to connection error with the OpenProject server'),
-				)
-				break
-			case 'other_error':
-				showError(
-					t('integration_openproject', 'Failed to revoke some users\' OpenProject OAuth access tokens'),
-				)
-				break
-			case 'success':
-				showSuccess(
-					t('integration_openproject', 'Successfully revoked users\' OpenProject OAuth access tokens'),
-				)
-				break
-			default:
-				break
-			}
-		},
-		resetNcOauthValues() {
-			OC.dialogs.confirmDestructive(
-				t('integration_openproject', 'If you proceed you will need to update the settings in your OpenProject with the new Nextcloud OAuth credentials. Also, all users in OpenProject will need to reauthorize access to their Nextcloud account.'),
-				t('integration_openproject', 'Replace Nextcloud OAuth values'),
-				{
-					type: OC.dialogs.YES_NO_BUTTONS,
-					confirm: t('integration_openproject', 'Yes, replace'),
-					confirmClasses: 'error',
-					cancel: t('integration_openproject', 'Cancel'),
-				},
-				async (result) => {
-					if (result) {
-						this.state.nc_oauth_client = null
-						this.createNCOAuthClient()
-					}
-				},
-				true,
-			)
 		},
 		async completeIntegrationWithoutProjectFolderSetUp() {
 			this.isFormStep = FORM.GROUP_FOLDER
@@ -1012,21 +744,6 @@ export default {
 			this.formMode.opUserAppPassword = F_MODES.EDIT
 			this.isFormCompleted.opUserAppPassword = false
 			await this.saveOPOptions()
-		},
-		createNCOAuthClient() {
-			const url = generateUrl('/apps/integration_openproject/nc-oauth')
-			axios.post(url).then((response) => {
-				this.state.nc_oauth_client = response.data
-				// generate part is complete but still the NC OAuth form is set to
-				// edit mode and not completed state so that copy buttons will be available for the user
-				this.formMode.ncOauth = F_MODES.EDIT
-				this.isFormCompleted.ncOauth = false
-			}).catch((error) => {
-				showError(
-					t('integration_openproject', 'Failed to create Nextcloud OAuth client')
-					+ ': ' + error.response.request.responseText,
-				)
-			})
 		},
 		setDefaultConfig() {
 			const url = generateUrl('/apps/integration_openproject/admin-config')

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -485,24 +485,16 @@ export default {
 				} else {
 					this.textLabelProjectFolderSetupButton = this.buttonTextLabel.keepCurrentChange
 				}
-				// for oauth2 authorization
 				if (this.state.openproject_instance_url && this.isAuthorizationSettingFormComplete) {
 					this.showDefaultManagedProjectFolders = true
+					this.formMode.projectFolderSetUp = F_MODES.EDIT
 				}
 				if (this.state.fresh_project_folder_setup === false) {
 					this.showDefaultManagedProjectFolders = true
 				}
 
-				if (!this.state.nc_oauth_client
-					&& this.state.openproject_instance_url
-					&& this.state.openproject_client_id
-					&& this.state.openproject_client_secret
-				    && this.textLabelProjectFolderSetupButton === 'Keep current setup') {
+				if (this.textLabelProjectFolderSetupButton === 'Keep current setup') {
 					this.showDefaultManagedProjectFolders = true
-					this.formMode.projectFolderSetUp = F_MODES.VIEW
-					this.isFormCompleted.projectFolderSetUp = true
-				}
-				if (this.showDefaultManagedProjectFolders) {
 					this.formMode.projectFolderSetUp = F_MODES.VIEW
 					this.isFormCompleted.projectFolderSetUp = true
 				}

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -29,7 +29,7 @@
 			:apps="state.apps"
 			@formcomplete="markFormComplete" />
 		<FormOAuthSettings
-			v-if="isOAuthMethod"
+			v-if="isOAuthMethod || !form.authenticationMethod.complete"
 			:is-dark-theme="isDarkTheme"
 			:form-state="form"
 			:oauth-settings="{
@@ -452,8 +452,8 @@ export default {
 				this.textLabelProjectFolderSetupButton = this.buttonTextLabel.completeWithProjectFolderSetup
 			}
 		},
-		'form.nextcloudOauth.complete'() {
-			if (this.form.nextcloudOauth.complete && this.formMode.projectFolderSetUp === F_MODES.DISABLE) {
+		'isAuthorizationSettingFormComplete'() {
+			if (this.form.openprojectOauth.complete && this.form.nextcloudOauth.complete && this.formMode.projectFolderSetUp === F_MODES.DISABLE) {
 				this.formMode.projectFolderSetUp = F_MODES.EDIT
 				this.showDefaultManagedProjectFolders = true
 				this.isProjectFolderSwitchEnabled = true
@@ -493,7 +493,7 @@ export default {
 					this.showDefaultManagedProjectFolders = true
 				}
 
-				if (this.textLabelProjectFolderSetupButton === 'Keep current setup') {
+				if (this.textLabelProjectFolderSetupButton === this.buttonTextLabel.keepCurrentChange) {
 					this.showDefaultManagedProjectFolders = true
 					this.formMode.projectFolderSetUp = F_MODES.VIEW
 					this.isFormCompleted.projectFolderSetUp = true

--- a/src/components/admin/FormOAuthSettings.vue
+++ b/src/components/admin/FormOAuthSettings.vue
@@ -226,9 +226,13 @@ export default {
 		disableOpenProjectFormSave() {
 			return !this.currentOpenProjectForm.clientId || !this.currentOpenProjectForm.clientSecret
 		},
+		openprojectAdminFileStoragesURL() {
+			const host = (this.formState.serverHost.value || '').replace(/\/$/, '')
+			return host + '/admin/settings/storages'
+		},
 		openProjectClientHint() {
 			const linkText = t('integration_openproject', 'Administration > File storages')
-			const htmlLink = `<a class="link" href="${this.adminFileStorageHref}" target="_blank" title="${linkText}">${linkText}</a>`
+			const htmlLink = `<a class="link" href="${this.openprojectAdminFileStoragesURL}" target="_blank" title="${linkText}">${linkText}</a>`
 			return t(
 				'integration_openproject',
 				'Go to your OpenProject {htmlLink} as an Administrator and start the setup and copy the values here.',
@@ -254,7 +258,7 @@ export default {
 		},
 		nextcloudClientHint() {
 			const linkText = t('integration_openproject', 'Administration > File storages')
-			const htmlLink = `<a class="link" href="${this.adminFileStorageHref}" target="_blank" title="${linkText}">${linkText}</a>`
+			const htmlLink = `<a class="link" href="${this.openprojectAdminFileStoragesURL}" target="_blank" title="${linkText}">${linkText}</a>`
 			return t('integration_openproject', 'Copy the following values back into the OpenProject {htmlLink} as an Administrator.', { htmlLink }, null, { escape: false, sanitize: false })
 		},
 	},
@@ -339,6 +343,7 @@ export default {
 			}
 		},
 		async saveOpenProjectClient() {
+			this.loading = true
 			try {
 				const response = await saveAdminConfig({
 					openproject_client_id: this.currentOpenProjectForm.clientId,
@@ -361,6 +366,7 @@ export default {
 				showError(message + ': ' + errorMessage)
 			}
 			this.notifyOpenProjectTokenRevoke()
+			this.loading = false
 		},
 		resetOpenProjectClient() {
 			OC.dialogs.confirmDestructive(

--- a/src/components/admin/FormOAuthSettings.vue
+++ b/src/components/admin/FormOAuthSettings.vue
@@ -1,0 +1,416 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Jankari Tech Pvt. Ltd.
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<section>
+		<div :class="openprojectFormId">
+			<FormHeading
+				:index="openprojectFormOrder"
+				:title="t('integration_openproject', 'OpenProject OAuth settings')"
+				:is-complete="isOpenProjectFormComplete"
+				:is-disabled="!showOpenProjectForm"
+				:is-dark-theme="isDarkTheme" />
+			<div v-if="showOpenProjectForm">
+				<FieldValue
+					v-if="isOpenProjectFormInViewMode"
+					is-required
+					:value="savedOpenProjectForm.clientId"
+					title="OpenProject OAuth client ID" />
+				<TextInput
+					v-else
+					id="openproject-oauth-client-id"
+					v-model="currentOpenProjectForm.clientId"
+					class="py-1"
+					is-required
+					label="OpenProject OAuth client ID"
+					:hint-text="openProjectClientHint" />
+				<FieldValue
+					v-if="isOpenProjectFormInViewMode"
+					is-required
+					class="pb-1"
+					encrypt-value
+					title="OpenProject OAuth client secret"
+					:value="savedOpenProjectForm.clientSecret" />
+				<TextInput
+					v-else
+					id="openproject-oauth-client-secret"
+					v-model="currentOpenProjectForm.clientSecret"
+					is-required
+					class="py-1"
+					label="OpenProject OAuth client secret"
+					:hint-text="openProjectClientHint" />
+				<div class="form-actions">
+					<NcButton
+						v-if="isOpenProjectFormComplete && isOpenProjectFormInViewMode"
+						data-test-id="reset-op-oauth-btn"
+						@click="resetOpenProjectClient">
+						<template #icon>
+							<AutoRenewIcon :size="20" />
+						</template>
+						{{ t('integration_openproject', 'Replace OpenProject OAuth values') }}
+					</NcButton>
+					<NcButton
+						v-else
+						data-test-id="submit-op-oauth-btn"
+						type="primary"
+						:disabled="disableOpenProjectFormSave"
+						@click="saveOpenProjectClient">
+						<template #icon>
+							<NcLoadingIcon v-if="loading" class="loading-spinner" :size="20" />
+							<CheckBoldIcon v-else fill-color="#FFFFFF" :size="20" />
+						</template>
+						{{ t('integration_openproject', 'Save') }}
+					</NcButton>
+				</div>
+			</div>
+		</div>
+		<div :class="nextcloudFormId">
+			<FormHeading
+				:index="nextcloudFormOrder"
+				:title="t('integration_openproject', 'Nextcloud OAuth client')"
+				:is-complete="isNextcloudFormComplete"
+				:is-disabled="!showNextcloudForm"
+				:is-dark-theme="isDarkTheme" />
+			<div v-if="showNextcloudForm">
+				<FieldValue
+					v-if="isNextcloudFormInViewMode"
+					title="Nextcloud OAuth client ID"
+					:value="savedNextcloudForm.clientId"
+					is-required />
+				<TextInput
+					v-else
+					id="nextcloud-oauth-client-id"
+					v-model="savedNextcloudForm.clientId"
+					class="py-1"
+					read-only
+					is-required
+					with-copy-btn
+					label="Nextcloud OAuth client ID"
+					:hint-text="nextcloudClientHint" />
+				<FieldValue
+					v-if="isNextcloudFormInViewMode"
+					title="Nextcloud OAuth client secret"
+					is-required
+					encrypt-value
+					value="***" />
+				<TextInput
+					v-else
+					id="nextcloud-oauth-client-secret"
+					v-model="savedNextcloudForm.clientSecret"
+					class="py-1"
+					read-only
+					is-required
+					with-copy-btn
+					label="Nextcloud OAuth client secret"
+					:hint-text="nextcloudClientHint" />
+				<div class="form-actions">
+					<NcButton
+						v-if="
+							!isNextcloudFormComplete
+								&& isOpenProjectFormComplete
+								&& isOpenProjectFormInViewMode">
+						<template #icon>
+							<AutoRenewIcon :size="20" />
+						</template>
+						{{ t('integration_openproject', 'Create Nextcloud OAuth values') }}
+					</NcButton>
+					<NcButton
+						v-else-if="isNextcloudFormComplete && isNextcloudFormInViewMode"
+						data-test-id="reset-nc-oauth-btn"
+						@click="resetNextcloudClient">
+						<template #icon>
+							<AutoRenewIcon :size="20" />
+						</template>
+						{{ t('integration_openproject', 'Replace Nextcloud OAuth values') }}
+					</NcButton>
+					<NcButton
+						v-else
+						type="primary"
+						:disabled="disableNextcloudFormSave"
+						data-test-id="submit-nc-oauth-values-form-btn"
+						@click="setNextcloudFromToViewMode">
+						<template #icon>
+							<CheckBoldIcon fill-color="#FFFFFF" :size="20" />
+						</template>
+						{{ t('integration_openproject', 'Yes, I have copied these values') }}
+					</NcButton>
+				</div>
+			</div>
+		</div>
+	</section>
+</template>
+
+<script>
+import { NcLoadingIcon, NcButton } from '@nextcloud/vue'
+import { showSuccess, showError } from '@nextcloud/dialogs'
+import AutoRenewIcon from 'vue-material-design-icons/Autorenew.vue'
+import CheckBoldIcon from 'vue-material-design-icons/CheckBold.vue'
+import FieldValue from './FieldValue.vue'
+import FormHeading from './FormHeading.vue'
+import TextInput from './TextInput.vue'
+import { F_MODES, ADMIN_SETTINGS_FORM } from '../../utils.js'
+import { saveAdminConfig, createNextcloudOAuthClient } from '../../api/settings.js'
+import { messages, messagesFmt } from '../../constants/messages.js'
+
+export default {
+	name: 'FormOAuthSettings',
+	components: {
+		NcLoadingIcon,
+		NcButton,
+		AutoRenewIcon,
+		CheckBoldIcon,
+		FieldValue,
+		FormHeading,
+		TextInput,
+	},
+	props: {
+		formState: {
+			type: Object,
+			required: true,
+		},
+		oauthSettings: {
+			type: Object,
+			required: true,
+		},
+		isDarkTheme: {
+			type: Boolean,
+			default: false,
+		},
+	},
+	data() {
+		return {
+			openprojectFormMode: F_MODES.NEW,
+			nextcloudFormMode: F_MODES.NEW,
+			openprojectFormId: ADMIN_SETTINGS_FORM.openprojectOauth.id,
+			nextcloudFormId: ADMIN_SETTINGS_FORM.nextcloudOauth.id,
+			openprojectFormOrder: ADMIN_SETTINGS_FORM.openprojectOauth.order.toString(),
+			nextcloudFormOrder: ADMIN_SETTINGS_FORM.nextcloudOauth.order.toString(),
+			messages,
+			messagesFmt,
+			loading: false,
+			openprojectTokenRevokeStatus: null,
+			// state that holds the current changed form values
+			currentOpenProjectForm: {
+				clientId: this.oauthSettings.openproject_client_id || '',
+				clientSecret: this.oauthSettings.openproject_client_secret || '',
+			},
+			// state that holds the saved form values (useful for resetting)
+			savedOpenProjectForm: {
+				clientId: this.oauthSettings.openproject_client_id || '',
+				clientSecret: this.oauthSettings.openproject_client_secret || '',
+			},
+			savedNextcloudForm: {
+				clientId: this.oauthSettings.nc_oauth_client?.nextcloud_client_id || '',
+				clientSecret: '',
+			},
+		}
+	},
+	computed: {
+		isOpenProjectFormComplete() {
+			return !!this.savedOpenProjectForm.clientId && !!this.savedOpenProjectForm.clientSecret
+		},
+		isOpenProjectFormInViewMode() {
+			return this.openprojectFormMode === F_MODES.VIEW
+		},
+		isOpenProjectFormInEditMode() {
+			return this.openprojectFormMode === F_MODES.EDIT
+		},
+		showOpenProjectForm() {
+			return this.formState.authenticationMethod.complete
+		},
+		disableOpenProjectFormSave() {
+			return !this.currentOpenProjectForm.clientId || !this.currentOpenProjectForm.clientSecret
+		},
+		openProjectClientHint() {
+			const linkText = t('integration_openproject', 'Administration > File storages')
+			const htmlLink = `<a class="link" href="${this.adminFileStorageHref}" target="_blank" title="${linkText}">${linkText}</a>`
+			return t(
+				'integration_openproject',
+				'Go to your OpenProject {htmlLink} as an Administrator and start the setup and copy the values here.',
+				{ htmlLink },
+				null,
+				{ escape: false, sanitize: false },
+			)
+		},
+		isNextcloudFormComplete() {
+			return !!this.savedNextcloudForm.clientId
+		},
+		isNextcloudFormInViewMode() {
+			return this.nextcloudFormMode === F_MODES.VIEW
+		},
+		isNextcloudFormInEditMode() {
+			return this.nextcloudFormMode === F_MODES.EDIT
+		},
+		showNextcloudForm() {
+			return this.formState.openprojectOauth.complete || this.isNextcloudFormComplete
+		},
+		disableNextcloudFormSave() {
+			return !this.savedNextcloudForm.clientId || !this.savedNextcloudForm.clientSecret
+		},
+		nextcloudClientHint() {
+			const linkText = t('integration_openproject', 'Administration > File storages')
+			const htmlLink = `<a class="link" href="${this.adminFileStorageHref}" target="_blank" title="${linkText}">${linkText}</a>`
+			return t('integration_openproject', 'Copy the following values back into the OpenProject {htmlLink} as an Administrator.', { htmlLink }, null, { escape: false, sanitize: false })
+		},
+	},
+	watch: {},
+	created() {
+		if (this.isOpenProjectFormComplete) {
+			this.setOpenProjectFromToViewMode()
+			this.$emit('formcomplete', this.markOpenProjectFormComplete)
+		} else {
+			this.setOpenProjectFormToEditMode()
+		}
+
+		if (this.isNextcloudFormComplete) {
+			this.setNextcloudFromToViewMode()
+			this.$emit('formcomplete', this.markNextcloudFormComplete)
+		}
+	},
+	methods: {
+		markOpenProjectFormComplete(formState) {
+			formState.openprojectOauth.complete = true
+			return formState
+		},
+		markNextcloudFormComplete(formState) {
+			formState.nextcloudOauth.complete = true
+			return formState
+		},
+		setOpenProjectFormMode(mode) {
+			this.openprojectFormMode = mode
+		},
+		setOpenProjectFromToViewMode() {
+			this.setOpenProjectFormMode(F_MODES.VIEW)
+		},
+		setOpenProjectFormToEditMode() {
+			this.setOpenProjectFormMode(F_MODES.EDIT)
+		},
+		setNextcloudFormMode(mode) {
+			this.nextcloudFormMode = mode
+		},
+		setNextcloudFromToViewMode() {
+			this.setNextcloudFormMode(F_MODES.VIEW)
+			this.$emit('formcomplete', this.markNextcloudFormComplete)
+		},
+		setNextcloudFormToEditMode() {
+			this.setNextcloudFormMode(F_MODES.EDIT)
+		},
+		notifyOpenProjectTokenRevoke() {
+			switch (this.openprojectTokenRevokeStatus) {
+			case 'connection_error':
+				showError(
+					t(
+						'integration_openproject',
+						'Failed to perform revoke request due to connection error with the OpenProject server',
+					),
+				)
+				break
+			case 'other_error':
+				showError(
+					t('integration_openproject', "Failed to revoke some users' OpenProject OAuth access tokens"),
+				)
+				break
+			case 'success':
+				showSuccess(
+					t('integration_openproject', "Successfully revoked users' OpenProject OAuth access tokens"),
+				)
+				break
+			default:
+				break
+			}
+		},
+		async createNextcloudClient() {
+			try {
+				const response = await createNextcloudOAuthClient()
+				const { nextcloud_client_id: clientId, nextcloud_client_secret: clientSecret } = response.data
+				this.savedNextcloudForm.clientId = clientId
+				this.savedNextcloudForm.clientSecret = clientSecret
+				// allow copying the generated Nextcloud OAuth client values
+				// before switching to view mode
+				this.setNextcloudFormToEditMode()
+			} catch (error) {
+				const errorMessage = t('integration_openproject', 'Failed to create Nextcloud OAuth client')
+				showError(errorMessage + ': ' + error?.response?.request?.responseText)
+			}
+		},
+		async saveOpenProjectClient() {
+			try {
+				const response = await saveAdminConfig({
+					openproject_client_id: this.currentOpenProjectForm.clientId,
+					openproject_client_secret: this.currentOpenProjectForm.clientSecret,
+				})
+				this.openprojectTokenRevokeStatus = response?.data?.oPOAuthTokenRevokeStatus
+				this.savedOpenProjectForm = structuredClone(this.currentOpenProjectForm)
+				this.setOpenProjectFromToViewMode()
+				this.$emit('formcomplete', this.markOpenProjectFormComplete)
+				showSuccess(t('integration_openproject', 'OpenProject admin options saved'))
+
+				// Add new Nextcloud OAuth client if does not exist
+				if (!this.savedNextcloudForm.clientId) {
+					await this.createNextcloudClient()
+				}
+			} catch (error) {
+				this.openprojectTokenRevokeStatus = null
+				const errorMessage = error?.response?.data?.error || error?.message
+				console.error(errorMessage)
+				showError(t('integration_openproject', 'Failed to save OpenProject admin options'))
+			}
+			this.notifyOpenProjectTokenRevoke()
+		},
+		resetOpenProjectClient() {
+			OC.dialogs.confirmDestructive(
+				t('integration_openproject', 'If you proceed you will need to update these settings with the new OpenProject OAuth credentials. Also, all users will need to reauthorize access to their OpenProject account.'),
+				t('integration_openproject', 'Replace OpenProject OAuth values'),
+				{
+					type: OC.dialogs.YES_NO_BUTTONS,
+					confirm: t('integration_openproject', 'Yes, replace'),
+					confirmClasses: 'error',
+					cancel: t('integration_openproject', 'Cancel'),
+				},
+				async (result) => {
+					if (result) {
+						await this.confirmResetOpenProjectClient()
+					}
+				},
+				true,
+			)
+		},
+		async confirmResetOpenProjectClient() {
+			this.currentOpenProjectForm.clientId = ''
+			this.currentOpenProjectForm.clientSecret = ''
+			await this.saveOpenProjectClient()
+			this.setOpenProjectFormToEditMode()
+		},
+		resetNextcloudClient() {
+			OC.dialogs.confirmDestructive(
+				t('integration_openproject', 'If you proceed you will need to update the settings in your OpenProject with the new Nextcloud OAuth credentials. Also, all users in OpenProject will need to reauthorize access to their Nextcloud account.'),
+				t('integration_openproject', 'Replace Nextcloud OAuth values'),
+				{
+					type: OC.dialogs.YES_NO_BUTTONS,
+					confirm: t('integration_openproject', 'Yes, replace'),
+					confirmClasses: 'error',
+					cancel: t('integration_openproject', 'Cancel'),
+				},
+				async (result) => {
+					if (result) {
+						this.createNextcloudClient()
+					}
+				},
+				true,
+			)
+		},
+	},
+}
+</script>
+
+<style scoped lang="scss">
+.pb-1 {
+	padding-bottom: 0.5rem;
+}
+
+.py-1 {
+	padding: 0.3rem 0;
+}
+</style>

--- a/src/components/admin/FormOAuthSettings.vue
+++ b/src/components/admin/FormOAuthSettings.vue
@@ -335,7 +335,7 @@ export default {
 				this.setNextcloudFormToEditMode()
 			} catch (error) {
 				const errorMessage = t('integration_openproject', 'Failed to create Nextcloud OAuth client')
-				showError(errorMessage + ': ' + error?.response?.request?.responseText)
+				showError(errorMessage + ': ' + error?.response?.statusText)
 			}
 		},
 		async saveOpenProjectClient() {
@@ -357,8 +357,8 @@ export default {
 			} catch (error) {
 				this.openprojectTokenRevokeStatus = null
 				const errorMessage = error?.response?.data?.error || error?.message
-				console.error(errorMessage)
-				showError(t('integration_openproject', 'Failed to save OpenProject admin options'))
+				const message = t('integration_openproject', 'Failed to save OpenProject admin options')
+				showError(message + ': ' + errorMessage)
 			}
 			this.notifyOpenProjectTokenRevoke()
 		},

--- a/src/components/admin/FormOAuthSettings.vue
+++ b/src/components/admin/FormOAuthSettings.vue
@@ -154,7 +154,6 @@ import FormHeading from './FormHeading.vue'
 import TextInput from './TextInput.vue'
 import { F_MODES, ADMIN_SETTINGS_FORM, AUTH_METHOD } from '../../utils.js'
 import { saveAdminConfig, createNextcloudOAuthClient } from '../../api/settings.js'
-import { messages, messagesFmt } from '../../constants/messages.js'
 
 export default {
 	name: 'FormOAuthSettings',
@@ -189,8 +188,6 @@ export default {
 			nextcloudFormId: ADMIN_SETTINGS_FORM.nextcloudOauth.id,
 			openprojectFormOrder: ADMIN_SETTINGS_FORM.openprojectOauth.order.toString(),
 			nextcloudFormOrder: ADMIN_SETTINGS_FORM.nextcloudOauth.order.toString(),
-			messages,
-			messagesFmt,
 			loading: false,
 			openprojectTokenRevokeStatus: null,
 			// state that holds the current changed form values
@@ -273,7 +270,6 @@ export default {
 
 		if (this.isNextcloudFormComplete) {
 			this.setNextcloudFromToViewMode()
-			this.$emit('formcomplete', this.markNextcloudFormComplete)
 		}
 	},
 	methods: {

--- a/src/components/admin/FormOAuthSettings.vue
+++ b/src/components/admin/FormOAuthSettings.vue
@@ -12,7 +12,7 @@
 				:is-complete="isOpenProjectFormComplete"
 				:is-disabled="!showOpenProjectForm"
 				:is-dark-theme="isDarkTheme" />
-			<div v-if="showOpenProjectForm">
+			<div v-if="showOpenProjectForm" class="oauth-settings--openproject">
 				<FieldValue
 					v-if="isOpenProjectFormInViewMode"
 					is-required
@@ -73,14 +73,14 @@
 				:is-complete="isNextcloudFormComplete"
 				:is-disabled="!showNextcloudForm"
 				:is-dark-theme="isDarkTheme" />
-			<div v-if="showNextcloudForm">
+			<div v-if="showNextcloudForm" class="oauth-settings--nextcloud">
 				<FieldValue
 					v-if="isNextcloudFormInViewMode"
 					title="Nextcloud OAuth client ID"
 					:value="savedNextcloudForm.clientId"
 					is-required />
 				<TextInput
-					v-else
+					v-else-if="isNextcloudFormComplete"
 					id="nextcloud-oauth-client-id"
 					v-model="savedNextcloudForm.clientId"
 					class="py-1"
@@ -96,7 +96,7 @@
 					encrypt-value
 					value="***" />
 				<TextInput
-					v-else
+					v-else-if="isNextcloudFormComplete"
 					id="nextcloud-oauth-client-secret"
 					v-model="savedNextcloudForm.clientSecret"
 					class="py-1"
@@ -110,7 +110,9 @@
 						v-if="
 							!isNextcloudFormComplete
 								&& isOpenProjectFormComplete
-								&& isOpenProjectFormInViewMode">
+								&& isOpenProjectFormInViewMode"
+						data-test-id="create-nc-oauth-btn"
+						@click="createNextcloudClient">
 						<template #icon>
 							<AutoRenewIcon :size="20" />
 						</template>
@@ -129,7 +131,7 @@
 						v-else
 						type="primary"
 						:disabled="disableNextcloudFormSave"
-						data-test-id="submit-nc-oauth-values-form-btn"
+						data-test-id="submit-nc-oauth-btn"
 						@click="setNextcloudFromToViewMode">
 						<template #icon>
 							<CheckBoldIcon fill-color="#FFFFFF" :size="20" />
@@ -150,7 +152,7 @@ import CheckBoldIcon from 'vue-material-design-icons/CheckBold.vue'
 import FieldValue from './FieldValue.vue'
 import FormHeading from './FormHeading.vue'
 import TextInput from './TextInput.vue'
-import { F_MODES, ADMIN_SETTINGS_FORM } from '../../utils.js'
+import { F_MODES, ADMIN_SETTINGS_FORM, AUTH_METHOD } from '../../utils.js'
 import { saveAdminConfig, createNextcloudOAuthClient } from '../../api/settings.js'
 import { messages, messagesFmt } from '../../constants/messages.js'
 
@@ -219,6 +221,7 @@ export default {
 		},
 		showOpenProjectForm() {
 			return this.formState.authenticationMethod.complete
+				&& this.formState.authenticationMethod.value === AUTH_METHOD.OAUTH2
 		},
 		disableOpenProjectFormSave() {
 			return !this.currentOpenProjectForm.clientId || !this.currentOpenProjectForm.clientSecret

--- a/tests/jest/components/AdminSettings.spec.js
+++ b/tests/jest/components/AdminSettings.spec.js
@@ -152,657 +152,18 @@ describe('AdminSettings.vue', () => {
 	afterEach(() => {
 		jest.restoreAllMocks()
 	})
-	const confirmSpy = jest.spyOn(global.OC.dialogs, 'confirmDestructive')
 
-	describe('form mode and completed status without project folder setup for OAUTH2 authorization config', () => {
-		it.each([
-			[
-				'with empty state',
-				{
-					openproject_instance_url: null,
-					authorization_method: null,
-					openproject_client_id: null,
-					openproject_client_secret: null,
-					nc_oauth_client: null,
-				},
-				{
-					opOauth: F_MODES.DISABLE,
-					ncOauth: F_MODES.DISABLE,
-					projectFolderSetUp: F_MODES.DISABLE,
-					opUserAppPassword: F_MODES.DISABLE,
-				},
-				{
-					authorizationMethod: false,
-					opOauth: false,
-					ncOauth: false,
-					projectFolderSetUp: false,
-					opUserAppPassword: false,
-				},
-			],
-			[
-				'with incomplete OpenProject Authorization Method',
-				{
-					openproject_instance_url: 'https://openproject.example.com',
-					authorization_method: null,
-					openproject_client_id: null,
-					openproject_client_secret: null,
-					nc_oauth_client: null,
-				},
-				{
-					authorizationMethod: F_MODES.EDIT,
-					opOauth: F_MODES.DISABLE,
-					ncOauth: F_MODES.DISABLE,
-					projectFolderSetUp: F_MODES.DISABLE,
-					opUserAppPassword: F_MODES.DISABLE,
-				},
-				{
-					authorizationMethod: false,
-					opOauth: false,
-					ncOauth: false,
-					projectFolderSetUp: false,
-					opUserAppPassword: false,
-				},
-			],
-			[
-				'with incomplete OpenProject OAuth values',
-				{
-					openproject_instance_url: 'https://openproject.example.com',
-					authorization_method: AUTH_METHOD.OAUTH2,
-					openproject_client_id: null,
-					openproject_client_secret: null,
-					nc_oauth_client: null,
-				},
-				{
-					authorizationMethod: F_MODES.VIEW,
-					opOauth: F_MODES.EDIT,
-					ncOauth: F_MODES.DISABLE,
-					projectFolderSetUp: F_MODES.DISABLE,
-					opUserAppPassword: F_MODES.DISABLE,
-				},
-				{
-					authorizationMethod: true,
-					opOauth: false,
-					ncOauth: false,
-					projectFolderSetUp: false,
-					opUserAppPassword: false,
-				},
-			],
-			[
-				'with complete OpenProject OAuth values',
-				{
-					openproject_instance_url: 'https://openproject.example.com',
-					authorization_method: AUTH_METHOD.OAUTH2,
-					openproject_client_id: 'abcd',
-					openproject_client_secret: 'abcdefgh',
-					nc_oauth_client: null,
-					fresh_project_folder_setup: true,
-				},
-				{
-					authorizationMethod: F_MODES.VIEW,
-					opOauth: F_MODES.VIEW,
-					ncOauth: F_MODES.DISABLE,
-					projectFolderSetUp: F_MODES.DISABLE,
-					opUserAppPassword: F_MODES.DISABLE,
-				},
-				{
-					authorizationMethod: true,
-					opOauth: true,
-					ncOauth: false,
-					projectFolderSetUp: false,
-					opUserAppPassword: false,
-				},
-			],
-			[
-				'with everything but empty OpenProject OAuth values',
-				{
-					openproject_instance_url: 'https://openproject.example.com',
-					authorization_method: AUTH_METHOD.OAUTH2,
-					openproject_client_id: null,
-					openproject_client_secret: null,
-					nc_oauth_client: {
-						nextcloud_client_id: 'some-client-id-here',
-						nextcloud_client_secret: 'some-client-secret-here',
-					},
-				},
-				{
-					authorizationMethod: F_MODES.VIEW,
-					opOauth: F_MODES.EDIT,
-					ncOauth: F_MODES.VIEW,
-					projectFolderSetUp: F_MODES.VIEW,
-					opUserAppPassword: F_MODES.DISABLE,
-				},
-				{
-					authorizationMethod: true,
-					opOauth: false,
-					ncOauth: true,
-					projectFolderSetUp: true,
-					opUserAppPassword: false,
-				},
-			],
-			[
-				'with a complete admin settings',
-				{
-					openproject_instance_url: 'https://openproject.example.com',
-					authorization_method: AUTH_METHOD.OAUTH2,
-					openproject_client_id: 'client-id-here',
-					openproject_client_secret: 'client-id-here',
-					nc_oauth_client: {
-						nextcloud_client_id: 'nc-client-id-here',
-						nextcloud_client_secret: 'nc-client-secret-here',
-					},
-				},
-				{
-					authorizationMethod: F_MODES.VIEW,
-					opOauth: F_MODES.VIEW,
-					ncOauth: F_MODES.VIEW,
-					projectFolderSetUp: F_MODES.VIEW,
-					opUserAppPassword: F_MODES.DISABLE,
-				},
-				{
-					authorizationMethod: true,
-					opOauth: true,
-					ncOauth: true,
-					projectFolderSetUp: true,
-					opUserAppPassword: false,
-				},
-			],
-		])('when the form is loaded %s', (name, state, expectedFormMode, expectedFormState) => {
-			const wrapper = getWrapper({ state })
-			expect(wrapper.vm.formMode.opOauth).toBe(expectedFormMode.opOauth)
-			expect(wrapper.vm.formMode.ncOauth).toBe(expectedFormMode.ncOauth)
-			expect(wrapper.vm.formMode.projectFolderSetUp).toBe(expectedFormMode.projectFolderSetUp)
-			expect(wrapper.vm.formMode.opUserAppPassword).toBe(expectedFormMode.opUserAppPassword)
-
-			expect(wrapper.vm.isFormCompleted.opOauth).toBe(expectedFormState.opOauth)
-			expect(wrapper.vm.isFormCompleted.ncOauth).toBe(expectedFormState.ncOauth)
-			expect(wrapper.vm.isFormCompleted.projectFolderSetUp).toBe(expectedFormState.projectFolderSetUp)
-			expect(wrapper.vm.isFormCompleted.opUserAppPassword).toBe(expectedFormState.opUserAppPassword)
-		})
-	})
-
-	describe('OpenProject OAuth values form', () => {
-		describe('view mode and completed state', () => {
-			let wrapper, opOAuthForm, resetButton
-			const saveOPOptionsSpy = jest.spyOn(axios, 'put')
-				.mockImplementationOnce(() => Promise.resolve({ data: { status: true, oPOAuthTokenRevokeStatus: '' } }))
-			beforeEach(() => {
-				wrapper = getMountedWrapper({
-					state: {
-						openproject_instance_url: 'http://openproject.com',
-						authorization_method: AUTH_METHOD.OAUTH2,
-						openproject_client_id: 'openproject-client-id',
-						openproject_client_secret: 'openproject-client-secret',
-						nc_oauth_client: null,
-					},
-					form: {
-						serverHost: {
-							complete: true,
-							value: 'http://openproject.com',
-						},
-						authenticationMethod: { complete: true, value: AUTH_METHOD.OAUTH2 },
-					},
-				})
-				opOAuthForm = wrapper.find(selectors.opOauthForm)
-				resetButton = opOAuthForm.find(selectors.resetOPOAuthFormButton)
-			})
-			it('should show field values and hide the form if server host form is complete', () => {
-				expect(opOAuthForm).toMatchSnapshot()
-			})
-			describe('reset button', () => {
-				it('should trigger confirm dialog on click', async () => {
-					await resetButton.trigger('click')
-					expect(confirmSpy).toBeCalledTimes(1)
-
-					const expectedDialogMessage = 'If you proceed you will need to update these settings with the new'
-						+ ' OpenProject OAuth credentials. Also, all users will need to reauthorize'
-						+ ' access to their OpenProject account.'
-					const expectedDialogTitle = 'Replace OpenProject OAuth values'
-					const expectedDialogOpts = {
-						cancel: 'Cancel',
-						confirm: 'Yes, replace',
-						confirmClasses: 'error',
-						type: 70,
-					}
-					expect(confirmSpy).toHaveBeenCalledWith(
-						expectedDialogMessage,
-						expectedDialogTitle,
-						expectedDialogOpts,
-						expect.any(Function),
-						true,
-					)
-					jest.clearAllMocks()
-					wrapper.destroy()
-				})
-				it('should clear values on confirm', async () => {
-					jest.clearAllMocks()
-					await wrapper.vm.clearOPOAuthClientValues()
-
-					expect(saveOPOptionsSpy).toBeCalledTimes(1)
-					expect(wrapper.vm.state.openproject_client_id).toBe(null)
-				})
-			})
-		})
-		describe('edit mode', () => {
-			let wrapper
-			beforeEach(() => {
-				jest.spyOn(axios, 'put')
-					.mockImplementationOnce(() => Promise.resolve({ data: { status: true } }))
-				jest.spyOn(axios, 'post')
-					.mockImplementationOnce(() => Promise.resolve({
-						data: {
-							clientId: 'nc-client-id101',
-							clientSecret: 'nc-client-secret101',
-						},
-					}))
-				wrapper = getWrapper({
-					state: {
-						openproject_instance_url: 'http://openproject.com',
-						authorization_method: AUTH_METHOD.OAUTH2,
-						openproject_client_id: '',
-						openproject_client_secret: '',
-						nc_oauth_client: null,
-					},
-					form: {
-						serverHost: {
-							complete: true,
-							value: 'http://openproject.com',
-						},
-						authenticationMethod: { complete: true, value: AUTH_METHOD.OAUTH2 },
-					},
-				})
-			})
-			afterEach(() => {
-				axios.post.mockReset()
-				axios.put.mockReset()
-				jest.clearAllMocks()
-				wrapper.destroy()
-			})
-			it('should show the form and hide the field values', () => {
-				expect(wrapper.find(selectors.opOauthForm)).toMatchSnapshot()
-			})
-			describe('submit button', () => {
-				it('should be enabled with complete client values', async () => {
-					let submitButton
-					submitButton = wrapper.find(selectors.submitOPOAuthFormButton)
-					expect(submitButton.attributes().disabled).toBe('true')
-					await wrapper.find(selectors.opOauthClientIdInput).vm.$emit('input', 'qwerty')
-					await wrapper.find(selectors.opOauthClientSecretInput).vm.$emit('input', 'qwerty')
-
-					submitButton = wrapper.find(selectors.submitOPOAuthFormButton)
-					expect(submitButton.attributes().disabled).toBe(undefined)
-				})
-				describe('when clicked', () => {
-					describe('when the save is successful', () => {
-						beforeEach(async () => {
-							jest.spyOn(wrapper.vm, 'saveOPOptions').mockReturnValue(true)
-							wrapper.find(selectors.opOauthClientIdInput).vm.$emit('input', 'qwerty')
-							wrapper.find(selectors.opOauthClientSecretInput).vm.$emit('input', 'qwerty')
-							wrapper.find(selectors.submitOPOAuthFormButton).vm.$emit('click')
-						})
-						it('should set the form to view mode', async () => {
-							expect(wrapper.vm.formMode.opOauth).toBe(F_MODES.VIEW)
-						})
-						it('should set the isFormCompleted to true', async () => {
-							expect(wrapper.vm.isFormCompleted.opOauth).toBe(true)
-						})
-
-						it('should not create Nextcloud OAuth client if already present', async () => {
-							jest.spyOn(axios, 'put')
-								.mockImplementationOnce(() => Promise.resolve({ data: { status: true } }))
-							const createNCOAuthClientSpy = jest.spyOn(AdminSettings.methods, 'createNCOAuthClient')
-								.mockImplementationOnce(() => jest.fn())
-							const wrapper = getMountedWrapper({
-								state: {
-									openproject_instance_url: 'http://openproject.com',
-									authorization_method: AUTH_METHOD.OAUTH2,
-									openproject_client_id: '',
-									openproject_client_secret: '',
-									nc_oauth_client: {
-										nextcloud_client_id: 'abcdefg',
-										nextcloud_client_secret: 'slkjdlkjlkd',
-									},
-								},
-								form: {
-									serverHost: {
-										complete: true,
-										value: 'http://openproject.com',
-									},
-									authenticationMethod: { complete: true, value: AUTH_METHOD.OAUTH2 },
-								},
-							})
-							await wrapper.find(`${selectors.opOauthClientIdInput} input`).setValue('qwerty')
-							await wrapper.find(`${selectors.opOauthClientSecretInput} input`).setValue('qwerty')
-							await wrapper.find(selectors.submitOPOAuthFormButton).trigger('click')
-							expect(createNCOAuthClientSpy).not.toHaveBeenCalled()
-						})
-
-						it('should create Nextcloud OAuth client if not already present', async () => {
-							jest.spyOn(axios, 'post')
-								.mockImplementationOnce(() => Promise.resolve({ data: { status: false } }))
-							const createNCOAuthClientSpy = jest.spyOn(AdminSettings.methods, 'createNCOAuthClient')
-								.mockImplementationOnce(() => jest.fn())
-							const wrapper = getMountedWrapper({
-								state: {
-									openproject_instance_url: 'http://openproject.com',
-									authorization_method: AUTH_METHOD.OAUTH2,
-									openproject_client_id: '',
-									openproject_client_secret: '',
-									nc_oauth_client: '',
-								},
-								form: {
-									serverHost: {
-										complete: true,
-										value: 'http://openproject.com',
-									},
-									authenticationMethod: { complete: true, value: AUTH_METHOD.OAUTH2 },
-								},
-							})
-							await wrapper.find(`${selectors.opOauthClientIdInput} input`).setValue('qwerty')
-							await wrapper.find(`${selectors.opOauthClientSecretInput} input`).setValue('qwerty')
-							await wrapper.find(selectors.submitOPOAuthFormButton).trigger('click')
-
-							expect(createNCOAuthClientSpy).toBeCalledTimes(1)
-						})
-					})
-
-					describe('when the save fails', () => {
-						beforeEach(async () => {
-							jest.spyOn(wrapper.vm, 'saveOPOptions').mockReturnValue(false)
-							wrapper.find(selectors.opOauthClientIdInput).vm.$emit('input', 'qwerty')
-							wrapper.find(selectors.opOauthClientSecretInput).vm.$emit('input', 'qwerty')
-							wrapper.find(selectors.submitOPOAuthFormButton).vm.$emit('click')
-						})
-						it('should set the form to view mode', async () => {
-							expect(wrapper.vm.formMode.opOauth).toBe(F_MODES.EDIT)
-						})
-						it('should set the isFormCompleted to true', async () => {
-							expect(wrapper.vm.isFormCompleted.opOauth).toBe(false)
-						})
-
-						it('should not create Nextcloud OAuth client', async () => {
-							jest.spyOn(axios, 'put')
-								.mockImplementationOnce(() => Promise.resolve({ data: { status: true } }))
-							const createNCOAuthClientSpy = jest.spyOn(AdminSettings.methods, 'createNCOAuthClient')
-								.mockImplementationOnce(() => jest.fn())
-							const wrapper = getMountedWrapper({
-								state: {
-									openproject_instance_url: 'http://openproject.com',
-									authorization_method: AUTH_METHOD.OAUTH2,
-									openproject_client_id: '',
-									openproject_client_secret: '',
-									nc_oauth_client: {
-										nextcloud_client_id: 'abcdefg',
-										nextcloud_client_secret: 'slkjdlkjlkd',
-									},
-								},
-								form: {
-									serverHost: {
-										complete: true,
-										value: 'http://openproject.com',
-									},
-									authenticationMethod: { complete: true, value: AUTH_METHOD.OAUTH2 },
-								},
-							})
-							await wrapper.find(`${selectors.opOauthClientIdInput} input`).setValue('qwerty')
-							await wrapper.find(`${selectors.opOauthClientSecretInput} input`).setValue('qwerty')
-							await wrapper.find(selectors.submitOPOAuthFormButton).trigger('click')
-							expect(createNCOAuthClientSpy).not.toHaveBeenCalled()
-						})
-					})
-
-					describe('when the admin config is ok on save options', () => {
-						beforeEach(async () => {
-							await wrapper.find(selectors.opOauthClientIdInput).vm.$emit('input', 'qwerty')
-							await wrapper.find(selectors.opOauthClientSecretInput).vm.$emit('input', 'qwerty')
-							await wrapper.find(selectors.submitOPOAuthFormButton).vm.$emit('click')
-							await flushPromises()
-						})
-						it('should set the form to view mode', () => {
-							expect(wrapper.vm.formMode.opOauth).toBe(F_MODES.VIEW)
-						})
-						it('should set the adminConfigStatus as "true"', () => {
-							expect(wrapper.vm.isAdminConfigOk).toBe(true)
-						})
-						it('should create Nextcloud OAuth client if not already present', () => {
-							expect(wrapper.vm.state.nc_oauth_client).toMatchObject({
-								clientId: 'nc-client-id101',
-								clientSecret: 'nc-client-secret101',
-							})
-						})
-						it('should not create Nextcloud OAuth client if already present', async () => {
-							jest.spyOn(axios, 'put')
-								.mockImplementationOnce(() => Promise.resolve({ data: { status: true } }))
-							const createNCOAuthClientSpy = jest.spyOn(AdminSettings.methods, 'createNCOAuthClient')
-								.mockImplementationOnce(() => jest.fn())
-							const wrapper = getWrapper({
-								state: {
-									openproject_instance_url: 'http://openproject.com',
-									authorization_method: AUTH_METHOD.OAUTH2,
-									openproject_client_id: '',
-									openproject_client_secret: '',
-									nc_oauth_client: {
-										nextcloud_client_id: 'abcdefg',
-										nextcloud_client_secret: 'slkjdlkjlkd',
-									},
-								},
-								form: {
-									serverHost: {
-										complete: true,
-										value: 'http://openproject.com',
-									},
-									authenticationMethod: { complete: true, value: AUTH_METHOD.OAUTH2 },
-								},
-							})
-							wrapper.find(selectors.opOauthClientIdInput).vm.$emit('input', 'qwerty')
-							wrapper.find(selectors.opOauthClientSecretInput).vm.$emit('input', 'qwerty')
-							wrapper.find(selectors.submitOPOAuthFormButton).vm.$emit('click')
-							await flushPromises()
-							expect(createNCOAuthClientSpy).not.toHaveBeenCalled()
-						})
-
-						it('should not create new user app password if already present', async () => {
-							const saveOPOptionsSpy = jest.spyOn(axios, 'put')
-								.mockImplementationOnce(() => Promise.resolve({ data: { oPUserAppPassword: null } }))
-							const wrapper = getMountedWrapper({
-								state: {
-									openproject_instance_url: 'http://openproject.com',
-									authorization_method: AUTH_METHOD.OAUTH2,
-									openproject_client_id: '',
-									openproject_client_secret: '',
-									nc_oauth_client: {
-										nextcloud_client_id: 'abcdefg',
-										nextcloud_client_secret: 'slkjdlkjlkd',
-									},
-									fresh_project_folder_setup: false,
-									project_folder_info: {
-										status: true,
-									},
-									app_password_set: false,
-								},
-								oPUserAppPassword: 'opUserPassword',
-							})
-							expect(saveOPOptionsSpy).toBeCalledWith(
-								'http://localhost/apps/integration_openproject/admin-config',
-								{
-									values: {
-										openproject_client_id: 'qwerty',
-										openproject_client_secret: 'qwerty',
-									},
-								},
-							)
-							expect(wrapper.vm.oPUserAppPassword).toBe('opUserPassword')
-						})
-					})
-				})
-			})
-		})
-	})
-
-	describe('Nextcloud OAuth values form', () => {
-		describe('view mode with complete values', () => {
-			it('should show the field values and hide the form', () => {
-				const wrapper = getWrapper({
-					state: {
-						openproject_instance_url: 'http://openproject.com',
-						authorization_method: AUTH_METHOD.OAUTH2,
-						openproject_client_id: 'some-client-id-here',
-						openproject_client_secret: 'some-client-secret-here',
-						nc_oauth_client: {
-							nextcloud_client_id: 'some-nc-client-id-here',
-							nextcloud_client_secret: 'some-nc-client-secret-here',
-						},
-					},
-				})
-				expect(wrapper.find(selectors.ncOauthForm)).toMatchSnapshot()
-			})
-			describe('reset button', () => {
-				afterEach(() => {
-					jest.clearAllMocks()
-				})
-				it('should trigger the confirm dialog', async () => {
-					const wrapper = getWrapper({
-						state: {
-							openproject_instance_url: 'http://openproject.com',
-							authorization_method: AUTH_METHOD.OAUTH2,
-							openproject_client_id: 'op-client-id',
-							openproject_client_secret: 'op-client-secret',
-							nc_oauth_client: {
-								nextcloud_client_id: 'nc-clientid',
-								nextcloud_client_secret: 'nc-clientsecret',
-							},
-						},
-					})
-
-					const expectedConfirmText = 'If you proceed you will need to update the settings in your OpenProject '
-						+ 'with the new Nextcloud OAuth credentials. Also, all users in OpenProject '
-						+ 'will need to reauthorize access to their Nextcloud account.'
-					const expectedConfirmOpts = {
-						cancel: 'Cancel',
-						confirm: 'Yes, replace',
-						confirmClasses: 'error',
-						type: 70,
-					}
-					const expectedConfirmTitle = 'Replace Nextcloud OAuth values'
-
-					const resetButton = wrapper.find(selectors.resetNcOAuthFormButton)
-					resetButton.vm.$emit('click')
-					await flushPromises()
-
-					expect(confirmSpy).toBeCalledTimes(1)
-					expect(confirmSpy).toBeCalledWith(
-						expectedConfirmText,
-						expectedConfirmTitle,
-						expectedConfirmOpts,
-						expect.any(Function),
-						true,
-					)
-					wrapper.destroy()
-				})
-				it('should create new client on confirm', async () => {
-					jest.spyOn(axios, 'post')
-						.mockImplementationOnce(() => Promise.resolve({
-							data: {
-								clientId: 'new-client-id77',
-								clientSecret: 'new-client-secret77',
-							},
-						}))
-					const wrapper = getMountedWrapper({
-						state: {
-							openproject_instance_url: 'http://openproject.com',
-							authorization_method: AUTH_METHOD.OAUTH2,
-							openproject_client_id: 'op-client-id',
-							openproject_client_secret: 'op-client-secret',
-							nc_oauth_client: {
-								nextcloud_client_id: 'nc-client-id',
-								nextcloud_client_secret: 'nc-client-secret',
-							},
-						},
-					})
-					await wrapper.vm.createNCOAuthClient()
-					expect(wrapper.vm.state.nc_oauth_client).toMatchObject({
-						clientId: 'new-client-id77',
-						clientSecret: 'new-client-secret77',
-					})
-					expect(wrapper.vm.formMode.ncOauth).toBe(F_MODES.EDIT)
-					expect(wrapper.vm.isFormCompleted.ncOauth).toBe(false)
-					wrapper.destroy()
-				})
-			})
-		})
-		describe('recreate button', () => {
-			it('should be displayed if nextcloud oauth credentials is empty and everything is set', async () => {
-				const wrapper = getMountedWrapper({
-					state: {
-						openproject_instance_url: 'http://openproject.com',
-						authorization_method: AUTH_METHOD.OAUTH2,
-						openproject_client_id: 'op-client-id',
-						openproject_client_secret: 'op-client-secret',
-						nc_oauth_client: null,
-					},
-					formMode: {
-						projectFolderSetUp: F_MODES.VIEW,
-					},
-					showDefaultManagedProjectFolders: true,
-					isFormCompleted: {
-						projectFolderSetUp: true,
-					},
-
-				})
-				const resetButton = wrapper.find(selectors.resetNcOAuthFormButton)
-				expect(resetButton.isVisible()).toBe(true)
-				expect(resetButton.text()).toBe('Create Nextcloud OAuth values')
-				wrapper.destroy()
-			})
-		})
-		describe('edit mode', () => {
-			it('should show the form and hide the field values', async () => {
-				const wrapper = getWrapper({
-					state: {
-						openproject_instance_url: 'http://openproject.com',
-						authorization_method: AUTH_METHOD.OAUTH2,
-						openproject_client_id: 'op-client-id',
-						openproject_client_secret: 'op-client-secret',
-						nc_oauth_client: {
-							nextcloud_client_id: 'nc-client-id',
-							nextcloud_client_secret: 'nc-client-secret',
-						},
-					},
-				})
-				await wrapper.setData({
-					formMode: {
-						ncOauth: F_MODES.EDIT,
-					},
-				})
-				expect(wrapper.find(selectors.ncOauthForm)).toMatchSnapshot()
-			})
-			describe('done button', () => {
-				it('should set the form to view mode if the oauth values are complete', async () => {
-					const wrapper = getMountedWrapper({
-						state: {
-							openproject_instance_url: 'http://openproject.com',
-							authorization_method: AUTH_METHOD.OAUTH2,
-							openproject_client_id: 'some-client-id-for-op',
-							openproject_client_secret: 'some-client-secret-for-op',
-							nc_oauth_client: {
-								nextcloud_client_id: 'something',
-								nextcloud_client_secret: 'something-else',
-							},
-						},
-					})
-					await wrapper.setData({
-						formMode: {
-							ncOauth: F_MODES.EDIT,
-						},
-					})
-					await wrapper.find(selectors.ncOauthForm)
-						.find(selectors.submitNcOAuthFormButton)
-						.trigger('click')
-					expect(wrapper.vm.formMode.ncOauth).toBe(F_MODES.VIEW)
-					expect(wrapper.vm.isFormCompleted.ncOauth).toBe(true)
-				})
-			})
-		})
-	})
+	const commonState = {
+		form: {
+			serverHost: { complete: true },
+			authenticationMethod: {
+				value: AUTH_METHOD.OAUTH2,
+				complete: true,
+			},
+			openprojectOauth: { complete: true },
+			nextcloudOauth: { complete: true },
+		},
+	}
 
 	describe('Project folders form (Project Folder Setup)', () => {
 		describe('Disable mode', () => {
@@ -862,14 +223,15 @@ describe('AdminSettings.vue', () => {
 								nextcloud_client_id: 'some-nc-client-id-here',
 								nextcloud_client_secret: 'some-nc-client-secret-here',
 							},
-							fresh_project_folder_setup: true,
-							// project folder is already not set up
+							fresh_project_folder_setup: false,
+							// project folder is already set up
 							project_folder_info: {
-								status: false,
+								status: true,
 							},
 							app_password_set: false,
 							...appState,
 						},
+						...commonState,
 					})
 					const projectFolderStatus = wrapper.find(selectors.projectFolderStatus)
 					const actualProjectFolderStatusValue = projectFolderStatus.text()
@@ -904,6 +266,7 @@ describe('AdminSettings.vue', () => {
 						formMode: {
 							projectFolderSetUp: F_MODES.VIEW,
 						},
+						...commonState,
 					})
 					const formHeading = wrapper.find(selectors.projectFolderFormHeading)
 					const errorNote = wrapper.find(selectors.projectFolderErrorNote)
@@ -979,15 +342,15 @@ describe('AdminSettings.vue', () => {
 								nextcloud_client_secret: 'some-nc-client-secret-here',
 							},
 							fresh_project_folder_setup: true,
-							// project folder is already not set up
+							// project folder is not set up
 							project_folder_info: {
 								status: false,
 							},
 							app_password_set: false,
 							...appState,
 						},
+						...commonState,
 					})
-					await wrapper.vm.setNCOAuthFormToViewMode()
 					expect(wrapper.vm.isProjectFolderSwitchEnabled).toBe(true)
 					const completeProjectFolderSetupWithGroupFolderButton = wrapper.find(selectors.completeProjectFolderSetupWithGroupFolderButton)
 					expect(completeProjectFolderSetupWithGroupFolderButton.text()).toBe('Setup OpenProject user, group and folder')
@@ -1012,8 +375,8 @@ describe('AdminSettings.vue', () => {
 							app_password_set: false,
 							...appState,
 						},
+						...commonState,
 					})
-					await wrapper.vm.setNCOAuthFormToViewMode()
 					expect(wrapper.vm.isProjectFolderSwitchEnabled).toBe(true)
 					const projectFolderSetupSwitchButton = wrapper.find(selectors.projectFolderSetupButtonStub)
 					projectFolderSetupSwitchButton.vm.$emit('update:checked', false)
@@ -1054,6 +417,7 @@ describe('AdminSettings.vue', () => {
 								},
 								app_password_set: false,
 							},
+							...commonState,
 						})
 						await wrapper.setData({
 							formMode: {
@@ -1147,6 +511,7 @@ describe('AdminSettings.vue', () => {
 									projectFolderSetupError: null,
 									...appState,
 								},
+								...commonState,
 							})
 
 							await wrapper.setData({
@@ -1213,6 +578,7 @@ describe('AdminSettings.vue', () => {
 									},
 								},
 								isGroupFolderAlreadySetup: null,
+								...commonState,
 							})
 							await wrapper.setData({
 								formMode: {
@@ -1963,10 +1329,7 @@ describe('AdminSettings.vue', () => {
 						nextcloud_client_secret: 'something-else',
 					},
 				},
-				form: {
-					serverHost: { complete: true },
-					authenticationMethod: { complete: true },
-				},
+				...commonState,
 			})
 
 			const $defaultEnableNavigation = wrapper.find(selectors.defaultEnableNavigation)
@@ -2008,10 +1371,7 @@ describe('AdminSettings.vue', () => {
 						nextcloud_client_secret: 'something-else',
 					},
 				},
-				form: {
-					serverHost: { complete: true },
-					authenticationMethod: { complete: true },
-				},
+				...commonState,
 			})
 			const $defaultEnableNavigation = wrapper.find(selectors.defaultEnableNavigation)
 			await $defaultEnableNavigation.trigger('click')
@@ -2019,60 +1379,6 @@ describe('AdminSettings.vue', () => {
 
 			expect(dialogs.showError).toBeCalledTimes(1)
 			expect(dialogs.showError).toBeCalledWith('Failed to save default user configuration: Some message')
-
-		})
-	})
-
-	describe('revoke OpenProject OAuth token', () => {
-		beforeEach(() => {
-			axios.put.mockReset()
-			dialogs.showSuccess.mockReset()
-			dialogs.showError.mockReset()
-		})
-		it('should show success when revoke status is success', async () => {
-			dialogs.showSuccess
-				.mockImplementationOnce()
-				.mockImplementationOnce()
-			const saveOPOptionsSpy = jest.spyOn(axios, 'put')
-				.mockImplementationOnce(
-					() => Promise.resolve({ data: { status: true, oPOAuthTokenRevokeStatus: 'success' } }),
-				)
-			const wrapper = getMountedWrapper({
-				state: completeOAUTH2IntegrationState,
-			})
-			await wrapper.vm.saveOPOptions()
-
-			await localVue.nextTick()
-
-			expect(saveOPOptionsSpy).toBeCalledTimes(1)
-			expect(dialogs.showSuccess).toBeCalledTimes(2)
-			expect(dialogs.showSuccess).toBeCalledWith('OpenProject admin options saved')
-			expect(dialogs.showSuccess).toBeCalledWith('Successfully revoked users\' OpenProject OAuth access tokens')
-
-		})
-		it.each([
-			['connection_error', 'Failed to perform revoke request due to connection error with the OpenProject server'],
-			['other_error', 'Failed to revoke some users\' OpenProject OAuth access tokens'],
-		])('should show error message on various failure', async (errorCode, errorMessage) => {
-			dialogs.showSuccess
-				.mockImplementationOnce()
-				.mockImplementationOnce()
-			const saveOPOptionsSpy = jest.spyOn(axios, 'put')
-				.mockImplementationOnce(
-					() => Promise.resolve({ data: { status: true, oPOAuthTokenRevokeStatus: errorCode } }),
-				)
-			const wrapper = getMountedWrapper({
-				state: completeOAUTH2IntegrationState,
-			})
-			await wrapper.vm.saveOPOptions()
-
-			await localVue.nextTick()
-
-			expect(saveOPOptionsSpy).toBeCalledTimes(1)
-			expect(dialogs.showSuccess).toBeCalledTimes(1)
-			expect(dialogs.showError).toBeCalledTimes(1)
-			expect(dialogs.showSuccess).toBeCalledWith('OpenProject admin options saved')
-			expect(dialogs.showError).toBeCalledWith(errorMessage)
 
 		})
 	})

--- a/tests/jest/components/__snapshots__/AdminSettings.spec.js.snap
+++ b/tests/jest/components/__snapshots__/AdminSettings.spec.js.snap
@@ -1,29 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AdminSettings.vue Nextcloud OAuth values form edit mode should show the form and hide the field values 1`] = `
-Wrapper {
-  "selector": ".nextcloud-oauth-values",
-}
-`;
-
-exports[`AdminSettings.vue Nextcloud OAuth values form view mode with complete values should show the field values and hide the form 1`] = `
-Wrapper {
-  "selector": ".nextcloud-oauth-values",
-}
-`;
-
-exports[`AdminSettings.vue OpenProject OAuth values form edit mode should show the form and hide the field values 1`] = `
-Wrapper {
-  "selector": ".openproject-oauth-values",
-}
-`;
-
-exports[`AdminSettings.vue OpenProject OAuth values form view mode and completed state should show field values and hide the form if server host form is complete 1`] = `
-Wrapper {
-  "selector": ".openproject-oauth-values",
-}
-`;
-
 exports[`AdminSettings.vue Project folders form (Project Folder Setup) view mode without project folder setup should show status as "Inactive" 1`] = `
 Wrapper {
   "selector": ".project-folder-setup",

--- a/tests/jest/components/admin/FormOAuthSettings.spec.js
+++ b/tests/jest/components/admin/FormOAuthSettings.spec.js
@@ -1,0 +1,706 @@
+/* jshint esversion: 8 */
+
+/**
+ * SPDX-FileCopyrightText: 2026 Jankari Tech Pvt. Ltd.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { createLocalVue, shallowMount } from '@vue/test-utils'
+import flushPromises from 'flush-promises' // eslint-disable-line n/no-unpublished-import
+import { showError, showSuccess } from '@nextcloud/dialogs'
+
+import { ADMIN_SETTINGS_FORM, F_MODES, AUTH_METHOD } from '../../../../src/utils.js'
+import { saveAdminConfig, createNextcloudOAuthClient } from '../../../../src/api/settings.js'
+import FormOAuthSettings from '../../../../src/components/admin/FormOAuthSettings.vue'
+
+// global mocks
+global.t = (app, text) => text
+global.OC = {
+	dialogs: {
+		confirmDestructive: jest.fn(),
+		YES_NO_BUTTONS: 70,
+	},
+}
+// module mocks
+jest.mock('@nextcloud/dialogs', () => ({
+	showError: jest.fn(),
+	showSuccess: jest.fn(),
+}))
+jest.mock('../../../../src/api/settings.js', () => ({
+	saveAdminConfig: jest.fn(() => ''),
+	createNextcloudOAuthClient: jest.fn(() => ''),
+}))
+
+const localVue = createLocalVue()
+
+const selectors = {
+	opFormHeading: 'formheading-stub[title="OpenProject OAuth settings"]',
+	opFormContainer: '.oauth-settings--openproject',
+	opClientIdLabel: 'fieldvalue-stub[title="OpenProject OAuth client ID"]',
+	opClientIdInput: 'textinput-stub[label="OpenProject OAuth client ID"]',
+	opClientSecretLabel: 'fieldvalue-stub[title="OpenProject OAuth client secret"]',
+	opClientSecretInput: 'textinput-stub[label="OpenProject OAuth client secret"]',
+	opSaveButton: 'ncbutton-stub[data-test-id="submit-op-oauth-btn"]',
+	opResetButton: 'ncbutton-stub[data-test-id="reset-op-oauth-btn"]',
+	ncFormHeading: 'formheading-stub[title="Nextcloud OAuth client"]',
+	ncFormContainer: '.oauth-settings--nextcloud',
+	ncClientIdLabel: 'fieldvalue-stub[title="Nextcloud OAuth client ID"]',
+	ncClientIdInput: 'textinput-stub[label="Nextcloud OAuth client ID"]',
+	ncClientSecretLabel: 'fieldvalue-stub[title="Nextcloud OAuth client secret"]',
+	ncClientSecretInput: 'textinput-stub[label="Nextcloud OAuth client secret"]',
+	ncCreateButton: 'ncbutton-stub[data-test-id="create-nc-oauth-btn"]',
+	ncSaveButton: 'ncbutton-stub[data-test-id="submit-nc-oauth-btn"]',
+	ncResetButton: 'ncbutton-stub[data-test-id="reset-nc-oauth-btn"]',
+}
+
+const formState = structuredClone(ADMIN_SETTINGS_FORM)
+formState.serverHost.complete = true
+formState.authenticationMethod.value = AUTH_METHOD.OAUTH2
+formState.authenticationMethod.complete = true
+const defaultProps = {
+	formState,
+	oauthSettings: {
+		openproject_client_id: '',
+		openproject_client_secret: '',
+		nc_oauth_client: {
+			nextcloud_client_id: '',
+		},
+	},
+}
+
+describe('Component: FormOAuthSettings', () => {
+	afterEach(() => {
+		jest.clearAllMocks()
+		saveAdminConfig.mockRestore()
+		createNextcloudOAuthClient.mockRestore()
+	})
+
+	describe('form states', () => {
+		it('form state: incomplete authorization method', () => {
+			const props = {
+				formState: {
+					...defaultProps.formState,
+					authenticationMethod: {
+						complete: false,
+					},
+				},
+			}
+			const wrapper = getWrapper({ props })
+
+			const opFormHeading = wrapper.find(selectors.opFormHeading)
+			const ncFormHeading = wrapper.find(selectors.ncFormHeading)
+			const opFormContainer = wrapper.find(selectors.opFormContainer)
+			const ncFormContainer = wrapper.find(selectors.ncFormContainer)
+			expect(opFormHeading.exists()).toBe(true)
+			expect(opFormHeading.attributes().isdisabled).toBe('true')
+			expect(ncFormHeading.exists()).toBe(true)
+			expect(ncFormHeading.attributes().isdisabled).toBe('true')
+			expect(opFormContainer.exists()).toBe(false)
+			expect(ncFormContainer.exists()).toBe(false)
+			expect(wrapper.element).toMatchSnapshot()
+		})
+		it('form state: complete authorization method but incomplete oauth settings', () => {
+			const wrapper = getWrapper()
+
+			const opFormHeading = wrapper.find(selectors.opFormHeading)
+			const ncFormHeading = wrapper.find(selectors.ncFormHeading)
+			const opFormContainer = wrapper.find(selectors.opFormContainer)
+			const ncFormContainer = wrapper.find(selectors.ncFormContainer)
+			expect(opFormHeading.exists()).toBe(true)
+			expect(opFormHeading.attributes().isdisabled).toBe(undefined)
+			expect(ncFormHeading.exists()).toBe(true)
+			expect(ncFormHeading.attributes().isdisabled).toBe('true')
+			expect(opFormContainer.exists()).toBe(true)
+			expect(opFormContainer.find(selectors.opClientIdLabel).exists()).toBe(false)
+			expect(opFormContainer.find(selectors.opClientIdInput).exists()).toBe(true)
+			expect(opFormContainer.find(selectors.opClientSecretLabel).exists()).toBe(false)
+			expect(opFormContainer.find(selectors.opClientSecretInput).exists()).toBe(true)
+			expect(opFormContainer.find(selectors.opSaveButton).exists()).toBe(true)
+			expect(opFormContainer.find(selectors.opSaveButton).attributes().disabled).toBe('true')
+			expect(opFormContainer.find(selectors.opResetButton).exists()).toBe(false)
+			expect(ncFormContainer.exists()).toBe(false)
+			expect(wrapper.element).toMatchSnapshot()
+		})
+		it('form state: complete authorization method and complete OpenProject form but not Nextcloud', () => {
+			const wrapper = getWrapper({
+				props: {
+					formState: {
+						...defaultProps.formState,
+						openprojectOauth: {
+							complete: true,
+						},
+					},
+					oauthSettings: {
+						openproject_client_id: 'op-client',
+						openproject_client_secret: 'op-client-secret',
+						nc_oauth_client: {
+							nextcloud_client_id: '',
+						},
+					},
+				},
+			})
+
+			const opFormHeading = wrapper.find(selectors.opFormHeading)
+			const ncFormHeading = wrapper.find(selectors.ncFormHeading)
+			const opFormContainer = wrapper.find(selectors.opFormContainer)
+			const ncFormContainer = wrapper.find(selectors.ncFormContainer)
+			expect(opFormHeading.exists()).toBe(true)
+			expect(opFormHeading.attributes().isdisabled).toBe(undefined)
+			expect(ncFormHeading.exists()).toBe(true)
+			expect(ncFormHeading.attributes().isdisabled).toBe(undefined)
+			expect(opFormContainer.exists()).toBe(true)
+			expect(opFormContainer.find(selectors.opClientIdLabel).exists()).toBe(true)
+			expect(opFormContainer.find(selectors.opClientIdLabel).attributes().value).toBe('op-client')
+			expect(opFormContainer.find(selectors.opClientIdInput).exists()).toBe(false)
+			expect(opFormContainer.find(selectors.opClientSecretLabel).exists()).toBe(true)
+			expect(opFormContainer.find(selectors.opClientSecretLabel).attributes().value).toBe('op-client-secret')
+			expect(opFormContainer.find(selectors.opClientSecretInput).exists()).toBe(false)
+			expect(opFormContainer.find(selectors.opSaveButton).exists()).toBe(false)
+			expect(opFormContainer.find(selectors.opResetButton).exists()).toBe(true)
+			expect(ncFormContainer.exists()).toBe(true)
+			expect(ncFormContainer.find(selectors.ncClientIdLabel).exists()).toBe(false)
+			expect(ncFormContainer.find(selectors.ncClientIdInput).exists()).toBe(false)
+			expect(ncFormContainer.find(selectors.ncClientSecretLabel).exists()).toBe(false)
+			expect(ncFormContainer.find(selectors.ncClientSecretInput).exists()).toBe(false)
+			expect(ncFormContainer.find(selectors.ncCreateButton).exists()).toBe(true)
+			expect(ncFormContainer.find(selectors.ncSaveButton).exists()).toBe(false)
+			expect(ncFormContainer.find(selectors.ncResetButton).exists()).toBe(false)
+			expect(wrapper.element).toMatchSnapshot()
+		})
+		it('form state: complete authorization method and complete Nextcloud form but not OpenProject', () => {
+			const wrapper = getWrapper({
+				props: {
+					...defaultProps,
+					oauthSettings: {
+						openproject_client_id: '',
+						openproject_client_secret: '',
+						nc_oauth_client: {
+							nextcloud_client_id: 'nc-client-id',
+						},
+					},
+				},
+			})
+
+			const opFormHeading = wrapper.find(selectors.opFormHeading)
+			const ncFormHeading = wrapper.find(selectors.ncFormHeading)
+			const opFormContainer = wrapper.find(selectors.opFormContainer)
+			const ncFormContainer = wrapper.find(selectors.ncFormContainer)
+			expect(opFormHeading.exists()).toBe(true)
+			expect(opFormHeading.attributes().isdisabled).toBe(undefined)
+			expect(ncFormHeading.exists()).toBe(true)
+			expect(ncFormHeading.attributes().isdisabled).toBe(undefined)
+			expect(opFormContainer.exists()).toBe(true)
+			expect(opFormContainer.find(selectors.opClientIdLabel).exists()).toBe(false)
+			expect(opFormContainer.find(selectors.opClientIdInput).exists()).toBe(true)
+			expect(opFormContainer.find(selectors.opClientSecretLabel).exists()).toBe(false)
+			expect(opFormContainer.find(selectors.opClientSecretInput).exists()).toBe(true)
+			expect(opFormContainer.find(selectors.opSaveButton).exists()).toBe(true)
+			expect(opFormContainer.find(selectors.opSaveButton).attributes().disabled).toBe('true')
+			expect(opFormContainer.find(selectors.opResetButton).exists()).toBe(false)
+			expect(ncFormContainer.exists()).toBe(true)
+			expect(ncFormContainer.find(selectors.ncClientIdLabel).exists()).toBe(true)
+			expect(ncFormContainer.find(selectors.ncClientIdLabel).attributes().value).toBe('nc-client-id')
+			expect(ncFormContainer.find(selectors.ncClientIdInput).exists()).toBe(false)
+			expect(ncFormContainer.find(selectors.ncClientSecretLabel).exists()).toBe(true)
+			expect(ncFormContainer.find(selectors.ncClientSecretLabel).attributes().value).toBe('***')
+			expect(ncFormContainer.find(selectors.ncClientSecretInput).exists()).toBe(false)
+			expect(ncFormContainer.find(selectors.ncCreateButton).exists()).toBe(false)
+			expect(ncFormContainer.find(selectors.ncSaveButton).exists()).toBe(false)
+			expect(ncFormContainer.find(selectors.ncResetButton).exists()).toBe(true)
+			expect(wrapper.element).toMatchSnapshot()
+		})
+		it('form state: complete OpenProject and Nextcloud oauth values', async () => {
+			const wrapper = getWrapper({
+				props: {
+					...defaultProps,
+					oauthSettings: {
+						openproject_client_id: 'op-client',
+						openproject_client_secret: 'op-client-secret',
+						nc_oauth_client: {
+							nextcloud_client_id: 'nc-client-id',
+						},
+					},
+				},
+			})
+
+			const opFormHeading = wrapper.find(selectors.opFormHeading)
+			const ncFormHeading = wrapper.find(selectors.ncFormHeading)
+			const opFormContainer = wrapper.find(selectors.opFormContainer)
+			const ncFormContainer = wrapper.find(selectors.ncFormContainer)
+			expect(opFormHeading.exists()).toBe(true)
+			expect(opFormHeading.attributes().isdisabled).toBe(undefined)
+			expect(ncFormHeading.exists()).toBe(true)
+			expect(ncFormHeading.attributes().isdisabled).toBe(undefined)
+			expect(opFormContainer.exists()).toBe(true)
+			expect(opFormContainer.find(selectors.opClientIdLabel).exists()).toBe(true)
+			expect(opFormContainer.find(selectors.opClientIdLabel).attributes().value).toBe('op-client')
+			expect(opFormContainer.find(selectors.opClientIdInput).exists()).toBe(false)
+			expect(opFormContainer.find(selectors.opClientSecretLabel).exists()).toBe(true)
+			expect(opFormContainer.find(selectors.opClientSecretLabel).attributes().value).toBe('op-client-secret')
+			expect(opFormContainer.find(selectors.opClientSecretInput).exists()).toBe(false)
+			expect(opFormContainer.find(selectors.opSaveButton).exists()).toBe(false)
+			expect(opFormContainer.find(selectors.opResetButton).exists()).toBe(true)
+			expect(ncFormContainer.exists()).toBe(true)
+			expect(ncFormContainer.find(selectors.ncClientIdLabel).exists()).toBe(true)
+			expect(ncFormContainer.find(selectors.ncClientIdLabel).attributes().value).toBe('nc-client-id')
+			expect(ncFormContainer.find(selectors.ncClientIdInput).exists()).toBe(false)
+			expect(ncFormContainer.find(selectors.ncClientSecretLabel).exists()).toBe(true)
+			expect(ncFormContainer.find(selectors.ncClientSecretLabel).attributes().value).toBe('***')
+			expect(ncFormContainer.find(selectors.ncClientSecretInput).exists()).toBe(false)
+			expect(ncFormContainer.find(selectors.ncSaveButton).exists()).toBe(false)
+			expect(ncFormContainer.find(selectors.ncCreateButton).exists()).toBe(false)
+			expect(ncFormContainer.find(selectors.ncResetButton).exists()).toBe(true)
+			expect(wrapper.element).toMatchSnapshot()
+		})
+	})
+
+	describe('OpenProject OAuth form', () => {
+		describe('view mode: reset values', () => {
+			let wrapper
+			beforeEach(() => {
+				wrapper = getWrapper({
+					props: {
+						...defaultProps,
+						oauthSettings: {
+							openproject_client_id: 'op-client',
+							openproject_client_secret: 'op-client-secret',
+							nc_oauth_client: {
+								nextcloud_client_id: 'nc-client-id',
+							},
+						},
+					},
+				})
+			})
+
+			it('should trigger confirm dialog on click', async () => {
+				const spyConfirmDialog = jest.spyOn(global.OC.dialogs, 'confirmDestructive')
+				const resetButton = wrapper.find(selectors.opResetButton)
+				await resetButton.vm.$emit('click')
+				await flushPromises()
+
+				expect(spyConfirmDialog).toHaveBeenCalledTimes(1)
+			})
+			it('should clear OpenProject OAuth values on confirm', async () => {
+				await wrapper.vm.confirmResetOpenProjectClient()
+				await flushPromises()
+
+				expect(saveAdminConfig).toHaveBeenCalledTimes(1)
+				expect(saveAdminConfig).toHaveBeenCalledWith({
+					openproject_client_id: '',
+					openproject_client_secret: '',
+				})
+				expect(wrapper.vm.currentOpenProjectForm.clientId).toBe('')
+				expect(wrapper.vm.currentOpenProjectForm.clientSecret).toBe('')
+				expect(wrapper.vm.openprojectFormMode).toBe(F_MODES.EDIT)
+				const opFormContainer = wrapper.find(selectors.opFormContainer)
+				expect(opFormContainer.exists()).toBe(true)
+				expect(opFormContainer.find(selectors.opClientIdLabel).exists()).toBe(false)
+				expect(opFormContainer.find(selectors.opClientIdInput).exists()).toBe(true)
+				expect(opFormContainer.find(selectors.opClientSecretLabel).exists()).toBe(false)
+				expect(opFormContainer.find(selectors.opClientSecretInput).exists()).toBe(true)
+				expect(opFormContainer.find(selectors.opSaveButton).exists()).toBe(true)
+				expect(opFormContainer.find(selectors.opSaveButton).attributes().disabled).toBe('true')
+				expect(opFormContainer.find(selectors.opResetButton).exists()).toBe(false)
+			})
+		})
+		describe('edit mode', () => {
+			let wrapper
+			beforeEach(() => {
+				wrapper = getWrapper()
+			})
+
+			it('should not enable save button if the form is incomplete', async () => {
+				const saveButton = wrapper.find(selectors.opSaveButton)
+				expect(saveButton.attributes().disabled).toBe('true')
+
+				await wrapper.find(selectors.opClientIdInput).vm.$emit('input', 'op-client-id')
+
+				expect(saveButton.attributes().disabled).toBe('true')
+			})
+			it('should enable save button if the form is complete', async () => {
+				const saveButton = wrapper.find(selectors.opSaveButton)
+				expect(saveButton.attributes().disabled).toBe('true')
+
+				await wrapper.find(selectors.opClientIdInput).vm.$emit('input', 'op-client-id')
+				await wrapper.find(selectors.opClientSecretInput).vm.$emit('input', 'op-client-secret')
+
+				expect(saveButton.attributes().disabled).toBe(undefined)
+			})
+
+			describe('save action', () => {
+				const opClientId = 'op-client-id'
+				const opClientSecret = 'op-client-secret'
+
+				describe('when the save is successful', () => {
+					it('should show success and set form to view mode', async () => {
+						createNextcloudOAuthClient.mockImplementation(() => Promise.resolve({
+							data: {
+								nextcloud_client_id: 'nc-client-id',
+								nextcloud_client_secret: 'nc-client-secret',
+							},
+						}))
+						const wrapper = getWrapper()
+						const spyCreateNextcloudClient = jest.spyOn(wrapper.vm, 'createNextcloudClient')
+						const spyNotifyOpenProjectTokenRevoke = jest.spyOn(wrapper.vm, 'notifyOpenProjectTokenRevoke')
+						wrapper.find(selectors.opClientIdInput).vm.$emit('input', opClientId)
+						wrapper.find(selectors.opClientSecretInput).vm.$emit('input', opClientSecret)
+						wrapper.find(selectors.opSaveButton).vm.$emit('click')
+						await flushPromises()
+
+						expect(saveAdminConfig).toHaveBeenCalledTimes(1)
+						expect(saveAdminConfig).toHaveBeenCalledWith({
+							openproject_client_id: opClientId,
+							openproject_client_secret: opClientSecret,
+						})
+
+						expect(wrapper.vm.savedOpenProjectForm.clientId).toBe(opClientId)
+						expect(wrapper.vm.savedOpenProjectForm.clientSecret).toBe(opClientSecret)
+						expect(wrapper.vm.openprojectFormMode).toBe(F_MODES.VIEW)
+						expect(wrapper.find(selectors.opClientIdLabel).exists()).toBe(true)
+						expect(wrapper.find(selectors.opClientIdInput).exists()).toBe(false)
+						expect(wrapper.find(selectors.opClientSecretLabel).exists()).toBe(true)
+						expect(wrapper.find(selectors.opClientSecretInput).exists()).toBe(false)
+						expect(wrapper.find(selectors.opResetButton).exists()).toBe(true)
+
+						expect(wrapper.emitted().formcomplete.length).toBe(1)
+						expect(wrapper.emitted().formcomplete[0][0]).toBeInstanceOf(Function)
+
+						expect(spyCreateNextcloudClient).toHaveBeenCalledTimes(1)
+						expect(showSuccess).toHaveBeenCalledTimes(1)
+						expect(showError).toHaveBeenCalledTimes(0)
+						expect(spyNotifyOpenProjectTokenRevoke).toHaveBeenCalledTimes(1)
+
+						expect(wrapper.vm.nextcloudFormMode).toBe(F_MODES.EDIT)
+						expect(wrapper.find(selectors.ncClientIdInput).exists()).toBe(true)
+						expect(wrapper.find(selectors.ncClientIdInput).attributes().value).toBe('nc-client-id')
+						expect(wrapper.find(selectors.ncClientIdLabel).exists()).toBe(false)
+						expect(wrapper.find(selectors.ncClientSecretInput).exists()).toBe(true)
+						expect(wrapper.find(selectors.ncClientSecretInput).attributes().value).toBe('nc-client-secret')
+						expect(wrapper.find(selectors.ncClientSecretLabel).exists()).toBe(false)
+						expect(wrapper.find(selectors.ncSaveButton).exists()).toBe(true)
+						expect(wrapper.find(selectors.ncCreateButton).exists()).toBe(false)
+						expect(wrapper.find(selectors.ncResetButton).exists()).toBe(false)
+					})
+
+					it('should not create Nextcloud OAuth client if already present', async () => {
+						const wrapper = getWrapper({
+							props: {
+								...defaultProps,
+								oauthSettings: {
+									openproject_client_id: '',
+									openproject_client_secret: '',
+									nc_oauth_client: {
+										nextcloud_client_id: 'nc-client-id',
+									},
+								},
+							},
+						})
+						const spyCreateNextcloudClient = jest.spyOn(wrapper.vm, 'createNextcloudClient')
+						const spyNotifyOpenProjectTokenRevoke = jest.spyOn(wrapper.vm, 'notifyOpenProjectTokenRevoke')
+						wrapper.find(selectors.opClientIdInput).vm.$emit('input', opClientId)
+						wrapper.find(selectors.opClientSecretInput).vm.$emit('input', opClientSecret)
+						wrapper.find(selectors.opSaveButton).vm.$emit('click')
+						await flushPromises()
+
+						expect(saveAdminConfig).toHaveBeenCalledTimes(1)
+						expect(spyCreateNextcloudClient).not.toHaveBeenCalled()
+						expect(showSuccess).toHaveBeenCalledTimes(1)
+						expect(showError).toHaveBeenCalledTimes(0)
+						expect(spyNotifyOpenProjectTokenRevoke).toHaveBeenCalledTimes(1)
+					})
+				})
+
+				describe('when the save fails', () => {
+					it('should show error and keep the form in edit mode', async () => {
+						saveAdminConfig.mockImplementation(() => Promise.reject(new Error('Failure')))
+						const wrapper = getWrapper()
+						const spyCreateNextcloudClient = jest.spyOn(wrapper.vm, 'createNextcloudClient').mockImplementation(() => jest.fn())
+						const spyNotifyOpenProjectTokenRevoke = jest.spyOn(wrapper.vm, 'notifyOpenProjectTokenRevoke')
+
+						wrapper.find(selectors.opClientIdInput).vm.$emit('input', opClientId)
+						wrapper.find(selectors.opClientSecretInput).vm.$emit('input', opClientSecret)
+						wrapper.find(selectors.opSaveButton).vm.$emit('click')
+						await flushPromises()
+
+						expect(saveAdminConfig).toHaveBeenCalledTimes(1)
+
+						expect(wrapper.vm.savedOpenProjectForm.clientId).toBe('')
+						expect(wrapper.vm.savedOpenProjectForm.clientSecret).toBe('')
+						expect(wrapper.vm.openprojectFormMode).toBe(F_MODES.EDIT)
+						expect(spyCreateNextcloudClient).toHaveBeenCalledTimes(0)
+
+						expect(wrapper.vm.openprojectTokenRevokeStatus).toBe(null)
+						expect(showSuccess).toHaveBeenCalledTimes(0)
+						expect(showError).toHaveBeenCalledTimes(1)
+						expect(spyNotifyOpenProjectTokenRevoke).toHaveBeenCalledTimes(1)
+					})
+					it('should show error if Nextcloud OAuth client creation fails', async () => {
+						createNextcloudOAuthClient.mockImplementation(() => Promise.reject(new Error('Failure')))
+						const wrapper = getWrapper()
+						const spyCreateNextcloudClient = jest.spyOn(wrapper.vm, 'createNextcloudClient')
+						const spyNotifyOpenProjectTokenRevoke = jest.spyOn(wrapper.vm, 'notifyOpenProjectTokenRevoke')
+
+						wrapper.find(selectors.opClientIdInput).vm.$emit('input', opClientId)
+						wrapper.find(selectors.opClientSecretInput).vm.$emit('input', opClientSecret)
+						wrapper.find(selectors.opSaveButton).vm.$emit('click')
+						await flushPromises()
+
+						expect(saveAdminConfig).toHaveBeenCalledTimes(1)
+						expect(wrapper.vm.savedOpenProjectForm.clientId).toBe(opClientId)
+						expect(wrapper.vm.savedOpenProjectForm.clientSecret).toBe(opClientSecret)
+						expect(wrapper.vm.openprojectFormMode).toBe(F_MODES.VIEW)
+
+						expect(wrapper.emitted().formcomplete.length).toBe(1)
+						expect(wrapper.emitted().formcomplete[0][0]).toBeInstanceOf(Function)
+
+						expect(spyCreateNextcloudClient).toHaveBeenCalledTimes(1)
+						expect(showSuccess).toHaveBeenCalledTimes(1)
+						expect(showError).toHaveBeenCalledTimes(1)
+						expect(spyNotifyOpenProjectTokenRevoke).toHaveBeenCalledTimes(1)
+					})
+				})
+			})
+		})
+	})
+
+	describe('Nextcloud OAuth form', () => {
+		describe('view mode: reset button', () => {
+			let wrapper
+			beforeEach(() => {
+				wrapper = getWrapper({
+					props: {
+						...defaultProps,
+						oauthSettings: {
+							openproject_client_id: 'op-client',
+							openproject_client_secret: 'op-client-secret',
+							nc_oauth_client: {
+								nextcloud_client_id: 'nc-client-id',
+							},
+						},
+					},
+				})
+			})
+
+			it('should trigger confirm dialog on click', async () => {
+				const spyConfirmDialog = jest.spyOn(global.OC.dialogs, 'confirmDestructive')
+				const resetButton = wrapper.find(selectors.ncResetButton)
+				resetButton.vm.$emit('click')
+				await flushPromises()
+
+				expect(spyConfirmDialog).toHaveBeenCalledTimes(1)
+			})
+			it('should create new client on confirm', async () => {
+				createNextcloudOAuthClient.mockImplementationOnce(() => Promise.resolve({
+					data: {
+						nextcloud_client_id: 'new-client-id',
+						nextcloud_client_secret: 'new-client-secret',
+					},
+				}))
+				await wrapper.vm.createNextcloudClient()
+				await flushPromises()
+
+				expect(createNextcloudOAuthClient).toHaveBeenCalledTimes(1)
+				expect(wrapper.vm.savedNextcloudForm.clientId).toBe('new-client-id')
+				expect(wrapper.vm.savedNextcloudForm.clientSecret).toBe('new-client-secret')
+				expect(wrapper.vm.nextcloudFormMode).toBe(F_MODES.EDIT)
+
+				const ncFormContainer = wrapper.find(selectors.ncFormContainer)
+				expect(ncFormContainer.exists()).toBe(true)
+				expect(ncFormContainer.find(selectors.ncClientIdLabel).exists()).toBe(false)
+				expect(ncFormContainer.find(selectors.ncClientIdInput).exists()).toBe(true)
+				expect(ncFormContainer.find(selectors.ncClientIdInput).attributes().value).toBe('new-client-id')
+				expect(ncFormContainer.find(selectors.ncClientSecretLabel).exists()).toBe(false)
+				expect(ncFormContainer.find(selectors.ncClientSecretInput).exists()).toBe(true)
+				expect(ncFormContainer.find(selectors.ncClientSecretInput).attributes().value).toBe('new-client-secret')
+
+				expect(ncFormContainer.find(selectors.ncSaveButton).exists()).toBe(true)
+				expect(ncFormContainer.find(selectors.ncSaveButton).attributes().disabled).toBe(undefined)
+				expect(ncFormContainer.find(selectors.ncSaveButton).text()).toBe('Yes, I have copied these values')
+				expect(ncFormContainer.find(selectors.ncResetButton).exists()).toBe(false)
+				expect(ncFormContainer.find(selectors.ncCreateButton).exists()).toBe(false)
+			})
+		})
+
+		describe('create button', () => {
+			let wrapper
+			beforeEach(() => {
+				createNextcloudOAuthClient.mockImplementationOnce(() => Promise.resolve({
+					data: {
+						nextcloud_client_id: 'nc-client-id',
+						nextcloud_client_secret: 'nc-client-secret',
+					},
+				}))
+				wrapper = getWrapper({
+					props: {
+						...defaultProps,
+						oauthSettings: {
+							openproject_client_id: 'op-client',
+							openproject_client_secret: 'op-client-secret',
+							nc_oauth_client: {
+								nextcloud_client_id: '',
+							},
+						},
+						formState: {
+							...defaultProps.formState,
+							openprojectOauth: {
+								complete: true,
+							},
+						},
+					},
+				})
+			})
+			it('should show create button if other settings are set but not Nextcloud OAuth client', async () => {
+				const createButton = wrapper.find(selectors.ncCreateButton)
+				expect(createButton.exists()).toBe(true)
+				expect(createButton.text()).toBe('Create Nextcloud OAuth values')
+				expect(wrapper.find(selectors.ncResetButton).exists()).toBe(false)
+				expect(wrapper.find(selectors.ncSaveButton).exists()).toBe(false)
+			})
+
+			it('should create Nextcloud OAuth client and set the form mode to edit', async () => {
+				const createButton = wrapper.find(selectors.ncCreateButton)
+				createButton.vm.$emit('click')
+				await flushPromises()
+
+				expect(createNextcloudOAuthClient).toHaveBeenCalledTimes(1)
+				expect(wrapper.vm.savedNextcloudForm.clientId).toBe('nc-client-id')
+				expect(wrapper.vm.savedNextcloudForm.clientSecret).toBe('nc-client-secret')
+				expect(wrapper.vm.nextcloudFormMode).toBe(F_MODES.EDIT)
+
+				const ncFormContainer = wrapper.find(selectors.ncFormContainer)
+				expect(ncFormContainer.exists()).toBe(true)
+				expect(ncFormContainer.find(selectors.ncClientIdLabel).exists()).toBe(false)
+				expect(ncFormContainer.find(selectors.ncClientIdInput).exists()).toBe(true)
+				expect(ncFormContainer.find(selectors.ncClientIdInput).attributes().value).toBe('nc-client-id')
+				expect(ncFormContainer.find(selectors.ncClientSecretLabel).exists()).toBe(false)
+				expect(ncFormContainer.find(selectors.ncClientSecretInput).exists()).toBe(true)
+				expect(ncFormContainer.find(selectors.ncClientSecretInput).attributes().value).toBe('nc-client-secret')
+
+				expect(ncFormContainer.find(selectors.ncSaveButton).exists()).toBe(true)
+				expect(ncFormContainer.find(selectors.ncSaveButton).attributes().disabled).toBe(undefined)
+				expect(ncFormContainer.find(selectors.ncSaveButton).text()).toBe('Yes, I have copied these values')
+				expect(ncFormContainer.find(selectors.ncResetButton).exists()).toBe(false)
+				expect(ncFormContainer.find(selectors.ncCreateButton).exists()).toBe(false)
+			})
+		})
+
+		describe('edit mode', () => {
+			it('should set the form to view mode on save', async () => {
+				createNextcloudOAuthClient.mockImplementationOnce(() => Promise.resolve({
+					data: {
+						nextcloud_client_id: 'new-client-id',
+						nextcloud_client_secret: 'new-client-secret',
+					},
+				}))
+				const wrapper = getWrapper({
+					props: {
+						...defaultProps,
+						oauthSettings: {
+							openproject_client_id: 'op-client',
+							openproject_client_secret: 'op-client-secret',
+							nc_oauth_client: {
+								nextcloud_client_id: 'nc-client-id',
+							},
+						},
+						formState: {
+							...defaultProps.formState,
+							openprojectOauth: {
+								complete: true,
+							},
+						},
+					},
+				})
+				const resetButton = wrapper.find(selectors.ncResetButton)
+				resetButton.vm.$emit('click')
+				await wrapper.vm.createNextcloudClient()
+				await flushPromises()
+
+				expect(wrapper.vm.nextcloudFormMode).toBe(F_MODES.EDIT)
+				expect(wrapper.find(selectors.ncClientIdInput).exists()).toBe(true)
+				expect(wrapper.find(selectors.ncClientSecretInput).exists()).toBe(true)
+				expect(wrapper.find(selectors.ncClientSecretInput).exists()).toBe(true)
+				expect(wrapper.find(selectors.ncResetButton).exists()).toBe(false)
+				expect(wrapper.find(selectors.ncCreateButton).exists()).toBe(false)
+
+				const saveButton = wrapper.find(selectors.ncSaveButton)
+				expect(saveButton.exists()).toBe(true)
+				saveButton.vm.$emit('click')
+				await flushPromises()
+
+				expect(wrapper.vm.nextcloudFormMode).toBe(F_MODES.VIEW)
+				expect(wrapper.find(selectors.ncClientIdInput).exists()).toBe(false)
+				expect(wrapper.find(selectors.ncClientIdLabel).exists()).toBe(true)
+				expect(wrapper.find(selectors.ncClientSecretInput).exists()).toBe(false)
+				expect(wrapper.find(selectors.ncClientSecretLabel).exists()).toBe(true)
+				expect(wrapper.find(selectors.ncResetButton).exists()).toBe(true)
+				expect(wrapper.find(selectors.ncCreateButton).exists()).toBe(false)
+				expect(wrapper.find(selectors.ncSaveButton).exists()).toBe(false)
+			})
+		})
+	})
+
+	describe('revoke OpenProject OAuth token', () => {
+		it('should show success when revoke status is success', async () => {
+			saveAdminConfig.mockImplementationOnce(() => Promise.resolve({
+				data: {
+					oPOAuthTokenRevokeStatus: 'success',
+				},
+			}))
+			const wrapper = getWrapper()
+			const spyCreateNextcloudClient = jest.spyOn(wrapper.vm, 'createNextcloudClient').mockImplementation(() => jest.fn())
+			const spyNotifyOpenProjectTokenRevoke = jest.spyOn(wrapper.vm, 'notifyOpenProjectTokenRevoke')
+			wrapper.find(selectors.opClientIdInput).vm.$emit('input', 'id')
+			wrapper.find(selectors.opClientSecretInput).vm.$emit('input', 'secret')
+			wrapper.find(selectors.opSaveButton).vm.$emit('click')
+			await flushPromises()
+
+			expect(spyCreateNextcloudClient).toHaveBeenCalledTimes(1)
+			expect(wrapper.vm.openprojectTokenRevokeStatus).toBe('success')
+			expect(spyNotifyOpenProjectTokenRevoke).toHaveBeenCalledTimes(1)
+			expect(showSuccess).toHaveBeenCalledTimes(2)
+			expect(showError).toHaveBeenCalledTimes(0)
+			expect(showSuccess).toHaveBeenCalledWith('OpenProject admin options saved')
+			expect(showSuccess).toHaveBeenCalledWith('Successfully revoked users\' OpenProject OAuth access tokens')
+
+		})
+		it.each([
+			['connection_error', 'Failed to perform revoke request due to connection error with the OpenProject server'],
+			['other_error', 'Failed to revoke some users\' OpenProject OAuth access tokens'],
+		])('should show error message on various failure', async (errorCode, errorMessage) => {
+			saveAdminConfig.mockImplementationOnce(() => Promise.resolve({
+				data: {
+					oPOAuthTokenRevokeStatus: errorCode,
+				},
+			}))
+			const wrapper = getWrapper()
+			const spyCreateNextcloudClient = jest.spyOn(wrapper.vm, 'createNextcloudClient').mockImplementation(() => jest.fn())
+			const spyNotifyOpenProjectTokenRevoke = jest.spyOn(wrapper.vm, 'notifyOpenProjectTokenRevoke')
+			wrapper.find(selectors.opClientIdInput).vm.$emit('input', 'id')
+			wrapper.find(selectors.opClientSecretInput).vm.$emit('input', 'secret')
+			wrapper.find(selectors.opSaveButton).vm.$emit('click')
+			await flushPromises()
+
+			expect(spyCreateNextcloudClient).toHaveBeenCalledTimes(1)
+			expect(wrapper.vm.openprojectTokenRevokeStatus).toBe(errorCode)
+			expect(spyNotifyOpenProjectTokenRevoke).toHaveBeenCalledTimes(1)
+
+			expect(showSuccess).toHaveBeenCalledTimes(1)
+			expect(showError).toHaveBeenCalledTimes(1)
+			expect(showSuccess).toHaveBeenCalledWith('OpenProject admin options saved')
+			expect(showError).toHaveBeenCalledWith(errorMessage)
+		})
+	})
+})
+
+function getWrapper({ data = {}, props = {} } = {}) {
+	return shallowMount(FormOAuthSettings, {
+		localVue,
+		mocks: {
+			t: (app, msg) => msg,
+		},
+		propsData: { ...defaultProps, ...props },
+		data() {
+			return data
+		},
+	})
+}

--- a/tests/jest/components/admin/FormOAuthSettings.spec.js
+++ b/tests/jest/components/admin/FormOAuthSettings.spec.js
@@ -71,8 +71,8 @@ const defaultProps = {
 describe('Component: FormOAuthSettings', () => {
 	afterEach(() => {
 		jest.clearAllMocks()
-		saveAdminConfig.mockRestore()
-		createNextcloudOAuthClient.mockRestore()
+		saveAdminConfig.mockReset()
+		createNextcloudOAuthClient.mockReset()
 	})
 
 	describe('form states', () => {
@@ -272,6 +272,10 @@ describe('Component: FormOAuthSettings', () => {
 				})
 			})
 
+			it('should mark form complete', async () => {
+				expect(wrapper.emitted().formcomplete.length).toBe(2)
+				expect(wrapper.emitted().formcomplete[0][0]).toBeInstanceOf(Function)
+			})
 			it('should trigger confirm dialog on click', async () => {
 				const spyConfirmDialog = jest.spyOn(global.OC.dialogs, 'confirmDestructive')
 				const resetButton = wrapper.find(selectors.opResetButton)
@@ -481,7 +485,13 @@ describe('Component: FormOAuthSettings', () => {
 				})
 			})
 
+			it('should mark form complete', async () => {
+				expect(wrapper.emitted().formcomplete.length).toBe(2)
+				expect(wrapper.emitted().formcomplete[0][0]).toBeInstanceOf(Function)
+			})
 			it('should trigger confirm dialog on click', async () => {
+				expect(wrapper.emitted().formcomplete.length).toBe(2)
+				expect(wrapper.emitted().formcomplete[0][0]).toBeInstanceOf(Function)
 				const spyConfirmDialog = jest.spyOn(global.OC.dialogs, 'confirmDestructive')
 				const resetButton = wrapper.find(selectors.ncResetButton)
 				resetButton.vm.$emit('click')
@@ -566,6 +576,9 @@ describe('Component: FormOAuthSettings', () => {
 				expect(wrapper.vm.savedNextcloudForm.clientId).toBe('nc-client-id')
 				expect(wrapper.vm.savedNextcloudForm.clientSecret).toBe('nc-client-secret')
 				expect(wrapper.vm.nextcloudFormMode).toBe(F_MODES.EDIT)
+
+				expect(wrapper.emitted().formcomplete.length).toBe(1)
+				expect(wrapper.emitted().formcomplete[0][0]).toBeInstanceOf(Function)
 
 				const ncFormContainer = wrapper.find(selectors.ncFormContainer)
 				expect(ncFormContainer.exists()).toBe(true)

--- a/tests/jest/components/admin/__snapshots__/FormOAuthSettings.spec.js.snap
+++ b/tests/jest/components/admin/__snapshots__/FormOAuthSettings.spec.js.snap
@@ -1,0 +1,382 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component: FormOAuthSettings form states form state: complete OpenProject and Nextcloud oauth values 1`] = `
+<section>
+  <div
+    class="openproject-oauth"
+  >
+    <formheading-stub
+      index="3"
+      iscomplete="true"
+      title="OpenProject OAuth settings"
+    />
+     
+    <div
+      class="oauth-settings--openproject"
+    >
+      <fieldvalue-stub
+        isrequired="true"
+        title="OpenProject OAuth client ID"
+        value="op-client"
+      />
+       
+      <fieldvalue-stub
+        class="pb-1"
+        encryptvalue="true"
+        isrequired="true"
+        title="OpenProject OAuth client secret"
+        value="op-client-secret"
+      />
+       
+      <div
+        class="form-actions"
+      >
+        <ncbutton-stub
+          alignment="center"
+          data-test-id="reset-op-oauth-btn"
+          nativetype="button"
+          size="normal"
+          target="_self"
+          type="secondary"
+          variant="secondary"
+        >
+          
+					Replace OpenProject OAuth values
+				
+        </ncbutton-stub>
+      </div>
+    </div>
+  </div>
+   
+  <div
+    class="nextcloud-oauth"
+  >
+    <formheading-stub
+      index="4"
+      iscomplete="true"
+      title="Nextcloud OAuth client"
+    />
+     
+    <div
+      class="oauth-settings--nextcloud"
+    >
+      <fieldvalue-stub
+        isrequired="true"
+        title="Nextcloud OAuth client ID"
+        value="nc-client-id"
+      />
+       
+      <fieldvalue-stub
+        encryptvalue="true"
+        isrequired="true"
+        title="Nextcloud OAuth client secret"
+        value="***"
+      />
+       
+      <div
+        class="form-actions"
+      >
+        <ncbutton-stub
+          alignment="center"
+          data-test-id="reset-nc-oauth-btn"
+          nativetype="button"
+          size="normal"
+          target="_self"
+          type="secondary"
+          variant="secondary"
+        >
+          
+					Replace Nextcloud OAuth values
+				
+        </ncbutton-stub>
+      </div>
+    </div>
+  </div>
+</section>
+`;
+
+exports[`Component: FormOAuthSettings form states form state: complete authorization method and complete Nextcloud form but not OpenProject 1`] = `
+<section>
+  <div
+    class="openproject-oauth"
+  >
+    <formheading-stub
+      index="3"
+      title="OpenProject OAuth settings"
+    />
+     
+    <div
+      class="oauth-settings--openproject"
+    >
+      <textinput-stub
+        class="py-1"
+        hinttext="Go to your OpenProject {htmlLink} as an Administrator and start the setup and copy the values here."
+        id="openproject-oauth-client-id"
+        isrequired="true"
+        label="OpenProject OAuth client ID"
+        placeholder=""
+        type="text"
+        value=""
+      />
+       
+      <textinput-stub
+        class="py-1"
+        hinttext="Go to your OpenProject {htmlLink} as an Administrator and start the setup and copy the values here."
+        id="openproject-oauth-client-secret"
+        isrequired="true"
+        label="OpenProject OAuth client secret"
+        placeholder=""
+        type="text"
+        value=""
+      />
+       
+      <div
+        class="form-actions"
+      >
+        <ncbutton-stub
+          alignment="center"
+          data-test-id="submit-op-oauth-btn"
+          disabled="true"
+          nativetype="button"
+          size="normal"
+          target="_self"
+          type="primary"
+          variant="secondary"
+        >
+          
+					Save
+				
+        </ncbutton-stub>
+      </div>
+    </div>
+  </div>
+   
+  <div
+    class="nextcloud-oauth"
+  >
+    <formheading-stub
+      index="4"
+      iscomplete="true"
+      title="Nextcloud OAuth client"
+    />
+     
+    <div
+      class="oauth-settings--nextcloud"
+    >
+      <fieldvalue-stub
+        isrequired="true"
+        title="Nextcloud OAuth client ID"
+        value="nc-client-id"
+      />
+       
+      <fieldvalue-stub
+        encryptvalue="true"
+        isrequired="true"
+        title="Nextcloud OAuth client secret"
+        value="***"
+      />
+       
+      <div
+        class="form-actions"
+      >
+        <ncbutton-stub
+          alignment="center"
+          data-test-id="reset-nc-oauth-btn"
+          nativetype="button"
+          size="normal"
+          target="_self"
+          type="secondary"
+          variant="secondary"
+        >
+          
+					Replace Nextcloud OAuth values
+				
+        </ncbutton-stub>
+      </div>
+    </div>
+  </div>
+</section>
+`;
+
+exports[`Component: FormOAuthSettings form states form state: complete authorization method and complete OpenProject form but not Nextcloud 1`] = `
+<section>
+  <div
+    class="openproject-oauth"
+  >
+    <formheading-stub
+      index="3"
+      iscomplete="true"
+      title="OpenProject OAuth settings"
+    />
+     
+    <div
+      class="oauth-settings--openproject"
+    >
+      <fieldvalue-stub
+        isrequired="true"
+        title="OpenProject OAuth client ID"
+        value="op-client"
+      />
+       
+      <fieldvalue-stub
+        class="pb-1"
+        encryptvalue="true"
+        isrequired="true"
+        title="OpenProject OAuth client secret"
+        value="op-client-secret"
+      />
+       
+      <div
+        class="form-actions"
+      >
+        <ncbutton-stub
+          alignment="center"
+          data-test-id="reset-op-oauth-btn"
+          nativetype="button"
+          size="normal"
+          target="_self"
+          type="secondary"
+          variant="secondary"
+        >
+          
+					Replace OpenProject OAuth values
+				
+        </ncbutton-stub>
+      </div>
+    </div>
+  </div>
+   
+  <div
+    class="nextcloud-oauth"
+  >
+    <formheading-stub
+      index="4"
+      title="Nextcloud OAuth client"
+    />
+     
+    <div
+      class="oauth-settings--nextcloud"
+    >
+      <!---->
+       
+      <!---->
+       
+      <div
+        class="form-actions"
+      >
+        <ncbutton-stub
+          alignment="center"
+          data-test-id="create-nc-oauth-btn"
+          nativetype="button"
+          size="normal"
+          target="_self"
+          type="secondary"
+          variant="secondary"
+        >
+          
+					Create Nextcloud OAuth values
+				
+        </ncbutton-stub>
+      </div>
+    </div>
+  </div>
+</section>
+`;
+
+exports[`Component: FormOAuthSettings form states form state: complete authorization method but incomplete oauth settings 1`] = `
+<section>
+  <div
+    class="openproject-oauth"
+  >
+    <formheading-stub
+      index="3"
+      title="OpenProject OAuth settings"
+    />
+     
+    <div
+      class="oauth-settings--openproject"
+    >
+      <textinput-stub
+        class="py-1"
+        hinttext="Go to your OpenProject {htmlLink} as an Administrator and start the setup and copy the values here."
+        id="openproject-oauth-client-id"
+        isrequired="true"
+        label="OpenProject OAuth client ID"
+        placeholder=""
+        type="text"
+        value=""
+      />
+       
+      <textinput-stub
+        class="py-1"
+        hinttext="Go to your OpenProject {htmlLink} as an Administrator and start the setup and copy the values here."
+        id="openproject-oauth-client-secret"
+        isrequired="true"
+        label="OpenProject OAuth client secret"
+        placeholder=""
+        type="text"
+        value=""
+      />
+       
+      <div
+        class="form-actions"
+      >
+        <ncbutton-stub
+          alignment="center"
+          data-test-id="submit-op-oauth-btn"
+          disabled="true"
+          nativetype="button"
+          size="normal"
+          target="_self"
+          type="primary"
+          variant="secondary"
+        >
+          
+					Save
+				
+        </ncbutton-stub>
+      </div>
+    </div>
+  </div>
+   
+  <div
+    class="nextcloud-oauth"
+  >
+    <formheading-stub
+      index="4"
+      isdisabled="true"
+      title="Nextcloud OAuth client"
+    />
+     
+    <!---->
+  </div>
+</section>
+`;
+
+exports[`Component: FormOAuthSettings form states form state: incomplete authorization method 1`] = `
+<section>
+  <div
+    class="openproject-oauth"
+  >
+    <formheading-stub
+      index="3"
+      isdisabled="true"
+      title="OpenProject OAuth settings"
+    />
+     
+    <!---->
+  </div>
+   
+  <div
+    class="nextcloud-oauth"
+  >
+    <formheading-stub
+      index="4"
+      isdisabled="true"
+      title="Nextcloud OAuth client"
+    />
+     
+    <!---->
+  </div>
+</section>
+`;


### PR DESCRIPTION
## Description
Separate oauth2 related forms from Admin component.

| before | after |
|--|--|
|<img width="755" height="643" alt="Screenshot from 2026-06-23 12-05-48" src="https://github.com/user-attachments/assets/02c2e79a-8dd2-423e-b3f9-74b95cf12257" /> | <img width="763" height="582" alt="Screenshot from 2026-06-23 12-12-12" src="https://github.com/user-attachments/assets/4d362fc7-c449-456d-80c4-059e7414f6a9" />|
|<img width="982" height="539" alt="Screenshot from 2026-06-22 18-25-55" src="https://github.com/user-attachments/assets/de959733-b66f-4c57-8297-bb265ebeafd5" /> | <img width="755" height="552" alt="Screenshot from 2026-06-23 12-06-06" src="https://github.com/user-attachments/assets/83ad94ef-dde1-45bf-b6fd-3cf58a0eb9c4" />|
|<img width="982" height="539" alt="Screenshot from 2026-06-22 18-26-01" src="https://github.com/user-attachments/assets/2a7e12fa-5cb8-4130-8ff1-e25bd6213435" /> | <img width="755" height="552" alt="Screenshot from 2026-06-23 12-06-12" src="https://github.com/user-attachments/assets/4119b2f9-e49a-49a0-8444-8a826e5ee44e" />|
|<img width="982" height="539" alt="Screenshot from 2026-06-22 18-26-09" src="https://github.com/user-attachments/assets/54929e39-df40-488a-bea1-0931c448f631" /> | <img width="841" height="552" alt="Screenshot from 2026-06-23 12-06-21" src="https://github.com/user-attachments/assets/8dec46e9-b548-4a6e-93b0-3b82c60e9c76" />|
|<img width="982" height="539" alt="Screenshot from 2026-06-22 18-26-15" src="https://github.com/user-attachments/assets/3ccda3b4-3945-49b5-bd0e-8abaf66a052e" /> | <img width="841" height="710" alt="Screenshot from 2026-06-23 12-06-31" src="https://github.com/user-attachments/assets/240d7254-bde9-4fcd-8c9d-e78d70cf7911" />|
|<img width="1011" height="811" alt="Screenshot from 2026-06-22 18-26-35" src="https://github.com/user-attachments/assets/f8b21492-024e-4f80-9d6e-db891c5d6813" /> | <img width="841" height="784" alt="Screenshot from 2026-06-23 12-06-43" src="https://github.com/user-attachments/assets/7d1ca2b6-ed24-4e14-a651-0d5ae15855b5" />|
|<img width="1011" height="811" alt="Screenshot from 2026-06-22 18-26-49" src="https://github.com/user-attachments/assets/786ef1da-edb1-4c71-9da1-fdb916ed7fa4" /> | <img width="841" height="784" alt="Screenshot from 2026-06-23 12-08-58" src="https://github.com/user-attachments/assets/03a5ac1e-9299-4bb0-96a0-61443e45b544" />|
|<img width="1011" height="811" alt="Screenshot from 2026-06-22 18-26-56" src="https://github.com/user-attachments/assets/76815135-5a5b-44ed-95a4-bf78a02b0220" /> | <img width="841" height="784" alt="Screenshot from 2026-06-23 12-09-05" src="https://github.com/user-attachments/assets/078677ab-b2ca-4d69-843f-5704b722ee2f" />|



## Related Issue or Workpackage
- Part of https://community.openproject.org/wp/NEX-464

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
