### PR TITLE
fix: do not create OAuth client while updating OIDC setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fix: Unnecessary 404 requests when searching OpenProject work packages [#1070](https://github.com/nextcloud/integration_openproject/pull/1070)
 - Fix: OpenProject avatar remains stale [#1069](https://github.com/nextcloud/integration_openproject/pull/1069)
-- Fix: Do not create OAuth client when setting up with OIDC auth method [#1049](https://github.com/nextcloud/integration_openproject/pull/1049)
+- Fix: Do not create OAuth client while setting up with OIDC auth method [#1049](https://github.com/nextcloud/integration_openproject/pull/1049)
+- Fix: Do not create OAuth client while updating OIDC setup [#1075](https://github.com/nextcloud/integration_openproject/pull/1075)
 
 ### Changed
 

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -667,22 +667,18 @@ class ConfigController extends Controller {
 			return new DataResponse($response);
 		} catch (OpenprojectGroupfolderSetupConflictException $e) {
 			return new DataResponse([
-				'status' => false,
 				'error' => $this->l->t($e->getMessage()),
 			], Http::STATUS_CONFLICT);
 		} catch (NoUserException $e) {
 			return new DataResponse([
-				'status' => false,
 				'error' => $this->l->t($e->getMessage())
 			], Http::STATUS_NOT_FOUND);
 		} catch (InvalidArgumentException $e) {
 			return new DataResponse([
-				'status' => false,
 				"error" => $e->getMessage()
 			], Http::STATUS_BAD_REQUEST);
 		} catch (\Exception $e) {
 			return new DataResponse([
-				'status' => false,
 				"error" => $e->getMessage()
 			], Http::STATUS_INTERNAL_SERVER_ERROR);
 		}
@@ -702,23 +698,28 @@ class ConfigController extends Controller {
 		try {
 			// individual settings can be updated
 			$this->settingsService->validateAdminSettingsForm($values);
-			$status = $this->setIntegrationConfig($values);
-			$oauthClientInternalId = $this->config->getAppValue(Application::APP_ID, 'nc_oauth_client_id', '');
-			$result = [];
-			if ($status['oPOAuthTokenRevokeStatus'] !== '') {
-				$result['openproject_revocation_status'] = $status['oPOAuthTokenRevokeStatus'];
+			$setup = $this->setIntegrationConfig($values);
+			$response = ['status' => $setup['status']];
+			$authMethod = $this->config->getAppValue(Application::APP_ID, 'authorization_method', '');
+
+			if ($authMethod === Application::AUTH_METHOD_OIDC) {
+				return new DataResponse($response);
 			}
-			if ($status['oPUserAppPassword'] !== null) {
-				$result['openproject_user_app_password'] = $status['oPUserAppPassword'];
-			}
-			if ($oauthClientInternalId !== '') {
-				$id = (int)$oauthClientInternalId;
-				$result = array_merge($this->oauthService->getClientInfo($id), $result);
+
+			$oauthDbId = (int)$this->config->getAppValue(Application::APP_ID, 'nc_oauth_client_id', '');
+			if ($oauthDbId) {
+				$response = \array_merge($response, $this->oauthService->getClientInfo($oauthDbId));
 			} else {
-				// we will recreate new oauth when admin has reset it
-				$result = array_merge($this->recreateOauthClientInformation(), $result);
+				$response = \array_merge($response, $this->recreateOauthClientInformation());
 			}
-			return new DataResponse($result);
+
+			if ($setup['oPOAuthTokenRevokeStatus']) {
+				$response['openproject_revocation_status'] = $setup['oPOAuthTokenRevokeStatus'];
+			}
+			if ($setup['oPUserAppPassword']) {
+				$response['openproject_user_app_password'] = $setup['oPUserAppPassword'];
+			}
+			return new DataResponse($response);
 		} catch (OpenprojectGroupfolderSetupConflictException $e) {
 			return new DataResponse([
 				'error' => $this->l->t($e->getMessage()),

--- a/tests/lib/Controller/ConfigControllerTest.php
+++ b/tests/lib/Controller/ConfigControllerTest.php
@@ -2018,9 +2018,179 @@ class ConfigControllerTest extends TestCase {
 			$this->assertArrayNotHasKey('nextcloud_client_id', $data);
 			$this->assertArrayNotHasKey('nextcloud_client_secret', $data);
 			$this->assertArrayNotHasKey('openproject_redirect_uri', $data);
+		} else {
+			$this->assertArrayHasKey('nextcloud_oauth_client_name', $data);
+			$this->assertArrayHasKey('nextcloud_client_id', $data);
+			$this->assertArrayHasKey('nextcloud_client_secret', $data);
+			$this->assertArrayHasKey('openproject_redirect_uri', $data);
 		}
 		if (!$settings['setup_app_password']) {
 			$this->assertArrayNotHasKey('openproject_user_app_password', $data);
+		}
+	}
+
+	/**
+	 * @return array<mixed>
+	 */
+	public function updateIntegrationSuccessProvider(): array {
+		return [
+			"oauth2: OpenProject url and existing Nextcloud client" => [
+				"authMethod" => Application::AUTH_METHOD_OAUTH,
+				"oauthClientId" => 1,
+				'settings' => [
+					'openproject_instance_url' => 'https://new.test',
+				],
+				'responseProps' => [
+					'status',
+					'nextcloud_oauth_client_name',
+					'nextcloud_client_id',
+					'nextcloud_client_secret',
+					'openproject_redirect_uri',
+				],
+			],
+			"oauth2: OpenProject client and non-existing Nextcloud client" => [
+				"authMethod" => Application::AUTH_METHOD_OAUTH,
+				"oauthClientId" => 0,
+				'settings' => [
+					'openproject_client_id' => 'test-new',
+					'openproject_client_secret' => 'test-new',
+				],
+				'responseProps' => [
+					'status',
+					'nextcloud_oauth_client_name',
+					'nextcloud_client_id',
+					'nextcloud_client_secret',
+					'openproject_redirect_uri',
+				],
+			],
+			"oidc: provider type" => [
+				"authMethod" => Application::AUTH_METHOD_OIDC,
+				"oauthClientId" => 0,
+				'settings' => [
+					'sso_provider_type' => Application::EXTERNAL_OIDC_PROVIDER_TYPE,
+				],
+				'responseProps' => [
+					'status',
+				],
+			],
+			"oauth to oidc" => [
+				"authMethod" => Application::AUTH_METHOD_OAUTH,
+				"oauthClientId" => 0,
+				'settings' => [
+					'authorization_method' => Application::AUTH_METHOD_OIDC,
+				],
+				'responseProps' => [
+					'status',
+				],
+			],
+			"oidc to oauth" => [
+				"authMethod" => Application::AUTH_METHOD_OIDC,
+				"oauthClientId" => 0,
+				'settings' => [
+					'authorization_method' => Application::AUTH_METHOD_OAUTH,
+				],
+				'responseProps' => [
+					'status',
+					'nextcloud_oauth_client_name',
+					'nextcloud_client_id',
+					'nextcloud_client_secret',
+					'openproject_redirect_uri',
+				],
+			],
+		];
+	}
+
+	/**
+	 * @param string $authMethod
+	 * @param int $oauthClientId
+	 * @param array<string, bool|string> $settings
+	 * @param array<string> $responseProps
+	 * @return void
+	 * @dataProvider updateIntegrationSuccessProvider
+	 */
+	public function testUpdateIntegrationSuccess(string $authMethod, int $oauthClientId, array $settings, array $responseProps): void {
+		$userManagerMock = $this->createMock(IUserManager::class);
+		$userManagerMock->method('userExists')->willReturn(true);
+		$oauthMock = $this->createMock(OauthService::class);
+
+		// change in authorization method
+		if (isset($settings['authorization_method'])) {
+			$authMethod = $settings['authorization_method'];
+		}
+
+		$configMock = $this->createMock(IConfig::class);
+		$configMock
+			->method('getAppValue')
+			->willReturnMap([
+				[Application::APP_ID, 'authorization_method', '', $authMethod],
+				[Application::APP_ID, 'nc_oauth_client_id', '', $oauthClientId],
+			]);
+
+		if ($authMethod === Application::AUTH_METHOD_OAUTH) {
+			if ($oauthClientId) {
+				$oauthMock->expects($this->never())
+					->method('createNcOauthClient');
+				$oauthMock->expects($this->once())
+					->method('getClientInfo')->willReturn([
+						'id' => $oauthClientId,
+						'nextcloud_oauth_client_name' => 'Openproject Client',
+						'openproject_redirect_uri' => 'https://openproject.test/oauth/callback',
+						'nextcloud_client_id' => 'client_id_existing',
+						'nextcloud_client_secret' => 'client_secret_existing',
+					]);
+			} else {
+				$oauthMock->expects($this->never())
+					->method('getClientInfo');
+				$oauthMock->expects($this->once())
+					->method('createNcOauthClient')->willReturn([
+						'id' => '2',
+						'nextcloud_oauth_client_name' => 'Openproject Client',
+						'openproject_redirect_uri' => 'https://openproject.test/oauth/callback',
+						'nextcloud_client_id' => 'client_id',
+						'nextcloud_client_secret' => 'client_secret',
+					]);
+			}
+		} else {
+			$oauthMock->expects($this->never())
+				->method('createNcOauthClient');
+			$oauthMock->expects($this->never())
+				->method('getClientInfo');
+		}
+
+		$openprojectAPIServiceMock = $this->createMock(OpenProjectAPIService::class);
+		$settingsServiceMock = $this->createMock(SettingsService::class);
+		$settingsServiceMock->expects($this->once())
+			->method('validateAdminSettingsForm');
+
+		$constructArgs = [
+			'config' => $configMock,
+			'oauthService' => $oauthMock,
+			'settingsService' => $settingsServiceMock,
+			'openprojectAPIService' => $openprojectAPIServiceMock,
+			'userManager' => $userManagerMock,
+		];
+		$constructArgs = $this->getConfigControllerConstructArgs($constructArgs);
+		$configController = new ConfigController(...$constructArgs);
+
+		$response = $configController->updateIntegration($settings);
+		$data = $response->getData();
+
+		$this->assertEquals(Http::STATUS_OK, $response->getStatus());
+		$this->assertArrayHasKey('status', $data);
+
+		foreach ($responseProps as $prop) {
+			$this->assertArrayHasKey($prop, $data);
+		}
+		if ($authMethod === Application::AUTH_METHOD_OIDC) {
+			$this->assertArrayNotHasKey('nextcloud_oauth_client_name', $data);
+			$this->assertArrayNotHasKey('nextcloud_client_id', $data);
+			$this->assertArrayNotHasKey('nextcloud_client_secret', $data);
+			$this->assertArrayNotHasKey('openproject_redirect_uri', $data);
+		} else {
+			$this->assertArrayHasKey('nextcloud_oauth_client_name', $data);
+			$this->assertArrayHasKey('nextcloud_client_id', $data);
+			$this->assertArrayHasKey('nextcloud_client_secret', $data);
+			$this->assertArrayHasKey('openproject_redirect_uri', $data);
 		}
 	}
 }


### PR DESCRIPTION
## Description
Do not create OAuth client while updating oidc setup.

Request:
```
PATCH /setup
{
...
}
```
1. for oauth method:
```yaml
200 OK
{
  "status": true,
  "nextcloud_oauth_client_name": "...",
  "nextcloud_client_id": "...",
  "nextcloud_client_secret": "...",
  "openproject_redirect_uri": "..."
}
```
2. for oidc method:
```yaml
200 OK
{
  "status": true
}
```


## Related Issue or Workpackage
- Fixes https://community.openproject.org/wp/NEX-639

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [x] Updated `CHANGELOG.md` file
