### PR TITLE
ci: fix nightly failure

### DIFF
--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -56,6 +56,7 @@ use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\Log\ILogFactory;
 use OCP\Security\ISecureRandom;
+use OCP\UserInterface;
 use phpmock\phpunit\PHPMock;
 use PhpPact\Consumer\InteractionBuilder;
 use PhpPact\Consumer\Model\Body\Binary;
@@ -4898,6 +4899,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 
 	public function dataProviderForIsOIDCUser(): array {
 		$backendMock = $this->getMockBuilder(OIDCBackend::class)->disableOriginalConstructor()->getMock();
+		$nonOidcBackend = $this->createMock(UserInterface::class);
 		return [
 			'has OIDCBackend class and OIDC user' => [
 				'hasOIDCBackend' => true,
@@ -4907,7 +4909,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 			],
 			'has OIDCBackend class but not OIDC user' => [
 				'hasOIDCBackend' => true,
-				'userBackend' => new \stdClass(),
+				'userBackend' => $nonOidcBackend,
 				'SSOProviderType' => 'external',
 				'expected' => false,
 			],
@@ -4919,7 +4921,7 @@ class OpenProjectAPIServiceTest extends TestCase {
 			],
 			'configure with Nextcloud Hub' => [
 				'hasOIDCBackend' => true,
-				'userBackend' => new \stdClass(),
+				'userBackend' => $nonOidcBackend,
 				'SSOProviderType' => OpenProjectAPIService::NEXTCLOUD_HUB_PROVIDER,
 				'expected' => true,
 			],


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR fixes the php unit test. Due to [changes on server](https://github.com/nextcloud/server/pull/61140)  where `IUser::getBackend()` is declared to return `?UserInterface` , but the tests were using `stdClass` instances for non-OIDC backends. This caused PHPUnit to throw an `IncompatibleReturnValueException` before the test logic could be executed.

## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Ci failure on step `php unit test`:


```zsh

There were 2 errors:

1) OCA\OpenProject\Service\OpenProjectAPIServiceTest::testIsOIDCUser with data set "has OIDCBackend class but not OIDC user" (true, stdClass Object (), 'external', false)
PHPUnit\Framework\MockObject\IncompatibleReturnValueException: Method getBackend may not return value of type stdClass, its declared return type is "?OCP\UserInterface"

/home/runner/work/integration_openproject/integration_openproject/integration_openproject/server/apps/integration_openproject/tests/lib/Service/OpenProjectAPIServiceTest.php:4945

2) OCA\OpenProject\Service\OpenProjectAPIServiceTest::testIsOIDCUser with data set "configure with Nextcloud Hub" (true, stdClass Object (), 'nextcloud_hub', true)
PHPUnit\Framework\MockObject\IncompatibleReturnValueException: Method getBackend may not return value of type stdClass, its declared return type is "?OCP\UserInterface"

/home/runner/work/integration_openproject/integration_openproject/integration_openproject/server/apps/integration_openproject/tests/lib/Service/OpenProjectAPIServiceTest.php:4945

--
``` 

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
