### PR TITLE
fix: assign default value for oidc_provider for updateIntegration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fix: Default OIDC provider name not set while updating to Nextcloud Hub setup [#1130](https://github.com/nextcloud/integration_openproject/pull/1130)
+
 ### Changed
 
 ### Removed

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -698,6 +698,12 @@ class ConfigController extends Controller {
 	public function updateIntegration(?array $values): DataResponse {
 		try {
 			// individual settings can be updated
+			if (
+				isset($values['sso_provider_type']) && $values['sso_provider_type'] === Application::NEXTCLOUD_HUB_OIDC_PROVIDER_TYPE
+				&& (!\array_key_exists('oidc_provider', $values) || !$values['oidc_provider'])
+			) {
+				$values['oidc_provider'] = Application::NEXTCLOUD_HUB_OIDC_PROVIDER_LABEL;
+			}
 			$this->settingsService->validateAdminSettingsForm($values);
 			$setup = $this->setIntegrationConfig($values);
 			$response = ['status' => $setup['status']];

--- a/tests/lib/Controller/ConfigControllerTest.php
+++ b/tests/lib/Controller/ConfigControllerTest.php
@@ -1987,11 +1987,21 @@ class ConfigControllerTest extends TestCase {
 					'openproject_redirect_uri',
 				],
 			],
-			"oidc: provider type" => [
+			"oidc: external provider type" => [
 				"authMethod" => Application::AUTH_METHOD_OIDC,
 				"oauthClientId" => 0,
 				'settings' => [
 					'sso_provider_type' => Application::EXTERNAL_OIDC_PROVIDER_TYPE,
+				],
+				'responseProps' => [
+					'status',
+				],
+			],
+			"oidc: nextcloud hub provider type" => [
+				"authMethod" => Application::AUTH_METHOD_OIDC,
+				"oauthClientId" => 0,
+				'settings' => [
+					'sso_provider_type' => Application::NEXTCLOUD_HUB_OIDC_PROVIDER_TYPE,
 				],
 				'responseProps' => [
 					'status',
@@ -2083,8 +2093,14 @@ class ConfigControllerTest extends TestCase {
 
 		$openprojectAPIServiceMock = $this->createMock(OpenProjectAPIService::class);
 		$settingsServiceMock = $this->createMock(SettingsService::class);
+		$actualValues = null;
 		$settingsServiceMock->expects($this->once())
-			->method('validateAdminSettingsForm');
+			->method('validateAdminSettingsForm')->with(
+				$this->callback(function (array $values) use (&$actualValues) {
+					$actualValues = $values;
+					return true;
+				})
+			);
 
 		$constructArgs = [
 			'config' => $configMock,
@@ -2097,8 +2113,12 @@ class ConfigControllerTest extends TestCase {
 		$configController = new ConfigController(...$constructArgs);
 
 		$response = $configController->updateIntegration($settings);
-		$data = $response->getData();
+		if (isset($settings['sso_provider_type']) && $settings['sso_provider_type'] === Application::NEXTCLOUD_HUB_OIDC_PROVIDER_TYPE) {
+			$this->assertArrayHasKey('oidc_provider', $actualValues);
+			$this->assertSame(Application::NEXTCLOUD_HUB_OIDC_PROVIDER_LABEL, $actualValues['oidc_provider']);
+		}
 
+		$data = $response->getData();
 		$this->assertEquals(Http::STATUS_OK, $response->getStatus());
 		$this->assertArrayHasKey('status', $data);
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
backport https://github.com/nextcloud/integration_openproject/pull/1126

## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://community.openproject.org/wp/NEX-677

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [x] Updated `CHANGELOG.md` file
