### PR TITLE
chore: backport changes from 3.1 release branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+### Changed
+
+### Removed
+
+## 3.1.1 - 2026-07-13
+
+### Fixed
+
 - Fix: App logo not seen in the App store section of Nextcloud [#1042](https://github.com/nextcloud/integration_openproject/pull/1042)
 - Fix: Unnecessary 404 requests when searching OpenProject work packages [#1061](https://github.com/nextcloud/integration_openproject/pull/1061)
 - Fix: OpenProject avatar remains stale [#1058](https://github.com/nextcloud/integration_openproject/pull/1058)
@@ -25,10 +33,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix: Handle invalid boolean auth-method value [#1079](https://github.com/nextcloud/integration_openproject/pull/1079)
 - Fix: False integration setup status even after complete oauth setup [#1088](https://github.com/nextcloud/integration_openproject/pull/1088)
 - Fix: Incompatible AMPF with the latest Nextcloud patch releases [#1098](https://github.com/nextcloud/integration_openproject/pull/1098)
-
-### Changed
-
-### Removed
 
 ## 3.1.0 - 2026-06-18
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -33,7 +33,7 @@ On the OpenProject end, users are able to:
 For more information on how to set up and use the OpenProject application, please refer to [integration setup guide](https://www.openproject.org/docs/system-admin-guide/integrations/nextcloud/) for administrators and [the user guide](https://www.openproject.org/docs/user-guide/nextcloud-integration/).
 	]]>
 	</description>
-	<version>4.0.0-dev</version>
+	<version>3.2.0-dev</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>OpenProject</namespace>

--- a/docs/release.md
+++ b/docs/release.md
@@ -82,4 +82,4 @@ On the current release branch:
 
 1. Add the release notes to the newly created [GitHub release](https://github.com/nextcloud/integration_openproject/releases).
 2. Merge the necessary commits from the release branch into the `master` branch.
-3. In the `master` branch, bump the app version to the next version (e.g.: `(X+1).0.0-dev`).
+3. In the `master` branch, bump the app version to the next minor version (e.g.: `X.(Y+1).0-dev`).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integration_openproject",
-  "version": "4.0.0-dev",
+  "version": "3.2.0-dev",
   "description": "OpenProject Integration",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Backport changes from `release/3.1` branch