### PR TITLE
fix: do not create OAuth client when setting up with OIDC auth method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fix: Unnecessary 404 requests when searching OpenProject work packages [#1070](https://github.com/nextcloud/integration_openproject/pull/1070)
 - Fix: OpenProject avatar remains stale [#1069](https://github.com/nextcloud/integration_openproject/pull/1069)
+- Fix: Do not create OAuth client when setting up with OIDC auth method [#1049](https://github.com/nextcloud/integration_openproject/pull/1049)
 
 ### Changed
 

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -651,29 +651,38 @@ class ConfigController extends Controller {
 			// check all required settings
 			$this->settingsService->validateAdminSettingsForm($values, true);
 
-			$status = $this->setIntegrationConfig($values);
-			$result = $this->recreateOauthClientInformation();
-			if ($status['oPOAuthTokenRevokeStatus'] !== '') {
-				$result['openproject_revocation_status'] = $status['oPOAuthTokenRevokeStatus'];
+			$setup = $this->setIntegrationConfig($values);
+			$response = ['status' => $setup['status']];
+
+			if ($values['authorization_method'] === OpenProjectAPIService::AUTH_METHOD_OAUTH) {
+				$response = \array_merge($response, $this->recreateOauthClientInformation());
 			}
-			if ($status['oPUserAppPassword'] !== null) {
-				$result['openproject_user_app_password'] = $status['oPUserAppPassword'];
+
+			if ($setup['oPOAuthTokenRevokeStatus']) {
+				$response['openproject_revocation_status'] = $setup['oPOAuthTokenRevokeStatus'];
 			}
-			return new DataResponse($result);
+			if ($setup['oPUserAppPassword']) {
+				$response['openproject_user_app_password'] = $setup['oPUserAppPassword'];
+			}
+			return new DataResponse($response);
 		} catch (OpenprojectGroupfolderSetupConflictException $e) {
 			return new DataResponse([
+				'status' => false,
 				'error' => $this->l->t($e->getMessage()),
 			], Http::STATUS_CONFLICT);
 		} catch (NoUserException $e) {
 			return new DataResponse([
+				'status' => false,
 				'error' => $this->l->t($e->getMessage())
 			], Http::STATUS_NOT_FOUND);
 		} catch (InvalidArgumentException $e) {
 			return new DataResponse([
+				'status' => false,
 				"error" => $e->getMessage()
 			], Http::STATUS_BAD_REQUEST);
 		} catch (\Exception $e) {
 			return new DataResponse([
+				'status' => false,
 				"error" => $e->getMessage()
 			], Http::STATUS_INTERNAL_SERVER_ERROR);
 		}

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -654,7 +654,7 @@ class ConfigController extends Controller {
 			$setup = $this->setIntegrationConfig($values);
 			$response = ['status' => $setup['status']];
 
-			if ($values['authorization_method'] === OpenProjectAPIService::AUTH_METHOD_OAUTH) {
+			if ($values['authorization_method'] === Application::AUTH_METHOD_OAUTH) {
 				$response = \array_merge($response, $this->recreateOauthClientInformation());
 			}
 

--- a/psalm.xml
+++ b/psalm.xml
@@ -21,6 +21,9 @@
 		<directory name="tests" />
 		<ignoreFiles>
 			<directory name="vendor" />
+			<directory name="tests/stub" />
+		</ignoreFiles>
+		<ignoreFiles allowMissingFiles="true">
 			<directory name="server/lib" />
 		</ignoreFiles>
 	</projectFiles>

--- a/tests/lib/Controller/ConfigControllerTest.php
+++ b/tests/lib/Controller/ConfigControllerTest.php
@@ -1941,14 +1941,13 @@ class ConfigControllerTest extends TestCase {
 			],
 			"with team folder" => [
 				"authMethod" => OpenProjectAPIService::AUTH_METHOD_OAUTH,
-				'settings' => [
-					...$defaultSettings,
+				'settings' => array_merge($defaultSettings, [
 					'authorization_method' => OpenProjectAPIService::AUTH_METHOD_OIDC,
 					'sso_provider_type' => SettingsService::NEXTCLOUDHUB_OIDC_PROVIDER_TYPE,
 					'targeted_audience_client_id' => 'test',
 					'setup_project_folder' => true,
 					'setup_app_password' => true,
-				],
+				]),
 				'response' => [
 					'status',
 					'openproject_user_app_password',
@@ -1992,7 +1991,7 @@ class ConfigControllerTest extends TestCase {
 			'openprojectAPIService' => $openprojectAPIServiceMock,
 			'userManager' => $userManagerMock,
 		];
-		$configController = $this->getConfigControllerMock([], $constructArgs);
+		$configController = $this->getConfigControllerMock(['setUpIntegration'], $constructArgs);
 
 		$response = $configController->setUpIntegration($settings);
 		$data = $response->getData();

--- a/tests/lib/Controller/ConfigControllerTest.php
+++ b/tests/lib/Controller/ConfigControllerTest.php
@@ -154,11 +154,10 @@ class ConfigControllerTest extends TestCase {
 		array $constructParams = [],
 	): MockObject {
 		$constructArgs = $this->getConfigControllerConstructArgs($constructParams);
-		$mock = $this->getMockBuilder(ConfigController::class)
+		return $this->getMockBuilder(ConfigController::class)
 			->setConstructorArgs($constructArgs)
 			->onlyMethods($mockMethods)
 			->getMock();
-		return $mock;
 	}
 
 	public function testOauthRedirectSuccess():void {
@@ -1875,8 +1874,8 @@ class ConfigControllerTest extends TestCase {
 	}
 
 	/**
-	 * @param array<string> $oldCreds
-	 * @param array<string> $credsToUpdate
+	 * @param array<string> $settings
+	 * @param array<string> $expectedSettings
 	 * @return void
 	 * @dataProvider integrationDefaultSettingsProvider
 	 */
@@ -1898,5 +1897,120 @@ class ConfigControllerTest extends TestCase {
 		]);
 		$configController = new ConfigController(...$constructArgs);
 		$configController->setUpIntegration($settings);
+	}
+
+	/**
+	 * @return array<mixed>
+	 */
+	public function setUpIntegrationSuccessProvider(): array {
+		$defaultSettings = [
+			'openproject_instance_url' => 'https://test.example.com',
+			'default_enable_navigation' => false,
+			'default_enable_unified_search' => false,
+			'setup_project_folder' => false,
+			'setup_app_password' => false,
+		];
+		return [
+			"complete oauth2 setup" => [
+				"authMethod" => OpenProjectAPIService::AUTH_METHOD_OAUTH,
+				'settings' => [
+					...$defaultSettings,
+					'authorization_method' => OpenProjectAPIService::AUTH_METHOD_OAUTH,
+					'openproject_client_id' => 'test',
+					'openproject_client_secret' => 'test',
+				],
+				'response' => [
+					'status',
+					'nextcloud_oauth_client_name',
+					'nextcloud_client_id',
+					'nextcloud_client_secret',
+					'openproject_redirect_uri',
+				],
+			],
+			"complete oidc setup" => [
+				"authMethod" => OpenProjectAPIService::AUTH_METHOD_OIDC,
+				'settings' => [
+					...$defaultSettings,
+					'authorization_method' => OpenProjectAPIService::AUTH_METHOD_OIDC,
+					'sso_provider_type' => SettingsService::NEXTCLOUDHUB_OIDC_PROVIDER_TYPE,
+					'targeted_audience_client_id' => 'test',
+				],
+				'response' => [
+					'status',
+				],
+			],
+			"with team folder" => [
+				"authMethod" => OpenProjectAPIService::AUTH_METHOD_OAUTH,
+				'settings' => [
+					...$defaultSettings,
+					'authorization_method' => OpenProjectAPIService::AUTH_METHOD_OIDC,
+					'sso_provider_type' => SettingsService::NEXTCLOUDHUB_OIDC_PROVIDER_TYPE,
+					'targeted_audience_client_id' => 'test',
+					'setup_project_folder' => true,
+					'setup_app_password' => true,
+				],
+				'response' => [
+					'status',
+					'openproject_user_app_password',
+				],
+			],
+		];
+	}
+
+	/**
+	 * @param string $authMethod
+	 * @param array<string> $settings
+	 * @param array<string> $responseProps
+	 * @return void
+	 * @dataProvider setUpIntegrationSuccessProvider
+	 */
+	public function testSetUpIntegrationSuccess(string $authMethod, array $settings, array $responseProps): void {
+		$userManagerMock = $this->createMock(IUserManager::class);
+		$userManagerMock->method('userExists')->willReturn(true);
+		$oauthMock = $this->createMock(OauthService::class);
+		$oauthMock->method('createNcOauthClient')->willReturn([
+			'id' => '1234',
+			'nextcloud_oauth_client_name' => 'Openproject Client',
+			'openproject_redirect_uri' => 'http://openproject.test/oauth/callback',
+			'nextcloud_client_id' => 'client_id',
+			'nextcloud_client_secret' => 'client_secret',
+		]);
+
+		$openprojectAPIServiceMock = $this->createMock(OpenProjectAPIService::class);
+		if ($settings['setup_project_folder']) {
+			$openprojectAPIServiceMock->expects($this->once())
+				->method('generateAppPasswordTokenForUser')
+				->willReturn('app_pass');
+		}
+		$settingsServiceMock = $this->createMock(SettingsService::class);
+		$settingsServiceMock->expects($this->once())
+			->method('validateAdminSettingsForm');
+
+		$constructArgs = [
+			'oauthService' => $oauthMock,
+			'settingsService' => $settingsServiceMock,
+			'openprojectAPIService' => $openprojectAPIServiceMock,
+			'userManager' => $userManagerMock,
+		];
+		$configController = $this->getConfigControllerMock([], $constructArgs);
+
+		$response = $configController->setUpIntegration($settings);
+		$data = $response->getData();
+
+		$this->assertEquals(Http::STATUS_OK, $response->getStatus());
+		$this->assertArrayHasKey('status', $data);
+
+		foreach ($responseProps as $prop) {
+			$this->assertArrayHasKey($prop, $data);
+		}
+		if ($authMethod === OpenProjectAPIService::AUTH_METHOD_OIDC) {
+			$this->assertArrayNotHasKey('nextcloud_oauth_client_name', $data);
+			$this->assertArrayNotHasKey('nextcloud_client_id', $data);
+			$this->assertArrayNotHasKey('nextcloud_client_secret', $data);
+			$this->assertArrayNotHasKey('openproject_redirect_uri', $data);
+		}
+		if (!$settings['setup_app_password']) {
+			$this->assertArrayNotHasKey('openproject_user_app_password', $data);
+		}
 	}
 }

--- a/tests/lib/Controller/ConfigControllerTest.php
+++ b/tests/lib/Controller/ConfigControllerTest.php
@@ -1874,8 +1874,8 @@ class ConfigControllerTest extends TestCase {
 	}
 
 	/**
-	 * @param array<string> $settings
-	 * @param array<string> $expectedSettings
+	 * @param array<string, bool|string> $settings
+	 * @param array<string, bool|string> $expectedSettings
 	 * @return void
 	 * @dataProvider integrationDefaultSettingsProvider
 	 */
@@ -1912,14 +1912,14 @@ class ConfigControllerTest extends TestCase {
 		];
 		return [
 			"complete oauth2 setup" => [
-				"authMethod" => OpenProjectAPIService::AUTH_METHOD_OAUTH,
+				"authMethod" => Application::AUTH_METHOD_OAUTH,
 				'settings' => [
 					...$defaultSettings,
-					'authorization_method' => OpenProjectAPIService::AUTH_METHOD_OAUTH,
+					'authorization_method' => Application::AUTH_METHOD_OAUTH,
 					'openproject_client_id' => 'test',
 					'openproject_client_secret' => 'test',
 				],
-				'response' => [
+				'responseProps' => [
 					'status',
 					'nextcloud_oauth_client_name',
 					'nextcloud_client_id',
@@ -1928,27 +1928,27 @@ class ConfigControllerTest extends TestCase {
 				],
 			],
 			"complete oidc setup" => [
-				"authMethod" => OpenProjectAPIService::AUTH_METHOD_OIDC,
+				"authMethod" => Application::AUTH_METHOD_OIDC,
 				'settings' => [
 					...$defaultSettings,
-					'authorization_method' => OpenProjectAPIService::AUTH_METHOD_OIDC,
-					'sso_provider_type' => SettingsService::NEXTCLOUDHUB_OIDC_PROVIDER_TYPE,
+					'authorization_method' => Application::AUTH_METHOD_OIDC,
+					'sso_provider_type' => Application::NEXTCLOUD_HUB_OIDC_PROVIDER_TYPE,
 					'targeted_audience_client_id' => 'test',
 				],
-				'response' => [
+				'responseProps' => [
 					'status',
 				],
 			],
 			"with team folder" => [
-				"authMethod" => OpenProjectAPIService::AUTH_METHOD_OAUTH,
+				"authMethod" => Application::AUTH_METHOD_OIDC,
 				'settings' => array_merge($defaultSettings, [
-					'authorization_method' => OpenProjectAPIService::AUTH_METHOD_OIDC,
-					'sso_provider_type' => SettingsService::NEXTCLOUDHUB_OIDC_PROVIDER_TYPE,
+					'authorization_method' => Application::AUTH_METHOD_OIDC,
+					'sso_provider_type' => Application::NEXTCLOUD_HUB_OIDC_PROVIDER_TYPE,
 					'targeted_audience_client_id' => 'test',
 					'setup_project_folder' => true,
 					'setup_app_password' => true,
 				]),
-				'response' => [
+				'responseProps' => [
 					'status',
 					'openproject_user_app_password',
 				],
@@ -1958,7 +1958,7 @@ class ConfigControllerTest extends TestCase {
 
 	/**
 	 * @param string $authMethod
-	 * @param array<string> $settings
+	 * @param array<string, bool|string> $settings
 	 * @param array<string> $responseProps
 	 * @return void
 	 * @dataProvider setUpIntegrationSuccessProvider
@@ -1967,19 +1967,29 @@ class ConfigControllerTest extends TestCase {
 		$userManagerMock = $this->createMock(IUserManager::class);
 		$userManagerMock->method('userExists')->willReturn(true);
 		$oauthMock = $this->createMock(OauthService::class);
-		$oauthMock->method('createNcOauthClient')->willReturn([
-			'id' => '1234',
-			'nextcloud_oauth_client_name' => 'Openproject Client',
-			'openproject_redirect_uri' => 'http://openproject.test/oauth/callback',
-			'nextcloud_client_id' => 'client_id',
-			'nextcloud_client_secret' => 'client_secret',
-		]);
+
+		if ($authMethod === Application::AUTH_METHOD_OAUTH) {
+			$oauthMock->expects($this->once())
+				->method('createNcOauthClient')->willReturn([
+					'id' => '1234',
+					'nextcloud_oauth_client_name' => 'Openproject Client',
+					'openproject_redirect_uri' => 'http://openproject.test/oauth/callback',
+					'nextcloud_client_id' => 'client_id',
+					'nextcloud_client_secret' => 'client_secret',
+				]);
+		} else {
+			$oauthMock->expects($this->never())
+				->method('createNcOauthClient');
+		}
 
 		$openprojectAPIServiceMock = $this->createMock(OpenProjectAPIService::class);
-		if ($settings['setup_project_folder']) {
+		if ($settings['setup_app_password']) {
 			$openprojectAPIServiceMock->expects($this->once())
 				->method('generateAppPasswordTokenForUser')
 				->willReturn('app_pass');
+		} else {
+			$openprojectAPIServiceMock->expects($this->never())
+				->method('generateAppPasswordTokenForUser');
 		}
 		$settingsServiceMock = $this->createMock(SettingsService::class);
 		$settingsServiceMock->expects($this->once())
@@ -1991,7 +2001,8 @@ class ConfigControllerTest extends TestCase {
 			'openprojectAPIService' => $openprojectAPIServiceMock,
 			'userManager' => $userManagerMock,
 		];
-		$configController = $this->getConfigControllerMock(['setUpIntegration'], $constructArgs);
+		$constructArgs = $this->getConfigControllerConstructArgs($constructArgs);
+		$configController = new ConfigController(...$constructArgs);
 
 		$response = $configController->setUpIntegration($settings);
 		$data = $response->getData();
@@ -2002,7 +2013,7 @@ class ConfigControllerTest extends TestCase {
 		foreach ($responseProps as $prop) {
 			$this->assertArrayHasKey($prop, $data);
 		}
-		if ($authMethod === OpenProjectAPIService::AUTH_METHOD_OIDC) {
+		if ($authMethod === Application::AUTH_METHOD_OIDC) {
 			$this->assertArrayNotHasKey('nextcloud_oauth_client_name', $data);
 			$this->assertArrayNotHasKey('nextcloud_client_id', $data);
 			$this->assertArrayNotHasKey('nextcloud_client_secret', $data);


### PR DESCRIPTION
## Description
Do not create OAuth client when setting up integration with oidc method.

Request:
```
POST /setup
{
...
}
```
1. for oauth method:
```yaml
200 OK
{
  "status": true,
  "nextcloud_oauth_client_name": "...",
  "nextcloud_client_id": "...",
  "nextcloud_client_secret": "...",
  "openproject_redirect_uri": "..."
}
```
2. for oidc method:
```yaml
200 OK
{
  "status": true
}
```

## Related Issue or Workpackage
- Fixes https://community.openproject.org/wp/NEX-628

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
