### PR TITLE
feat: show new OpenProject work package display ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Show new OpenProject work package display ID if available [#1071](https://github.com/nextcloud/integration_openproject/pull/1071)
+
 ### Fixed
 
 ### Changed

--- a/src/components/tab/WorkPackage.vue
+++ b/src/components/tab/WorkPackage.vue
@@ -14,7 +14,7 @@
 				</div>
 			</div>
 			<div class="row__workpackage">
-				#{{ workpackage.id }} - {{ workpackage.project }}
+				{{ getWPDisplayID() }} - {{ workpackage.project }}
 			</div>
 		</div>
 		<div class="row">
@@ -99,6 +99,14 @@ export default {
 			} catch (e) {
 				// something went  wrong, leave the values as they are
 			}
+		},
+		getWPDisplayID() {
+			const id = this.workpackage.displayId
+			const isNumericId = /^\d+$/.test(id)
+			if (isNumericId) {
+				return '#' + id
+			}
+			return id
 		},
 		setWPStatusBorder() {
 			try {

--- a/src/components/tab/WorkPackage.vue
+++ b/src/components/tab/WorkPackage.vue
@@ -14,7 +14,7 @@
 				</div>
 			</div>
 			<div class="row__workpackage">
-				{{ getWPDisplayID() }} - {{ workpackage.project }}
+				{{ getWPDisplayID }} - {{ workpackage.project }}
 			</div>
 		</div>
 		<div class="row">
@@ -70,6 +70,16 @@ export default {
 		wpStatusFontColor: '#FFFFFF',
 		wpStatusBorder: '0',
 	}),
+	computed: {
+		getWPDisplayID() {
+			const id = this.workpackage.displayId
+			const isNumericId = /^\d+$/.test(id)
+			if (isNumericId) {
+				return '#' + id
+			}
+			return id
+		},
+	},
 	created() {
 		this.setWPTypeTextStroke()
 		this.setWPStatusFontColor()
@@ -99,14 +109,6 @@ export default {
 			} catch (e) {
 				// something went  wrong, leave the values as they are
 			}
-		},
-		getWPDisplayID() {
-			const id = this.workpackage.displayId
-			const isNumericId = /^\d+$/.test(id)
-			if (isNumericId) {
-				return '#' + id
-			}
-			return id
 		},
 		setWPStatusBorder() {
 			try {

--- a/src/utils/workpackageHelper.js
+++ b/src/utils/workpackageHelper.js
@@ -81,6 +81,7 @@ export const workpackageHelper = {
 
 		return {
 			id: workPackage.id,
+			displayId: workPackage.displayId || workPackage.id.toString(),
 			subject: workPackage.subject,
 			project: workPackage._links.project.title,
 			projectId,

--- a/tests/jest/components/tab/WorkPackage.spec.js
+++ b/tests/jest/components/tab/WorkPackage.spec.js
@@ -11,33 +11,60 @@ import workPackagesSearchResponse from '../../fixtures/workPackagesSearchRespons
 
 const localVue = createLocalVue()
 
+const selectors = {
+	wpItemSelector: '.workpackage',
+	wpInfoSelector: '.row__workpackage',
+}
+
 describe('WorkPackage.vue', () => {
 	let wrapper
-	const workPackagesSelector = '.workpackage'
-	beforeEach(() => {
+	describe('old work package id', () => {
+		const wp = structuredClone(workPackagesSearchResponse[0])
+		wp.displayId = `${wp.id}`
+		beforeEach(() => {
+			wrapper = shallowMount(WorkPackage, {
+				localVue,
+				propsData: {
+					workpackage: wp,
+				},
+			})
+		})
+		it('shows work packages information', async () => {
+			const workPackages = wrapper.find(selectors.wpItemSelector)
+			expect(workPackages.exists()).toBeTruthy()
+			expect(workPackages.find(selectors.wpInfoSelector).text()).toBe(`#${wp.displayId} - ${wp.project}`)
+			expect(workPackages.element).toMatchSnapshot()
+		})
 
-		wrapper = shallowMount(WorkPackage, {
-			localVue,
-			propsData: {
-				workpackage: workPackagesSearchResponse[0],
-			},
+		it('passes displayName, size and url props to NcAvatar but does not pass the user props', () => {
+			const avatar = wrapper.findComponent({ name: 'NcAvatar' })
+			expect(avatar.exists()).toBe(true)
+			expect(avatar.props()).toMatchObject({
+				displayName: wp.assignee,
+				size: expect.any(Number),
+				url: '/server/index.php/apps/integration_openproject/avatar?userId=1&userName=System',
+			})
+			expect(avatar.props('user')).toBeUndefined()
 		})
 	})
-	it('shows work packages information', async () => {
-		const workPackages = wrapper.find(workPackagesSelector)
-		expect(workPackages.exists()).toBeTruthy()
-		expect(workPackages).toMatchSnapshot()
 
-	})
+	describe('new work package id', () => {
+		const wp = structuredClone(workPackagesSearchResponse[0])
+		wp.displayId = `WP-${wp.id}`
 
-	it('passes displayName, size and url props to NcAvatar but does not pass the user props', () => {
-		const avatar = wrapper.findComponent({ name: 'NcAvatar' })
-		expect(avatar.exists()).toBe(true)
-		expect(avatar.props()).toMatchObject({
-			displayName: 'test',
-			size: expect.any(Number),
-			url: '/server/index.php/apps/integration_openproject/avatar?userId=1&userName=System',
+		beforeEach(() => {
+			wrapper = shallowMount(WorkPackage, {
+				localVue,
+				propsData: {
+					workpackage: wp,
+				},
+			})
 		})
-		expect(avatar.props('user')).toBeUndefined()
+		it('shows work packages information', async () => {
+			const workPackages = wrapper.find(selectors.wpItemSelector)
+			expect(workPackages.exists()).toBeTruthy()
+			expect(workPackages.find(selectors.wpInfoSelector).text()).toBe(`${wp.displayId} - ${wp.project}`)
+			expect(workPackages.element).toMatchSnapshot()
+		})
 	})
 })

--- a/tests/jest/components/tab/__snapshots__/SearchInput.spec.js.snap
+++ b/tests/jest/components/tab/__snapshots__/SearchInput.spec.js.snap
@@ -50,6 +50,7 @@ exports[`SearchInput.vue work packages select search list should only use the op
   "isSmartPicker": false,
   "workpackage": {
     "assignee": "some assignee",
+    "displayId": "1",
     "fileId": 111,
     "id": 1,
     "picture": "http://localhost/apps/integration_openproject/api/v1/avatar?userId=&userName=some%20assignee",

--- a/tests/jest/components/tab/__snapshots__/WorkPackage.spec.js.snap
+++ b/tests/jest/components/tab/__snapshots__/WorkPackage.spec.js.snap
@@ -1,10 +1,167 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`WorkPackage.vue shows work packages information 1`] = `
-VueWrapper {
-  "_emitted": {},
-  "_emittedByOrder": [],
-  "isFunctionalComponent": undefined,
-  "selector": ".workpackage",
-}
+exports[`WorkPackage.vue new work package id shows work packages information 1`] = `
+<div
+  class="workpackage"
+>
+  <div
+    class="row"
+  >
+    <div
+      class="row__status"
+      style="background-color: blue; border: 0px;"
+    >
+      <div
+        class="row__status__title"
+        style="color: rgb(255, 255, 255);"
+      >
+        
+				in-progress
+			
+      </div>
+    </div>
+     
+    <div
+      class="row__workpackage"
+    >
+      
+			WP-1 - test
+		
+    </div>
+  </div>
+   
+  <div
+    class="row"
+  >
+    <div
+      class="row__subject"
+    >
+      <span
+        class="row__subject__type"
+        style="color: red;"
+      >
+        
+				task
+			
+      </span>
+      
+			Organize work-packages
+		
+    </div>
+  </div>
+   
+  <div
+    class="row"
+  >
+    <div
+      class="row__assignee"
+    >
+      <div
+        class="row__assignee__avatar"
+      >
+        <ncavatar-stub
+          allowplaceholder="true"
+          class="item-avatar"
+          displayname="test"
+          menucontainer="body"
+          showuserstatus="true"
+          showuserstatuscompact="true"
+          size="23"
+          url="/server/index.php/apps/integration_openproject/avatar?userId=1&userName=System"
+        />
+      </div>
+       
+      <div
+        class="row__assignee__assignee"
+      >
+        
+				test
+			
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`WorkPackage.vue old work package id shows work packages information 1`] = `
+<div
+  class="workpackage"
+>
+  <div
+    class="row"
+  >
+    <div
+      class="row__status"
+      style="background-color: blue; border: 0px;"
+    >
+      <div
+        class="row__status__title"
+        style="color: rgb(255, 255, 255);"
+      >
+        
+				in-progress
+			
+      </div>
+    </div>
+     
+    <div
+      class="row__workpackage"
+    >
+      
+			#1 - test
+		
+    </div>
+  </div>
+   
+  <div
+    class="row"
+  >
+    <div
+      class="row__subject"
+    >
+      <span
+        class="row__subject__type"
+        style="color: red;"
+      >
+        
+				task
+			
+      </span>
+      
+			Organize work-packages
+		
+    </div>
+  </div>
+   
+  <div
+    class="row"
+  >
+    <div
+      class="row__assignee"
+    >
+      <div
+        class="row__assignee__avatar"
+      >
+        <ncavatar-stub
+          allowplaceholder="true"
+          class="item-avatar"
+          displayname="test"
+          menucontainer="body"
+          showuserstatus="true"
+          showuserstatuscompact="true"
+          size="23"
+          url="/server/index.php/apps/integration_openproject/avatar?userId=1&userName=System"
+        />
+      </div>
+       
+      <div
+        class="row__assignee__assignee"
+      >
+        
+				test
+			
+      </div>
+    </div>
+  </div>
+</div>
 `;


### PR DESCRIPTION
## Description
Show new OpenProject work package display id.
As per the requirement,
- numeric id will be displayed as `#<id>`. E.g.: `#123`
- new semantic id will be displayed as it is: `<id>`: #.g.: `ABC-123`
- links will still use the numeric work package id

| numeric id | semantic id |
|--|--|
|<img width="536" height="570" alt="Screenshot from 2026-06-23 14-28-02" src="https://github.com/user-attachments/assets/f127f59c-d4c9-43a7-a410-98d1f8c3fe00" /> | <img width="546" height="564" alt="Screenshot from 2026-06-23 14-33-20" src="https://github.com/user-attachments/assets/8e46f2f4-9f55-4908-a0c7-e7b443bb0f8a" />|
|<img width="536" height="570" alt="Screenshot from 2026-06-23 14-28-14" src="https://github.com/user-attachments/assets/73d12471-1152-44be-a3e3-55f8aa87f96c" /> | <img width="527" height="448" alt="Screenshot from 2026-06-23 14-33-31" src="https://github.com/user-attachments/assets/1786575a-93e0-4de6-b904-4121e333f3d4" />|
|<img width="684" height="601" alt="Screenshot from 2026-06-23 14-28-32" src="https://github.com/user-attachments/assets/2a6447ef-ce78-4da1-ae3b-108180cbe289" /> | <img width="684" height="601" alt="Screenshot from 2026-06-23 14-33-04" src="https://github.com/user-attachments/assets/092185ba-731f-442c-aa9c-8beede95b6a3" /> |


### For Testing
1. Setup integration (NC and OP 17)
2. Enable project-based semantic wp identifiers:
    `Administration -> Work packages -> Identifiers`

## Related Issue or Workpackage
- Resolves https://community.openproject.org/wp/NEX-675

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [x] Updated `CHANGELOG.md` file
