### PR TITLE
fix: unnecessary 404 return request during work package search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Fixed
+- Fix: Unnecessary 404 requests when searching OpenProject work packages [#1061](https://github.com/nextcloud/integration_openproject/pull/1061)
 
 ### Changed
 

--- a/src/components/tab/WorkPackage.vue
+++ b/src/components/tab/WorkPackage.vue
@@ -33,7 +33,6 @@
 					<NcAvatar class="item-avatar"
 						:size="23"
 						:url="workpackage.picture"
-						:user="workpackage.assignee"
 						:display-name="workpackage.assignee" />
 				</div>
 				<div class="row__assignee__assignee">

--- a/tests/jest/components/tab/WorkPackage.spec.js
+++ b/tests/jest/components/tab/WorkPackage.spec.js
@@ -29,4 +29,15 @@ describe('WorkPackage.vue', () => {
 		expect(workPackages).toMatchSnapshot()
 
 	})
+
+	it('passes displayName, size and url props to NcAvatar but does not pass the user props', () => {
+		const avatar = wrapper.findComponent({ name: 'NcAvatar' })
+		expect(avatar.exists()).toBe(true)
+		expect(avatar.props()).toMatchObject({
+			displayName: 'test',
+			size: expect.any(Number),
+			url: '/server/index.php/apps/integration_openproject/avatar?userId=1&userName=System',
+		})
+		expect(avatar.props('user')).toBeUndefined()
+	})
 })


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The `NcAvatar` component was trying to look up Nextcloud user information for OpenProject assignee names. This caused many failed requests to the following:

```console
GET /ocs/v2.php/apps/user_status/api/v1/statuses/{assignee}
```

These requests failed because OpenProject names are not Nextcloud users.

So, this PR removes the `user` prop which is not necessary in the `NcAvatar` component.
ref: https://nextcloud-vue-components.netlify.app/#/Components/NcAvatar



## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://community.openproject.org/projects/NEX/work_packages/NEX-626

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file

## Backport needed on
- `release/2.11`
- `release/3.1`
