### PR TITLE
ci: fix upgrade test for 2.11 and master

### DIFF
--- a/.github/workflows/app-upgrade.yml
+++ b/.github/workflows/app-upgrade.yml
@@ -12,11 +12,11 @@ on:
       nextcloud_versions:
         required: false
         type: string
-        default: "master"
+        default: 'master'
       php_versions:
         required: false
         type: string
-        default: "8.3"
+        default: '8.3'
 
 jobs:
   create-matrix:
@@ -32,8 +32,8 @@ jobs:
         env:
           NEXTCLOUD_VERSIONS: ${{ inputs.nextcloud_versions }}
           PHP_VERSIONS: ${{ inputs.php_versions }}
-          DEFAULT_PHP_VERSION: "8.3"
-          DEFAULT_DATABASE: "mysql"
+          DEFAULT_PHP_VERSION: '8.3'
+          DEFAULT_DATABASE: 'mysql'
         run: |
           MATRIX=$(./.github/scripts/generate-matrix.sh)
           echo "matrix={\"include\": [$MATRIX]}" >> $GITHUB_OUTPUT

--- a/.github/workflows/app-upgrade.yml
+++ b/.github/workflows/app-upgrade.yml
@@ -92,13 +92,13 @@ jobs:
       
       - name: Wait for Nextcloud server to be ready
         run: |
-          if ! timeout 8m bash -c '
+          if ! timeout 5m bash -c '
             until curl -s -f http://localhost/status.php | grep '"'"'"installed":true'"'"'; do
               echo "[INFO] Waiting for server to be ready..."
-              sleep 15
+              sleep 10
             done
           '; then
-            echo "[ERROR] Server not ready within 8 minutes."
+            echo "[ERROR] Server not ready within 5 minutes."
             exit 1
           fi
 

--- a/.github/workflows/app-upgrade.yml
+++ b/.github/workflows/app-upgrade.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: ${{ inputs.branch }}
 
       - name: Create matrix
         id: create-matrix
@@ -79,6 +81,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           path: integration_openproject
+          ref: ${{ inputs.branch }}
       
       - name: Setup PHP ${{ format('{0}.{1}', matrix.phpVersionMajor,matrix.phpVersionMinor) }}
         uses: shivammathur/setup-php@a4e22b60bbb9c1021113f2860347b0759f66fe5d
@@ -89,13 +92,13 @@ jobs:
       
       - name: Wait for Nextcloud server to be ready
         run: |
-          if ! timeout 5m bash -c '
+          if ! timeout 8m bash -c '
             until curl -s -f http://localhost/status.php | grep '"'"'"installed":true'"'"'; do
               echo "[INFO] Waiting for server to be ready..."
-              sleep 10
+              sleep 15
             done
           '; then
-            echo "[ERROR] Server not ready within 5 minutes."
+            echo "[ERROR] Server not ready within 8 minutes."
             exit 1
           fi
 

--- a/.github/workflows/nighlty-ci-master.yml
+++ b/.github/workflows/nighlty-ci-master.yml
@@ -16,8 +16,13 @@ jobs:
     with:
       branch: master
 
+  app-upgrade-test:
+    uses: ./.github/workflows/app-upgrade.yml
+    with:
+      branch: '33'
+
   notify-nightly-report:
-    needs: [builds]
+    needs: [builds, app-upgrade-test]
     if: ${{ always() }}
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/nighlty-ci-master.yml
+++ b/.github/workflows/nighlty-ci-master.yml
@@ -16,13 +16,8 @@ jobs:
     with:
       branch: master
 
-  app-upgrade-test:
-    uses: ./.github/workflows/app-upgrade.yml
-    with:
-      branch: master
-
   notify-nightly-report:
-    needs: [builds, app-upgrade-test]
+    needs: [builds]
     if: ${{ always() }}
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR fixes the failure in the `Upgrade testing` CI job.
In order to fix the CI, the following changes are done:
- Added the missing checkout step with the input ref.
- Skipped upgrade testing for the master branch because no app versions compatible with the Nextcloud master branch are available in the App Store, which is causing the following failure:
```bash
 occ app:enable groupfolders
    App "Team Folders" cannot be installed because it is not compatible with this version of the server.
 🔄 retrying
 occ app:enable user_oidc
    App "OpenID Connect user backend" cannot be installed because it is not compatible with this version of the server.
 🔄 retrying
 occ app:enable integration_openproject
    App "OpenProject Integration" cannot be installed because it is not compatible with this version of the server.
 🔄 retrying
```

## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
