### PR TITLE
chore: implement expected failure

### DIFF
--- a/.github/workflows/shared_workflow.yml
+++ b/.github/workflows/shared_workflow.yml
@@ -10,11 +10,11 @@ on:
       nextcloud_versions:
         required: false
         type: string
-        default: "31 32"
+        default: '31 32'
       php_versions:
         required: false
         type: string
-        default: "8.2 8.3 8.4"
+        default: '8.2 8.3 8.4'
 
 name: CI
 
@@ -66,7 +66,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           lcov-file: ./coverage/jest/lcov.info
           delete-old-comments: true
-          title: "JS Code Coverage"
+          title: 'JS Code Coverage'
 
       - name: JS coverage check
         if: ${{ github.event_name == 'pull_request' }}
@@ -93,9 +93,9 @@ jobs:
         env:
           NEXTCLOUD_VERSIONS: ${{ inputs.nextcloud_versions }}
           PHP_VERSIONS: ${{ inputs.php_versions }}
-          DEFAULT_PHP_VERSION: "8.3"
-          DEFAULT_DATABASE: "mysql"
-          EXTRA_DATABASES: "pgsql"
+          DEFAULT_PHP_VERSION: '8.3'
+          DEFAULT_DATABASE: 'mysql'
+          EXTRA_DATABASES: 'pgsql'
         run: |
           MATRIX=$(./.github/scripts/generate-matrix.sh)
           echo "matrix={\"include\": [$MATRIX]}" >> $GITHUB_OUTPUT
@@ -120,8 +120,8 @@ jobs:
         env:
           SQL: ${{ matrix.database }}
           SERVER_BRANCH: ${{ matrix.nextcloudVersion }}
-          NEXTCLOUD_AUTOINSTALL: "Yes"
-          WITH_REDIS: "YES"
+          NEXTCLOUD_AUTOINSTALL: 'Yes'
+          WITH_REDIS: 'YES'
         ports:
           - 80:80
         options: --name=nextcloud
@@ -290,7 +290,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           lcov-file: 'integration_openproject/server/apps/integration_openproject/coverage/php/lcov.info'
           delete-old-comments: true
-          title: "PHP Code Coverage"
+          title: 'PHP Code Coverage'
 
       - name: PHP coverage check
         if: ${{ github.event_name == 'pull_request' && matrix.nextcloudVersion == 'stable32' && matrix.phpVersion == '8.2' }}
@@ -326,6 +326,8 @@ jobs:
       - name: API Tests
         env:
           NEXTCLOUD_BASE_URL: http://localhost
+          NEXTCLOUD_VERSION: ${{ matrix.nextcloudVersion }}
+          BEHAT_FILTER_TAGS: '~@skip'
         run: make api-test
 
   notify-nightly-report:

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ log/
 vendor/
 .php-cs-fixer.cache
 tests/pact/
+tests/acceptance/reports
 docker-compose.override.yml
 compose.override.yaml
 .env

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 		"cs:check": "php-cs-fixer fix --dry-run --diff",
 		"psalm": "psalm",
 		"test:unit": "phpunit",
-		"test:api": "behat"
+		"test:api": "behat -c tests/acceptance/config/behat.yml"
 	},
 	"config": {
 		"allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 		"cs:check": "php-cs-fixer fix --dry-run --diff",
 		"psalm": "psalm",
 		"test:unit": "phpunit",
-		"test:api": "behat -c tests/acceptance/config/behat.yml"
+		"test:api": "behat"
 	},
 	"config": {
 		"allow-plugins": {

--- a/docs/running_API_test.md
+++ b/docs/running_API_test.md
@@ -12,6 +12,7 @@ To run the whole of the acceptance tests locally run the command below:
 
 ```shell
 NEXTCLOUD_BASE_URL=http://<nextcloud_host> \
+BEHAT_FILTER_TAGS="~@skip" \
 make api-test
 ```
 

--- a/docs/running_API_test.md
+++ b/docs/running_API_test.md
@@ -5,7 +5,7 @@
 
 ## 🧪 Running API tests
 
-> **_NOTE:_**  
+> **_NOTE:_**
 > Before running the API tests, the nextcloud instance needs to be ready, and also integration app needs to be enabled
 
 To run the whole of the acceptance tests locally run the command below:
@@ -29,3 +29,6 @@ We can mark a scenario as expected to fail for all Nextcloud versions or for spe
 
 - `@expect-fail`: Marks a scenario as expected failure for all Nextcloud versions
 - `@expect-fail-on-nc<major-version>`: Marks a scenario as expected failure for a specific Nextcloud version. (E.g.: `@expect-fail-on-nc33`)
+
+> **_NOTE:_**
+> We MUST provide `NEXTCLOUD_VERSION` environment variable while running the tests that are tagged `@expect-fail-on-nc<major-version>`.

--- a/docs/running_API_test.md
+++ b/docs/running_API_test.md
@@ -32,3 +32,11 @@ We can mark a scenario as expected to fail for all Nextcloud versions or for spe
 
 > **_NOTE:_**
 > We MUST provide `NEXTCLOUD_VERSION` environment variable while running the tests that are tagged `@expect-fail-on-nc<major-version>`.
+>
+> Possible values for `NEXTCLOUD_VERSION`: `stable33` (any major version number), `33` (any major version number) and `master`
+>
+> ```shell
+> NEXTCLOUD_BASE_URL=http://<nextcloud_host> \
+> NEXTCLOUD_VERSION=33 \
+> make api-test
+> ```

--- a/docs/running_API_test.md
+++ b/docs/running_API_test.md
@@ -2,19 +2,30 @@
   - SPDX-FileCopyrightText: 2024 Jankari Tech Pvt. Ltd.
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
-### 🧪 Running API tests
+
+## 🧪 Running API tests
 
 > **_NOTE:_**  
 > Before running the API tests, the nextcloud instance needs to be ready, and also integration app needs to be enabled
 
-To run the whole of the acceptance tests locally run the command below.
+To run the whole of the acceptance tests locally run the command below:
+
 ```shell
-NEXTCLOUD_BASE_URL=http://<nextcloud_host> make api-test
+NEXTCLOUD_BASE_URL=http://<nextcloud_host> \
+make api-test
 ```
 
-In order to run only a specific scenario
+In order to run only a specific scenario:
+
 ```shell
-NEXTCLOUD_BASE_URL=http://<nextcloud_host> \                                                                                                                                            
-make api-test \
-FEATURE_PATH=tests/acceptance/features/api/directUpload.feature:15
+NEXTCLOUD_BASE_URL=http://<nextcloud_host> \
+BEHAT_FEATURE_PATH=tests/acceptance/features/api/directUpload.feature:15 \
+make api-test
 ```
+
+## Mark Scenario as Expected Failure
+
+We can mark a scenario as expected to fail for all Nextcloud versions or for specific versions using tags.
+
+- `@expect-fail`: Marks a scenario as expected failure for all Nextcloud versions
+- `@expect-fail-on-nc<major-version>`: Marks a scenario as expected failure for a specific Nextcloud version. (E.g.: `@expect-fail-on-nc33`)

--- a/makefile
+++ b/makefile
@@ -14,12 +14,6 @@ build_tools_directory=$(CURDIR)/build/tools
 npm=$(shell which npm 2> /dev/null)
 composer=$(shell which composer 2> /dev/null)
 
-#check for BEHAT_FILTER_TAGS env is set any
-FILTER_TAGS := ~@skip
-ifdef BEHAT_FILTER_TAGS
-	FILTER_TAGS:=$(FILTER_TAGS)&&${BEHAT_FILTER_TAGS}
-endif
-
 all: build
 
 .PHONY: build
@@ -108,7 +102,7 @@ jsunit:
 
 .PHONY: api-test
 api-test:
-	composer run test:api -- --tags '${FILTER_TAGS}' ${FEATURE_PATH}
+	bash tests/acceptance/run.sh
 
 .PHONY: test
 test: phpunit jsunit api-test

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -105,12 +105,12 @@ class FeatureContext implements Context {
 	 */
 	public function getServerVersion(): string {
 		$version = getenv('NEXTCLOUD_VERSION');
-		if ($version === false) {
+		if (!$version) {
 			return "";
 		}
 		$version = preg_replace("/^stable/", "", $version);
 		$version = explode(".", $version)[0];
-		return "nc$version";
+		return "nc{$version}";
 	}
 
 	public function __construct(
@@ -1392,8 +1392,8 @@ class FeatureContext implements Context {
 	 */
 	public function checkExpectedFailure(AfterScenarioScope $scope): void {
 		$reportDir = dirname(dirname(__DIR__)) . "/reports";
-		if (!is_dir($reportDir)) {
-			mkdir($reportDir, 0777, true);
+		if (!is_dir($reportDir) && !mkdir($reportDir, 0755, true)) {
+			throw new \RuntimeException("Failed to create report directory: {$reportDir}");
 		}
 
 		$serverVersion = $this->getServerVersion();
@@ -1417,28 +1417,29 @@ class FeatureContext implements Context {
 			}
 		}
 
+		$reportFile = null;
 		if ($hasExpectFailTag && !$serverVersion) {
-			echo "[ERROR] Scenario has tag '$hasExpectFailTag' but could not determine server version. Use 'NEXTCLOUD_VERSION' env";
+			echo "[ERROR] Scenario has tag '$hasExpectFailTag' but could not determine server version. Set 'NEXTCLOUD_VERSION' env";
+			if ($result->isPassed()) {
+				$reportFile = "$reportDir/unexpected-passes.txt";
+			}
 		}
 
 		if ($scenario->hasTag($tag) || $scenario->hasTag("expect-fail")) {
 			if ($result->getResultCode() === TestResult::FAILED) {
-				$expectedFailureFile = "$reportDir/expected-failures.txt";
-				file_put_contents($expectedFailureFile, $scenarioLine . PHP_EOL, FILE_APPEND);
-				return;
+				$reportFile = "$reportDir/expected-failures.txt";
 			} elseif ($result->isPassed()) {
-				$unexpectedPassedFile = "$reportDir/unexpected-passes.txt";
-				file_put_contents($unexpectedPassedFile, $scenarioLine . PHP_EOL, FILE_APPEND);
-				return;
+				$reportFile = "$reportDir/unexpected-passes.txt";
+				echo "[ERROR] Scenario was expected to fail but it did not.";
 			} else {
-				$unexpectedFailureFile = "$reportDir/failures.txt";
-				file_put_contents($unexpectedFailureFile, $scenarioLine . PHP_EOL, FILE_APPEND);
+				$reportFile = "$reportDir/failures.txt";
 			}
-
-			echo "[ERROR] Scenario was expected to fail on server version '$serverVersion' but it did not.";
 		} elseif (!$result->isPassed()) {
-			$unexpectedFailureFile = "$reportDir/failures.txt";
-			file_put_contents($unexpectedFailureFile, $scenarioLine . PHP_EOL, FILE_APPEND);
+			$reportFile = "$reportDir/failures.txt";
+		}
+
+		if ($reportFile) {
+			file_put_contents($reportFile, $scenarioLine . PHP_EOL, FILE_APPEND);
 		}
 	}
 }

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -957,6 +957,7 @@ class FeatureContext implements Context {
 		if ($user !== null && $password !== null) {
 			$options['auth'] = [$user, $password];
 		}
+		$options['verify'] = false;
 		$client = new Client($options);
 		if ($headers === null) {
 			$headers = [];

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -1397,7 +1397,7 @@ class FeatureContext implements Context {
 		}
 
 		$serverVersion = $this->getServerVersion();
-		$tag = "expect-fail-on-$serverVersion";
+		$tag = "expect-fail-on-{$serverVersion}";
 		$scenario = $scope->getScenario();
 		$feature = $scope->getFeature();
 		$result = $scope->getTestResult();

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -1427,7 +1427,7 @@ class FeatureContext implements Context {
 				file_put_contents($expectedFailureFile, $scenarioLine . PHP_EOL, FILE_APPEND);
 				return;
 			} elseif ($result->isPassed()) {
-				$unexpectedPassedFile = "$reportDir/unexpected-passed.txt";
+				$unexpectedPassedFile = "$reportDir/unexpected-passes.txt";
 				file_put_contents($unexpectedPassedFile, $scenarioLine . PHP_EOL, FILE_APPEND);
 				return;
 			} else {

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -106,15 +106,11 @@ class FeatureContext implements Context {
 	public function getServerVersion(): string {
 		$version = getenv('NEXTCLOUD_VERSION');
 		if ($version === false) {
-			$version = "";
+			return "";
 		}
-		// extract version number
-		$versionNumber = preg_replace('/\D/', '', $version);
-		if ($versionNumber === "") {
-			// if version number not found, return the provided version string.
-			return strtolower($version);
-		}
-		return "nc$versionNumber";
+		$version = preg_replace("/^stable/", "", $version);
+		$version = explode(".", $version)[0];
+		return "nc$version";
 	}
 
 	public function __construct(
@@ -1413,9 +1409,13 @@ class FeatureContext implements Context {
 		$lineNumber = $scenario->getLine();
 		$scenarioLine = "  - $keyword: $title ($featurePath:$lineNumber)";
 
-		$hasExpectFailTag = array_find($scenario->getTags(), function ($t) use ($tag) {
-			return str_starts_with($t, $tag);
-		});
+		$hasExpectFailTag = false;
+		foreach ($scenario->getTags() as $t) {
+			if (str_starts_with($t, $tag)) {
+				$hasExpectFailTag = true;
+				break;
+			}
+		}
 
 		if ($hasExpectFailTag && !$serverVersion) {
 			echo "[ERROR] Scenario has tag '$hasExpectFailTag' but could not determine server version. Use 'NEXTCLOUD_VERSION' env";

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -8,9 +8,11 @@
 
 use Behat\Behat\Context\Context;
 use Behat\Behat\Context\Environment\InitializedContextEnvironment;
+use Behat\Behat\Hook\Scope\AfterScenarioScope;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
+use Behat\Testwork\Tester\Result\TestResult;
 use GuzzleHttp\Client;
 use GuzzleHttp\Cookie\CookieJar;
 use GuzzleHttp\Exception\GuzzleException;
@@ -96,6 +98,23 @@ class FeatureContext implements Context {
 	 */
 	public function setResponse(?ResponseInterface $response): void {
 		$this->response = $response;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getServerVersion(): string {
+		$version = getenv('NEXTCLOUD_VERSION');
+		if ($version === false) {
+			$version = "";
+		}
+		// extract version number
+		$versionNumber = preg_replace('/\D/', '', $version);
+		if ($versionNumber === "") {
+			// if version number not found, return the provided version string.
+			return strtolower($version);
+		}
+		return "nc$versionNumber";
 	}
 
 	public function __construct(
@@ -1366,5 +1385,60 @@ class FeatureContext implements Context {
 			$this->theAdministratorDeletesTheGroup($groups);
 		}
 		$this->createdAppPasswords = [];
+	}
+
+	/**
+	 * @AfterScenario
+	 *
+	 * @param AfterScenarioScope $scope
+	 *
+	 * @return void
+	 */
+	public function checkExpectedFailure(AfterScenarioScope $scope): void {
+		$reportDir = dirname(dirname(__DIR__)) . "/reports";
+		if (!is_dir($reportDir)) {
+			mkdir($reportDir, 0777, true);
+		}
+
+		$serverVersion = $this->getServerVersion();
+		$tag = "expect-fail-on-$serverVersion";
+		$scenario = $scope->getScenario();
+		$feature = $scope->getFeature();
+		$result = $scope->getTestResult();
+
+		$featurePath = $feature->getFile();
+		$featurePath = "tests/" . explode("/tests/", $featurePath)[1];
+		$title = $scenario->getTitle();
+		$keyword = $scenario->getKeyword();
+		$lineNumber = $scenario->getLine();
+		$scenarioLine = "  - $keyword: $title ($featurePath:$lineNumber)";
+
+		$hasExpectFailTag = array_find($scenario->getTags(), function ($t) use ($tag) {
+			return str_starts_with($t, $tag);
+		});
+
+		if ($hasExpectFailTag && !$serverVersion) {
+			echo "[ERROR] Scenario has tag '$hasExpectFailTag' but could not determine server version. Use 'NEXTCLOUD_VERSION' env";
+		}
+
+		if ($scenario->hasTag($tag) || $scenario->hasTag("expect-fail")) {
+			if ($result->getResultCode() === TestResult::FAILED) {
+				$expectedFailureFile = "$reportDir/expected-failures.txt";
+				file_put_contents($expectedFailureFile, $scenarioLine . PHP_EOL, FILE_APPEND);
+				return;
+			} elseif ($result->isPassed()) {
+				$unexpectedPassedFile = "$reportDir/unexpected-passed.txt";
+				file_put_contents($unexpectedPassedFile, $scenarioLine . PHP_EOL, FILE_APPEND);
+				return;
+			} else {
+				$unexpectedFailureFile = "$reportDir/failures.txt";
+				file_put_contents($unexpectedFailureFile, $scenarioLine . PHP_EOL, FILE_APPEND);
+			}
+
+			echo "[ERROR] Scenario was expected to fail on server version '$serverVersion' but it did not.";
+		} elseif (!$result->isPassed()) {
+			$unexpectedFailureFile = "$reportDir/failures.txt";
+			file_put_contents($unexpectedFailureFile, $scenarioLine . PHP_EOL, FILE_APPEND);
+		}
 	}
 }

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -1409,10 +1409,10 @@ class FeatureContext implements Context {
 		$lineNumber = $scenario->getLine();
 		$scenarioLine = "  - $keyword: $title ($featurePath:$lineNumber)";
 
-		$hasExpectFailTag = false;
+		$hasExpectFailTag = "";
 		foreach ($scenario->getTags() as $t) {
 			if (str_starts_with($t, $tag)) {
-				$hasExpectFailTag = true;
+				$hasExpectFailTag = $t;
 				break;
 			}
 		}

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -4,18 +4,21 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 SCRIPT_DIR="$(dirname "$0")"
-BEHAT_CONFIG="${SCRIPT_DIR}/config/behat.yml"
 REPORTS_DIR="${SCRIPT_DIR}/reports"
 
 # options for behat command
-BEHAT_OPTIONS="-c $BEHAT_CONFIG -f pretty"
+BEHAT_OPTIONS=(-f pretty)
 
 if [ -n "$BEHAT_FILTER_TAGS" ]; then
-  BEHAT_OPTIONS="$BEHAT_OPTIONS --tags $BEHAT_FILTER_TAGS"
+  BEHAT_OPTIONS+=(--tags "$BEHAT_FILTER_TAGS")
 fi
 
 function run_test() {
-  composer run test:api -- $BEHAT_OPTIONS $BEHAT_FEATURE_PATH
+  local args=("${BEHAT_OPTIONS[@]}")
+  if [ -n "$BEHAT_FEATURE_PATH" ]; then
+    args+=("$BEHAT_FEATURE_PATH")
+  fi
+  composer run test:api -- "${args[@]}"
 }
 
 # cleanup reports directory
@@ -29,7 +32,7 @@ exit_code=$?
 if [ ! -f "$REPORTS_DIR/failures.txt" ] && [ ! -f "$REPORTS_DIR/unexpected-passes.txt" ]; then
   # pass the test execution if the exit code is non-zero
   # but there are expected failures defined.
-  if [ $exit_code -ne 0 ] && [ -s "$REPORTS_DIR/expected-failures.txt" ]; then
+  if [ $exit_code -eq 1 ] && [ -s "$REPORTS_DIR/expected-failures.txt" ]; then
     exit_code=0
   fi
 else
@@ -37,6 +40,7 @@ else
     echo ""
     echo "[ERROR] Failed scenarios:"
     cat "$REPORTS_DIR/failures.txt"
+    exit_code=1
   fi
   if [ -s "$REPORTS_DIR/unexpected-passes.txt" ]; then
     echo ""

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -16,7 +16,7 @@ function run_test() {
 }
 
 # cleanup reports directory
-rm -rf $REPORTS_DIR
+rm -rf "$REPORTS_DIR"
 
 # run the tests
 run_test

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+SCRIPT_DIR="$(dirname "$0")"
+BEHAT_CONFIG="${SCRIPT_DIR}/config/behat.yml"
+REPORTS_DIR="${SCRIPT_DIR}/reports"
+
+if [ -z "$BEHAT_FILTER_TAGS" ]; then
+  BEHAT_FILTER_TAGS=""
+fi
+
+function run_test() {
+  composer run test:api -- -c $BEHAT_CONFIG -f pretty --tags $BEHAT_FILTER_TAGS $BEHAT_FEATURE_PATH
+}
+
+# cleanup reports directory
+rm -rf $REPORTS_DIR
+
+# run the tests
+run_test
+
+exit_code=$?
+
+if [ $exit_code -ne 0 ]; then
+  echo "### [ TEST REPORTS ] ###"
+fi
+
+if [ ! -f "$REPORTS_DIR/failures.txt" ] && [ ! -f "$REPORTS_DIR/unexpected-passed.txt" ]; then
+  # pass the test execution if the exit code is non-zero
+  # but there are expected failures defined.
+  if [ $exit_code -ne 0 ] && [ -s "$REPORTS_DIR/expected-failures.txt" ]; then
+    exit_code=0
+  fi
+else
+  if [ -s "$REPORTS_DIR/failures.txt" ]; then
+    echo "[ERROR] Failed scenarios:"
+    cat "$REPORTS_DIR/failures.txt"
+    echo ""
+  fi
+  if [ -s "$REPORTS_DIR/unexpected-passed.txt" ]; then
+    echo "[ERROR] Unexpected passed scenarios:"
+    cat "$REPORTS_DIR/unexpected-passed.txt"
+    echo ""
+  fi
+fi
+
+if [ -s "$REPORTS_DIR/expected-failures.txt" ]; then
+  echo "[INFO] Expected failed scenarios:"
+  cat "$REPORTS_DIR/expected-failures.txt"
+fi
+
+exit $exit_code

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -7,12 +7,15 @@ SCRIPT_DIR="$(dirname "$0")"
 BEHAT_CONFIG="${SCRIPT_DIR}/config/behat.yml"
 REPORTS_DIR="${SCRIPT_DIR}/reports"
 
-if [ -z "$BEHAT_FILTER_TAGS" ]; then
-  BEHAT_FILTER_TAGS=""
+# options for behat command
+BEHAT_OPTIONS="-c $BEHAT_CONFIG -f pretty"
+
+if [ -n "$BEHAT_FILTER_TAGS" ]; then
+  BEHAT_OPTIONS="$BEHAT_OPTIONS --tags $BEHAT_FILTER_TAGS"
 fi
 
 function run_test() {
-  composer run test:api -- -c $BEHAT_CONFIG -f pretty --tags $BEHAT_FILTER_TAGS $BEHAT_FEATURE_PATH
+  composer run test:api -- $BEHAT_OPTIONS $BEHAT_FEATURE_PATH
 }
 
 # cleanup reports directory

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Jankari Tech Pvt. Ltd.
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 SCRIPT_DIR="$(dirname "$0")"
 BEHAT_CONFIG="${SCRIPT_DIR}/config/behat.yml"
 REPORTS_DIR="${SCRIPT_DIR}/reports"
@@ -20,11 +23,7 @@ run_test
 
 exit_code=$?
 
-if [ $exit_code -ne 0 ]; then
-  echo "### [ TEST REPORTS ] ###"
-fi
-
-if [ ! -f "$REPORTS_DIR/failures.txt" ] && [ ! -f "$REPORTS_DIR/unexpected-passed.txt" ]; then
+if [ ! -f "$REPORTS_DIR/failures.txt" ] && [ ! -f "$REPORTS_DIR/unexpected-passes.txt" ]; then
   # pass the test execution if the exit code is non-zero
   # but there are expected failures defined.
   if [ $exit_code -ne 0 ] && [ -s "$REPORTS_DIR/expected-failures.txt" ]; then
@@ -32,20 +31,23 @@ if [ ! -f "$REPORTS_DIR/failures.txt" ] && [ ! -f "$REPORTS_DIR/unexpected-passe
   fi
 else
   if [ -s "$REPORTS_DIR/failures.txt" ]; then
+    echo ""
     echo "[ERROR] Failed scenarios:"
     cat "$REPORTS_DIR/failures.txt"
-    echo ""
   fi
-  if [ -s "$REPORTS_DIR/unexpected-passed.txt" ]; then
-    echo "[ERROR] Unexpected passed scenarios:"
-    cat "$REPORTS_DIR/unexpected-passed.txt"
+  if [ -s "$REPORTS_DIR/unexpected-passes.txt" ]; then
     echo ""
+    echo "[ERROR] Unexpected passed scenarios:"
+    cat "$REPORTS_DIR/unexpected-passes.txt"
+    exit_code=1
   fi
 fi
 
 if [ -s "$REPORTS_DIR/expected-failures.txt" ]; then
+  echo ""
   echo "[INFO] Expected failed scenarios:"
   cat "$REPORTS_DIR/expected-failures.txt"
 fi
 
+echo ""
 exit $exit_code

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -5,6 +5,9 @@
 
 SCRIPT_DIR="$(dirname "$0")"
 REPORTS_DIR="${SCRIPT_DIR}/reports"
+EXPECTED_FAILURES_FILE="$REPORTS_DIR/expected-failures.txt"
+FAILURES_FILE="$REPORTS_DIR/failures.txt"
+UNEXPECTED_PASSES_FILE="$REPORTS_DIR/unexpected-passes.txt"
 
 # options for behat command
 BEHAT_OPTIONS=(-f pretty)
@@ -29,31 +32,31 @@ run_test
 
 exit_code=$?
 
-if [ ! -f "$REPORTS_DIR/failures.txt" ] && [ ! -f "$REPORTS_DIR/unexpected-passes.txt" ]; then
-  # pass the test execution if the exit code is non-zero
+if [ ! -f "$FAILURES_FILE" ] && [ ! -f "$UNEXPECTED_PASSES_FILE" ]; then
+  # pass the test execution if the exit code is 1
   # but there are expected failures defined.
-  if [ $exit_code -eq 1 ] && [ -s "$REPORTS_DIR/expected-failures.txt" ]; then
+  if [ $exit_code -eq 1 ] && [ -s "$EXPECTED_FAILURES_FILE" ]; then
     exit_code=0
   fi
 else
-  if [ -s "$REPORTS_DIR/failures.txt" ]; then
+  if [ -s "$FAILURES_FILE" ]; then
     echo ""
     echo "[ERROR] Failed scenarios:"
-    cat "$REPORTS_DIR/failures.txt"
+    cat "$FAILURES_FILE"
     exit_code=1
   fi
-  if [ -s "$REPORTS_DIR/unexpected-passes.txt" ]; then
+  if [ -s "$UNEXPECTED_PASSES_FILE" ]; then
     echo ""
     echo "[ERROR] Unexpected passed scenarios:"
-    cat "$REPORTS_DIR/unexpected-passes.txt"
+    cat "$UNEXPECTED_PASSES_FILE"
     exit_code=1
   fi
 fi
 
-if [ -s "$REPORTS_DIR/expected-failures.txt" ]; then
+if [ -s "$EXPECTED_FAILURES_FILE" ]; then
   echo ""
   echo "[INFO] Expected failed scenarios:"
-  cat "$REPORTS_DIR/expected-failures.txt"
+  cat "$EXPECTED_FAILURES_FILE"
 fi
 
 echo ""


### PR DESCRIPTION
## Description
Now we can mark scenarios as expected to fail for all or specific Nextcloud versions.

Special tags to be used:
```feature
@expect-fail - expect to fail on all Nextcloud versions

# @expect-fail
# Scenario: a test scenario

@expect-fail-on-nc<version> - expect to fail on specific Nextcloud version

# @expect-fail-on-nc33
# Scenario: a test scenario
```

Notable changes:
- A test runner is introduce to facilitate the test execution and the determination of execution pass/fail based on the test reports available.
- Env renamed `FEATURE_PATH` -> `BEHAT_FEATURE_PATH`
- New test reports dir:
  - `tests/acceptance/reports/failures.txt` - list of failed scenarios (does not include expected failures)
  - `tests/acceptance/reports/expected-failures.txt` - list of expected to fail scenarios
  - `tests/acceptance/reports/unexpected-passes.txt` - list of unexpectedly passed scenarios

Command exmaple:
```
NEXTCLOUD_BASE_URL=http://<nextcloud_host> \
NEXTCLOUD_VERSION=32 \
BEHAT_FEATURE_PATH=tests/acceptance/features/api/directUpload.feature:15 \
make api-test
```

Example ci builds:
- https://github.com/nextcloud/integration_openproject/actions/runs/27195907932/job/80287582770