### PR TITLE
ci: on test update the error message 

### DIFF
--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -290,6 +290,7 @@ class FeatureContext implements Context {
 		// Skip if Nextcloud Docker container does not exist
 		exec("docker ps --format \"{{.Names}}\"", $containers);
 		if (!in_array('nextcloud', $containers)) {
+			echo "Docker container 'nextcloud' not found. Skipping user data deletion.\n";
 			return;
 		}
 
@@ -304,7 +305,7 @@ class FeatureContext implements Context {
 		$checkCmd = "docker exec nextcloud /bin/bash -c '[ -d $folder1 ] || [ -d $folder2 ]'";
 		exec($checkCmd, $checkOutput, $checkCode);
 		if ($checkCode === 1) {
-			echo "User data directory doesn't exist, skipping deletion.\n";
+			echo "User '$user' data directory doesn't exist, skipping deletion.\n";
 			if (count($checkOutput) > 0) {
 				echo "Command output: " . implode("\n", $checkOutput);
 			}

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -146,7 +146,7 @@ class FeatureContext implements Context {
 	/**
 	 * @Given user :user has been created
 	 */
-	public function userHasBeenCreated(string $user, string $displayName = null):void {
+	public function userHasBeenCreated(string $user, ?string $displayName = null):void {
 		$userAttributes['userid'] = $user;
 		$userAttributes['password'] = $this->getRegularUserPassword();
 		if ($displayName !== null) {
@@ -283,12 +283,24 @@ class FeatureContext implements Context {
 	private function deleteUserDataFromDocker(string $user): void {
 		$dataDir = "data";
 		// check if docker exists
-		if (!exec("docker --version")) {
-			echo "'docker' command not found. Skipping user data deletion.\n";
+		exec("docker --version 2>&1", $dockerVersionOutput, $dockerVersionCode);
+		if ($dockerVersionCode !== 0) {
+			echo "'docker' command not found or not executable. Skipping user data deletion.\n";
+			if (count($dockerVersionOutput) > 0) {
+				echo "Command output: " . implode("\n", $dockerVersionOutput) . "\n";
+			}
 			return;
 		}
+
 		// Skip if Nextcloud Docker container does not exist
-		exec("docker ps --format \"{{.Names}}\"", $containers);
+		exec("docker ps --format \"{{.Names}}\" 2>&1", $containers, $dockerPsCode);
+		if ($dockerPsCode !== 0) {
+			echo "Failed to list Docker containers. Skipping user data deletion.\n";
+			if (count($containers) > 0) {
+				echo "Command output: " . implode("\n", $containers) . "\n";
+			}
+			return;
+		}
 		if (!in_array('nextcloud', $containers)) {
 			echo "Docker container 'nextcloud' not found. Skipping user data deletion.\n";
 			return;
@@ -302,21 +314,32 @@ class FeatureContext implements Context {
 		$folder2 = "$dataDir/" . strtoupper($firstChar) . $restChars;
 
 		// check data folders
-		$checkCmd = "docker exec nextcloud /bin/bash -c '[ -d $folder1 ] || [ -d $folder2 ]'";
+		$checkCmd = "docker exec nextcloud /bin/bash -c '[ -d $folder1 ] || [ -d $folder2 ]' 2>&1";
 		exec($checkCmd, $checkOutput, $checkCode);
-		if ($checkCode === 1) {
-			echo "User '$user' data directory doesn't exist, skipping deletion.\n";
+		if ($checkCode !== 0) {
+			if ($checkCode === 1) {
+				echo "User '$user' data directory doesn't exist, skipping deletion.\n";
+			} else {
+				echo "Failed to check user data directory for '$user'.\n";
+				echo "Command: $checkCmd\n";
+				echo "Exit code: $checkCode\n";
+			}
 			if (count($checkOutput) > 0) {
-				echo "Command output: " . implode("\n", $checkOutput);
+				echo "Command output: " . implode("\n", $checkOutput) . "\n";
 			}
 			return;
 		}
+
 		// delete user data directory
-		$rmCmd = "docker exec nextcloud /bin/bash -c 'rm -rf $dataDir/$userPattern'";
+		$rmCmd = "docker exec nextcloud /bin/bash -c 'rm -rf $dataDir/$userPattern' 2>&1";
 		exec($rmCmd, $output, $rmCode);
 		if ($rmCode !== 0) {
 			echo "Failed to delete data directory of user '$user'.\n";
-			echo "Command output: " . implode("\n", $output);
+			echo "Command: $rmCmd\n";
+			echo "Exit code: $rmCode\n";
+			if (count($output) > 0) {
+				echo "Command output: " . implode("\n", $output) . "\n";
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
There is a flaky CI failure during user cleanup in the `API tests`. The current error messages do not provide enough information to help with debugging.

The failure did not occur while working on this PR, so the root cause could not be identified. This PR adds error messages to make it easier to identify the issue when the flaky failure happens again.

## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
```bash
  Scenario: get information of a non-existing file                                 # /home/runner/work/integration_openproject/integration_openproject/integration_openproject/tests/acceptance/features/api/getFileinfoByFileIDAPI.feature:220
    Given user "Carol" has been created                                            # FeatureContext::userHasBeenCreated()
      HTTP status code 400 is not the expected value 200
      Failed asserting thamatches wereaexpected, notpected 200.

````

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->




## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
