### PR TITLE
Ci: fix nightly upgrade testing

### DIFF
--- a/.github/workflows/app-upgrade.yml
+++ b/.github/workflows/app-upgrade.yml
@@ -174,5 +174,7 @@ jobs:
         working-directory: integration_openproject
         env:
           NEXTCLOUD_BASE_URL: http://localhost
+          NEXTCLOUD_VERSION: ${{ matrix.nextcloudVersion }}
+          BEHAT_FILTER_TAGS: '~@skip'
         run: |
           make api-test


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR add the env  in step `api-test`.

this has been tested:
https://github.com/nextcloud/integration_openproject/actions/runs/27537950673/job/81392122499?pr=1059


## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Nightly ci failure in api-test
```zsh
Error: RROR] Scenario has tag 'expect-fail-on-nc34' but could not determine server version. Set 'NEXTCLOUD_VERSION' env
```

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
