### PR TITLE
fix: openproject avatar remains stale due to long browser cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Fix: Unnecessary 404 requests when searching OpenProject work packages [#1061](https://github.com/nextcloud/integration_openproject/pull/1061)
+- Fix: OpenProject avatar remains stale [#1058](https://github.com/nextcloud/integration_openproject/pull/1058)
 
 ### Changed
 

--- a/lib/Controller/OpenProjectAPIController.php
+++ b/lib/Controller/OpenProjectAPIController.php
@@ -16,9 +16,9 @@ use OCA\OpenProject\Service\OpenProjectAPIService;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
-use OCP\AppFramework\Http\DataDisplayResponse;
 use OCP\AppFramework\Http\DataDownloadResponse;
 use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\Http\Response;
 use OCP\AppFramework\OCSController;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
@@ -70,7 +70,7 @@ class OpenProjectAPIController extends OCSController {
 	 *
 	 * @param string $userId
 	 * @param string $userName
-	 * @return DataDisplayResponse|DataDownloadResponse
+	 * @return DataDownloadResponse|Response
 	 * @throws \OCP\Files\NotFoundException
 	 * @throws \OCP\Files\NotPermittedException
 	 * @throws \OCP\Lock\LockedException
@@ -81,11 +81,20 @@ class OpenProjectAPIController extends OCSController {
 		$result = $this->openprojectAPIService->getOpenProjectAvatar(
 			$userId, $userName, $this->userId
 		);
-		$response = new DataDownloadResponse(
-			$result['avatar'], 'avatar', $result['type'] ?? ''
+
+		$etag = '"' . $result['etag'] . '"';
+		$headers = [
+			'Cache-Control' => 'no-cache',
+			'ETag' => $etag,
+		];
+		$ifNoneMatch = $this->request->getHeader('If-None-Match');
+		if ($ifNoneMatch && $ifNoneMatch === $etag) {
+			return new Response(Http::STATUS_NOT_MODIFIED, $headers);
+		}
+
+		return new DataDownloadResponse(
+			$result['avatar'], 'avatar', $result['type'], Http::STATUS_OK, $headers
 		);
-		$response->cacheFor(60 * 60 * 24);
-		return $response;
 	}
 
 	/**

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -345,7 +345,7 @@ class OpenProjectAPIService {
 	 * @param string $openprojectUserId
 	 * @param string $openprojectUserName
 	 * @param string $nextcloudUserId
-	 * @return array{avatar: string, type?: string}
+	 * @return array{avatar: string, type: string, etag: string}
 	 * @throws \OCP\Files\NotFoundException
 	 * @throws \OCP\Files\NotPermittedException
 	 * @throws \OCP\Lock\LockedException
@@ -394,12 +394,18 @@ class OpenProjectAPIService {
 			return [
 				'avatar' => $imageData,
 				'type' => $imageMimeType ,
+				'etag' => md5($imageData),
 			];
 		} catch (ServerException | ClientException | ConnectException | OpenprojectAvatarErrorException | Exception $e) {
 			$this->logger->debug('Error while getting OpenProject avatar for user ' . $openprojectUserId . ': ' . $e->getMessage(), ['app' => $this->appName]);
 			$avatar = $this->avatarManager->getGuestAvatar($openprojectUserName);
-			$avatarContent = $avatar->getFile(64)->getContent();
-			return ['avatar' => $avatarContent];
+			$avatarFile = $avatar->getFile(64);
+			$avatarContent = $avatarFile->getContent();
+			return [
+				'avatar' => $avatarContent,
+				'type' => $avatarFile->getMimeType(),
+				'etag' => md5($avatarContent),
+			];
 		}
 	}
 

--- a/tests/lib/Controller/OpenProjectAPIControllerTest.php
+++ b/tests/lib/Controller/OpenProjectAPIControllerTest.php
@@ -204,50 +204,67 @@ class OpenProjectAPIControllerTest extends TestCase {
 	}
 
 	/**
-	 *
-	 * @param string $authorizationMethod
-	 * @return void
-	 *
-	 * @dataProvider getAuthorizationMethodDataProvider
+	 * Data provider for testGetOpenProjectAvatar
 	 */
-	public function testGetOpenProjectAvatar(string $authorizationMethod) {
-		$service = $this->getMockBuilder(OpenProjectAPIService::class)
-			->disableOriginalConstructor()
-			->onlyMethods(['getOpenProjectAvatar', 'getAccessToken'])
-			->getMock();
-		$service
-			->method('getAccessToken')
-			->willReturn('123');
-		$service->expects($this->once())
-			->method('getOpenProjectAvatar')
-			->with(
-				'id', 'name'
-			)
-			->willReturn(['avatar' => 'some image data', 'type' => 'image/png']);
-		$controller = $this->getOpenProjectAPIControllerMock([
-			'openProjectAPIService' => $service,
-			'config' => $this->getConfigMock($authorizationMethod),
-		]);
-		$response = $controller->getOpenProjectAvatar('id', 'name');
-		$this->assertSame('some image data', $response->render());
-		$this->assertMatchesRegularExpression(
-			'/attachment; filename="?avatar"?/',
-			$response->getHeaders()["Content-Disposition"]
-		);
-		$this->assertSame(
-			"image/png",
-			$response->getHeaders()["Content-Type"]
-		);
+	public function getOpenProjectAvatarDataProvider(): array {
+		return [
+			'OAuth: returns 200 OK when If-None-Match differs from ETag' => [
+				'authorizationMethod' => OpenProjectAPIService::AUTH_METHOD_OAUTH,
+				'etag' => 'some etag',
+				'ifNoneMatch' => '"different etag"',
+				'contentType' => 'image/jpeg',
+				'expectedStatusCode' => Http::STATUS_OK,
+			],
+			'OAuth: returns 200 OK if If-None-Match is empty' => [
+				'authorizationMethod' => OpenProjectAPIService::AUTH_METHOD_OAUTH,
+				'etag' => 'some etag',
+				'ifNoneMatch' => '',
+				'contentType' => 'image/jpeg',
+				'expectedStatusCode' => Http::STATUS_OK
+			],
+			'OAuth: returns 304 Not Modified when If-None-Match matches ETag' => [
+				'authorizationMethod' => OpenProjectAPIService::AUTH_METHOD_OAUTH,
+				'etag' => 'some etag',
+				'ifNoneMatch' => '"some etag"',
+				'contentType' => 'image/jpeg',
+				'expectedStatusCode' => Http::STATUS_NOT_MODIFIED,
+			],
+			'OIDC: returns 200 OK when If-None-Match differs from ETag' => [
+				'authorizationMethod' => OpenProjectAPIService::AUTH_METHOD_OIDC,
+				'etag' => 'some etag',
+				'ifNoneMatch' => '"different etag"',
+				'contentType' => 'image/jpeg',
+				'expectedStatusCode' => Http::STATUS_OK,
+			],
+			'OIDC: returns 200 OK if If-None-Match is empty' => [
+				'authorizationMethod' => OpenProjectAPIService::AUTH_METHOD_OIDC,
+				'etag' => 'some etag',
+				'ifNoneMatch' => '',
+				'contentType' => 'image/jpeg',
+				'expectedStatusCode' => Http::STATUS_OK
+			],
+			'OIDC: returns 304 Not Modified when If-None-Match matches ETag' => [
+				'authorizationMethod' => OpenProjectAPIService::AUTH_METHOD_OIDC,
+				'etag' => 'some etag',
+				'ifNoneMatch' => '"some etag"',
+				'contentType' => 'image/jpeg',
+				'expectedStatusCode' => Http::STATUS_NOT_MODIFIED,
+			]
+		];
 	}
 
 	/**
 	 *
+	 * @dataProvider getOpenProjectAvatarDataProvider
 	 * @param string $authorizationMethod
+	 * @param string $etag
+	 * @param string $ifNoneMatch
+	 * @param string $contentType
+	 * @param int $expectedStatusCode
 	 * @return void
 	 *
-	 * @dataProvider getAuthorizationMethodDataProvider
 	 */
-	public function testGetOpenProjectAvatarNoType(string $authorizationMethod) {
+	public function testGetOpenProjectAvatar(string $authorizationMethod, string $etag, string $ifNoneMatch, string $contentType, int $expectedStatusCode): void {
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['getOpenProjectAvatar', 'getAccessToken'])
@@ -260,18 +277,44 @@ class OpenProjectAPIControllerTest extends TestCase {
 			->with(
 				'id', 'name'
 			)
-			->willReturn(['avatar' => 'some image data']);
+			->willReturn(['avatar' => 'some image data', 'type' => $contentType, 'etag' => $etag]);
+		$request = $this->createMock(IRequest::class);
+		$request->expects($this->once())->method('getHeader')->with('If-None-Match')->willReturn($ifNoneMatch);
 		$controller = $this->getOpenProjectAPIControllerMock([
 			'openProjectAPIService' => $service,
 			'config' => $this->getConfigMock($authorizationMethod),
+			'request' => $request,
 		]);
 		$response = $controller->getOpenProjectAvatar('id', 'name');
-		$this->assertSame('some image data', $response->render());
-		$this->assertMatchesRegularExpression(
-			'/attachment; filename="?avatar"?/',
-			$response->getHeaders()["Content-Disposition"]
+		$etag = '"' . $etag . '"';
+		$headers = $response->getHeaders();
+		$this->assertSame(
+			"no-cache",
+			$headers["Cache-Control"]
 		);
-		$this->assertEmpty($response->getHeaders()["Content-Type"]);
+		$this->assertSame(
+			$etag,
+			$headers["ETag"]
+		);
+		$this->assertSame(
+			$expectedStatusCode,
+			$response->getStatus()
+		);
+		if ($etag === $ifNoneMatch) {
+			$this->assertEmpty($response->render());
+			$this->assertArrayNotHasKey("Content-Disposition", $headers);
+			$this->assertArrayNotHasKey("Content-Type", $headers);
+		} else {
+			$this->assertSame('some image data', $response->render());
+			$this->assertMatchesRegularExpression(
+				'/attachment; filename="?avatar"?/',
+				$headers["Content-Disposition"]
+			);
+			$this->assertSame(
+				$contentType,
+				$headers["Content-Type"]
+			);
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Replaced `max-age=86400` with `Cache-Control: no-cache` so the browser always revalidates the avatar on each request
- Added `ETag` support based on `md5` of the `avatar content` so the browser can skip downloading the body if the avatar hasn't changed (`304 Not Modified`)

References: see [ref1](https://medium.com/@ironman8318/browser-caching-practical-etags-and-cache-control-6c7139bdcb39), [ref2](https://traffic-control-cdn.readthedocs.io/en/latest/basics/cache_revalidation.html)

## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://community.openproject.org/projects/NEX/work_packages/NEX-627/activity

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
