### PR TITLE
ci: provide php version for 2.11 nightly ci

### DIFF
--- a/.github/workflows/nighlty-ci-release-2-branch.yml
+++ b/.github/workflows/nighlty-ci-release-2-branch.yml
@@ -16,6 +16,7 @@ jobs:
     with:
       branch: release/2.11
       nextcloud_versions: "31 32"
+      php_versions: "8.2 8.3 8.4"
 
   app-upgrade-test:
     uses: ./.github/workflows/app-upgrade.yml


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR added the php_version variable `8.2, 8.3, 8.4`  for the 2.11 nightly ci.

## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes ci failure: https://github.com/nextcloud/integration_openproject/actions/runs/29058716729/job/86255732474
<img width="1118" height="471" alt="image" src="https://github.com/user-attachments/assets/11ad39e9-74e1-40c8-9799-d0f20fe6c146" />


## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
