### PR TITLE
fix: handle invalid boolean auth-method value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix: OpenProject avatar remains stale [#1069](https://github.com/nextcloud/integration_openproject/pull/1069)
 - Fix: Do not create OAuth client while setting up with OIDC auth method [#1049](https://github.com/nextcloud/integration_openproject/pull/1049)
 - Fix: Do not create OAuth client while updating OIDC setup [#1075](https://github.com/nextcloud/integration_openproject/pull/1075)
+- Fix: Handle invalid boolean auth-method value [#1074](https://github.com/nextcloud/integration_openproject/pull/1074)
 
 ### Changed
 

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -102,7 +102,7 @@ class SettingsService {
 		$settingsToSkip = [];
 
 		if ($completeSetup) {
-			if (!\in_array('authorization_method', $settingsToCheck)) {
+			if (!\in_array('authorization_method', $settingsToCheck, true)) {
 				throw new InvalidArgumentException("'authorization_method' setting is missing");
 			}
 			$authMethod = $values['authorization_method'];

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -106,7 +106,8 @@ class SettingsService {
 				throw new InvalidArgumentException("'authorization_method' setting is missing");
 			}
 			$authMethod = $values['authorization_method'];
-			if (!\in_array($authMethod, [Application::AUTH_METHOD_OAUTH, Application::AUTH_METHOD_OIDC])) {
+			// do strict comparison
+			if (!\in_array($authMethod, self::GENERAL_ADMIN_SETTINGS['authorization_method'], true)) {
 				throw new InvalidArgumentException('Invalid authorization method');
 			}
 			if ($authMethod === Application::AUTH_METHOD_OAUTH) {
@@ -141,10 +142,10 @@ class SettingsService {
 
 			// check if all required settings are present
 			foreach ($settings as $key) {
-				if (\in_array($key, $settingsToSkip)) {
+				if (\in_array($key, $settingsToSkip, true)) {
 					continue;
 				}
-				if (!\in_array($key, $settingsToCheck)) {
+				if (!\in_array($key, $settingsToCheck, true)) {
 					// throw new InvalidArgumentException('Incomplete settings');
 					// for error message compatibility
 					throw new InvalidArgumentException('invalid key');
@@ -152,7 +153,7 @@ class SettingsService {
 			}
 			// check if there are no unknown settings
 			foreach ($settingsToCheck as $key) {
-				if (!in_array($key, $settings)) {
+				if (!in_array($key, $settings, true)) {
 					// throw new InvalidArgumentException("Unknown setting: $key");
 					// for error message compatibility
 					throw new InvalidArgumentException('invalid key');
@@ -169,7 +170,7 @@ class SettingsService {
 		} else {
 			$settings = $this->getAllSettings();
 			foreach ($settingsToCheck as $key) {
-				if (!in_array($key, $settings)) {
+				if (!in_array($key, $settings, true)) {
 					// throw new InvalidArgumentException("Unknown setting: $key");
 					// for error message compatibility
 					throw new InvalidArgumentException('invalid key');
@@ -206,7 +207,7 @@ class SettingsService {
 	 */
 	private function hasValidType(mixed $value, string|array $type): bool {
 		if (\is_array($type)) {
-			return \in_array($value, $type);
+			return \in_array($value, $type, true);
 		}
 		return $type === \gettype($value);
 	}

--- a/tests/lib/Service/SettingsServiceTest.php
+++ b/tests/lib/Service/SettingsServiceTest.php
@@ -82,10 +82,18 @@ class SettingsServiceTest extends TestCase {
 				"completeSetup" => true,
 				"message" => "'authorization_method' setting is missing",
 			],
-			"invalid 'authorization_method' value" => [
+			"invalid 'authorization_method' value - random string" => [
 				"configs" => [
 					"openproject_instance_url" => "http://test.op.example",
 					"authorization_method" => "test",
+				],
+				"completeSetup" => true,
+				"message" => "Invalid authorization method",
+			],
+			"invalid 'authorization_method' value - boolean true" => [
+				"configs" => [
+					"openproject_instance_url" => "http://test.op.example",
+					"authorization_method" => true,
 				],
 				"completeSetup" => true,
 				"message" => "Invalid authorization method",

--- a/tests/lib/Service/SettingsServiceTest.php
+++ b/tests/lib/Service/SettingsServiceTest.php
@@ -227,6 +227,21 @@ class SettingsServiceTest extends TestCase {
 				"completeSetup" => true,
 				"message" => "invalid key",
 			],
+			"unknown settings - boolean key" => [
+				"configs" => [
+					"openproject_instance_url" => "http://test.op.example",
+					"authorization_method" => Application::AUTH_METHOD_OAUTH,
+					"default_enable_navigation" => false,
+					"default_enable_unified_search" => false,
+					'openproject_client_id' => 'test',
+					'openproject_client_secret' => 'test',
+					"setup_project_folder" => false,
+					"setup_app_password" => false,
+					true => 'test', // unknown setting
+				],
+				"completeSetup" => true,
+				"message" => "invalid key",
+			],
 			"update action - unknown settings" => [
 				"configs" => [
 					"default_enable_navigation" => true,
@@ -238,6 +253,13 @@ class SettingsServiceTest extends TestCase {
 			"update action - invalid url" => [
 				"configs" => [
 					"openproject_instance_url" => "test", // invalid URL
+				],
+				"completeSetup" => false,
+				"message" => "invalid data",
+			],
+			"update action - invalid 'authorization_method' value - boolean true" => [
+				"configs" => [
+					"authorization_method" => true,
 				],
 				"completeSetup" => false,
 				"message" => "invalid data",


### PR DESCRIPTION
## Description
Do strict comparison while using `in_array` method.
Problematic code :-1: :
```php
in_array(true, ['e1', 'e2']);  // true ❌
```
Fix :+1::
```php
in_array(true, ['e1', 'e2'], true);  // false ✔️
```

## Related Issue or Workpackage
- Fixes https://community.openproject.org/wp/NEX-638

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [x] Updated `CHANGELOG.md` file
