### PR TITLE
fix: user shown connected in webUI after converting existing OAuth to SSO via setup endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fix: Default OIDC provider name not set while updating to Nextcloud Hub setup [#1126](https://github.com/nextcloud/integration_openproject/pull/1126)
+- Fix: User shown connected in webUI after converting existing OAuth to SSO via setup endpoint [#1132](https://github.com/nextcloud/integration_openproject/pull/1132)
 
 ### Changed
 

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -241,14 +241,9 @@ class ConfigController extends Controller {
 		}
 		// since we can now switch between both authorization method we need to know what we are resetting (either "oauth2" or "oidc" method)
 		// determines if we are switching from "oauth2" to "oidc" auth method
-		$runningOauth2Reset = (
-			key_exists('openproject_client_id', $values) &&
-			!$values['openproject_client_id'] &&
-			key_exists('openproject_client_secret', $values) &&
-			!$values['openproject_client_secret'] &&
-			$oldOpenProjectOauthUrl &&
-			$oldClientId &&
-			$oldClientSecret
+		$switchingOAuthToOIDC = (
+			$oldAuthMethod === Application::AUTH_METHOD_OAUTH && key_exists('authorization_method', $values) &&
+			$values['authorization_method'] === Application::AUTH_METHOD_OIDC
 		);
 
 		// determines if we are switching from "oidc" to "oauth2" auth method
@@ -309,13 +304,14 @@ class ConfigController extends Controller {
 		}
 
 		$this->config->deleteAppValue(Application::APP_ID, 'oPOAuthTokenRevokeStatus');
+		$resetOpenProjectClient = ((key_exists('openproject_client_id', $values) && $values['openproject_client_id'] !== $oldClientId) ||
+						(key_exists('openproject_client_secret', $values) && $values['openproject_client_secret'] !== $oldClientSecret));
 		if (
 			// when the OP client information has changed
-			(!$runningFullResetWithOIDCAuth && ((key_exists('openproject_client_id', $values) && $values['openproject_client_id'] !== $oldClientId) ||
-						(key_exists('openproject_client_secret', $values) && $values['openproject_client_secret'] !== $oldClientSecret))) ||
+			(!$runningFullResetWithOIDCAuth && $resetOpenProjectClient) ||
 			// when the OP client information is reset
 			$runningFullResetWithOAuth2Auth ||
-			$runningOauth2Reset
+			$switchingOAuthToOIDC
 		) {
 			$this->userManager->callForAllUsers(function (IUser $user) use (
 				$oldOpenProjectOauthUrl, $oldClientId, $oldClientSecret
@@ -378,8 +374,7 @@ class ConfigController extends Controller {
 		}
 
 		// when switching from "oauth2" to "oidc" authorization method
-		if (key_exists('authorization_method', $values) &&
-			$values['authorization_method'] === Application::AUTH_METHOD_OIDC && $runningOauth2Reset) {
+		if ($switchingOAuthToOIDC) {
 			$this->resetOauth2Configs();
 		}
 

--- a/tests/lib/Controller/ConfigControllerTest.php
+++ b/tests/lib/Controller/ConfigControllerTest.php
@@ -2007,9 +2007,19 @@ class ConfigControllerTest extends TestCase {
 					'status',
 				],
 			],
-			"oauth to oidc" => [
+			"oauth to oidc: no existing oauth client" => [
 				"authMethod" => Application::AUTH_METHOD_OAUTH,
 				"oauthClientId" => 0,
+				'settings' => [
+					'authorization_method' => Application::AUTH_METHOD_OIDC,
+				],
+				'responseProps' => [
+					'status',
+				],
+			],
+			"oauth to oidc: existing oauth client" => [
+				"authMethod" => Application::AUTH_METHOD_OAUTH,
+				"oauthClientId" => 1,
 				'settings' => [
 					'authorization_method' => Application::AUTH_METHOD_OIDC,
 				],
@@ -2043,22 +2053,59 @@ class ConfigControllerTest extends TestCase {
 	 * @dataProvider updateIntegrationSuccessProvider
 	 */
 	public function testUpdateIntegrationSuccess(string $authMethod, int $oauthClientId, array $settings, array $responseProps): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('testUser');
+
 		$userManagerMock = $this->createMock(IUserManager::class);
 		$userManagerMock->method('userExists')->willReturn(true);
+		$userManagerMock->method('callForAllUsers')
+			->willReturnCallback(function (callable $callback) use ($user) {
+				$callback($user);
+			});
+
 		$oauthMock = $this->createMock(OauthService::class);
 
+		$oldAuthMethod = $authMethod;
 		// change in authorization method
 		if (isset($settings['authorization_method'])) {
 			$authMethod = $settings['authorization_method'];
 		}
 
+		$configState = [
+			'authorization_method' => $oldAuthMethod,
+			'nc_oauth_client_id' => $oauthClientId,
+		];
+
+		$setAppValueCalls = [];
+		$deletedKeys = [];
+
 		$configMock = $this->createMock(IConfig::class);
-		$configMock
-			->method('getAppValue')
-			->willReturnMap([
-				[Application::APP_ID, 'authorization_method', '', $authMethod],
-				[Application::APP_ID, 'nc_oauth_client_id', '', $oauthClientId],
-			]);
+
+		$configMock->method('getAppValue')
+			->willReturnCallback(function ($app, $key, $default = '') use (&$configState) {
+				return $configState[$key] ?? $default;
+			});
+
+		$configMock->method('setAppValue')
+			->willReturnCallback(function ($app, $key, $value) use (&$configState, &$setAppValueCalls) {
+				$setAppValueCalls[] = [$app, $key, $value];
+				$configState[$key] = $value;
+				return true;
+			});
+
+		$configMock->method('deleteAppValue')
+			->willReturnCallback(function ($app, $key) use (&$configState, &$deletedKeys) {
+				$deletedKeys[] = $key;
+				unset($configState[$key]);
+				return true;
+			});
+
+		$deletedUserValues = [];
+		$configMock->method('deleteUserValue')
+			->willReturnCallback(function ($uid, $app, $key) use (&$deletedUserValues) {
+				$deletedUserValues[] = [$uid, $app, $key];
+				return true;
+			});
 
 		if ($authMethod === Application::AUTH_METHOD_OAUTH) {
 			if ($oauthClientId) {
@@ -2121,6 +2168,22 @@ class ConfigControllerTest extends TestCase {
 		$data = $response->getData();
 		$this->assertEquals(Http::STATUS_OK, $response->getStatus());
 		$this->assertArrayHasKey('status', $data);
+
+		if ($oldAuthMethod === Application::AUTH_METHOD_OAUTH
+			&& isset($settings['authorization_method'])
+			&& $settings['authorization_method'] === Application::AUTH_METHOD_OIDC) {
+			$this->assertContains([Application::APP_ID, 'openproject_client_id', ''], $setAppValueCalls);
+			$this->assertContains([Application::APP_ID, 'openproject_client_secret', ''], $setAppValueCalls);
+			$this->assertContains('nc_oauth_client_id', $deletedKeys);
+
+			$expectedDeletedKeys = ['token', 'login', 'user_id', 'user_name', 'refresh_token', 'token_expires_at'];
+			foreach ($expectedDeletedKeys as $key) {
+				$this->assertContains(
+					['testUser', Application::APP_ID, $key],
+					$deletedUserValues
+				);
+			}
+		}
 
 		foreach ($responseProps as $prop) {
 			$this->assertArrayHasKey($prop, $data);


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->
- updated `runningOauth2Reset` to  `switchingOAuthToOIDC` to correctly determine when switching from "oauth2" to "oidc" and then triggering `$this->clearUserInfo($userUID)` and `this->resetOauth2Configs()` for proper clean up of stale token, op client id, op client secret, nc client id and so on. 
- updated unit test `testUpdateIntegrationSuccess` for adding test coverage for the bug fix

## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://community.openproject.org/wp/NEX-678

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [x] Updated `CHANGELOG.md` file
