### PR TITLE
fix: false `integration setup` status even after complete oauth setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix: Do not create OAuth client while updating OIDC setup [#1075](https://github.com/nextcloud/integration_openproject/pull/1075)
 - Fix: Handle invalid boolean auth-method value [#1074](https://github.com/nextcloud/integration_openproject/pull/1074)
 - Fix: Update OpenProject icon [#1078](https://github.com/nextcloud/integration_openproject/pull/1078)
+- Fix: False integration setup status even after complete oauth setup [#1086](https://github.com/nextcloud/integration_openproject/pull/1086)
 
 ## 2.11.3 - 2026-06-18
 

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -656,6 +656,7 @@ class ConfigController extends Controller {
 
 			if ($values['authorization_method'] === Application::AUTH_METHOD_OAUTH) {
 				$response = \array_merge($response, $this->recreateOauthClientInformation());
+				$response['status'] = OpenProjectAPIService::isAdminConfigOk($this->config);
 			}
 
 			if ($setup['oPOAuthTokenRevokeStatus']) {
@@ -711,6 +712,7 @@ class ConfigController extends Controller {
 				$response = \array_merge($response, $this->oauthService->getClientInfo($oauthDbId));
 			} else {
 				$response = \array_merge($response, $this->recreateOauthClientInformation());
+				$response['status'] = OpenProjectAPIService::isAdminConfigOk($this->config);
 			}
 
 			if ($setup['oPOAuthTokenRevokeStatus']) {


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->
- `nc_oauth_client_id` is set by `recreateOauthClientInformation()` function, but `isAdminConfigOk()` was being called before that, causing it to return `false` for `OAuth` setup even when the setup was complete. So updated the `setup status` again in response after `recreateOauthClientInformation()` function is called

## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://community.openproject.org/projects/NEX/work_packages/76456

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Updated `CHANGELOG.md` file
