### PR TITLE
fix: no OpenProject notification in Nextcloud dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fix: Wrong message "Unauthorized to connect to OpenProject" shown with valid SSO connection [#1018](https://github.com/nextcloud/integration_openproject/pull/1018)
+- Fix: No OpenProject notification in Nextcloud dashboard [#1045](https://github.com/nextcloud/integration_openproject/pull/1045)
 
 ## 3.0.0 - 2026-03-17
 

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -64,7 +64,6 @@ export default {
 			authMethod: loadState('integration_openproject', 'authorization_method'),
 			oidc_user: loadState('integration_openproject', 'oidc_user'),
 			settingsUrl: generateUrl('/settings/user/openproject'),
-			themingColor: OCA.Theming ? OCA.Theming.color.replace('#', '') : '0082C9',
 			windowVisibility: true,
 			itemMenu: {
 				markAsRead: {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- removed unused component state `themingColor` as `OCA.Theming` doesnot have `color` properties which broke the `notification`

Tested the solution in both `33` and `34`

## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://community.openproject.org/projects/NEX/work_packages/NEX-625/activity

## Screenshots (if appropriate):
<img width="1848" height="1001" alt="image" src="https://github.com/user-attachments/assets/c32ae9a8-629d-4b17-9fab-223091ad3356" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Updated `CHANGELOG.md` file
