### PR TITLE
test: adapt DirectDownloadServiceTest for DirectController dependency changes

### DIFF
--- a/tests/lib/Service/DirectDownloadServiceTest.php
+++ b/tests/lib/Service/DirectDownloadServiceTest.php
@@ -13,6 +13,7 @@ use OCA\DAV\Db\DirectMapper;
 use OCA\OpenProject\AppInfo\Application;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Share\IManager;
 use OCP\Files\IRootFolder;
 use OCP\IRequest;
 use OCP\IURLGenerator;
@@ -70,7 +71,8 @@ class DirectDownloadServiceTest extends TestCase {
 			$c->get(ISecureRandom::class),
 			$c->get(ITimeFactory::class),
 			$c->get(IURLGenerator::class),
-			$c->get(IEventDispatcher::class)
+			$c->get(IEventDispatcher::class),
+			$c->get(IManager::class)
 		);
 	}
 

--- a/tests/lib/Service/DirectDownloadServiceTest.php
+++ b/tests/lib/Service/DirectDownloadServiceTest.php
@@ -8,17 +8,11 @@
 
 namespace OCA\OpenProject\Service;
 
+use OC\User\Session;
 use OCA\DAV\Controller\DirectController;
-use OCA\DAV\Db\DirectMapper;
 use OCA\OpenProject\AppInfo\Application;
-use OCP\AppFramework\Utility\ITimeFactory;
-use OCP\EventDispatcher\IEventDispatcher;
-use OCP\Share\IManager;
 use OCP\Files\IRootFolder;
-use OCP\IRequest;
-use OCP\IURLGenerator;
 use OCP\IUserManager;
-use OCP\Security\ISecureRandom;
 use PHPUnit\Framework\TestCase;
 
 class DirectDownloadServiceTest extends TestCase {
@@ -55,32 +49,27 @@ class DirectDownloadServiceTest extends TestCase {
 		$app = new Application();
 		$c = $app->getContainer();
 
-		/** @var DirectDownloadService directDownloadService */
+		$userManager = $c->get(IUserManager::class);
+		$user = $userManager->get(self::USER_ID);
+		$userSession = $c->get(Session::class);
+		$userSession->setUser($user);
+
+		/** @var DirectDownloadService $directDownloadService */
 		$directDownloadService = $c->get(DirectDownloadService::class);
 		$this->directDownloadService = $directDownloadService;
 
 		/** @var IRootFolder $root */
 		$root = $c->get(IRootFolder::class);
 		$this->userFolder = $root->getUserFolder(self::USER_ID);
-		$this->directController = new DirectController(
-			'dav',
-			$c->get(IRequest::class),
-			$root,
-			self::USER_ID,
-			$c->get(DirectMapper::class),
-			$c->get(ISecureRandom::class),
-			$c->get(ITimeFactory::class),
-			$c->get(IURLGenerator::class),
-			$c->get(IEventDispatcher::class),
-			$c->get(IManager::class)
-		);
+
+		$this->directController = $c->get(DirectController::class);
 	}
 
 	public static function tearDownAfterClass(): void {
 		$app = new Application();
 		$c = $app->getContainer();
 		$userManager = $c->get(IUserManager::class);
-		$user = $userManager->get('test');
+		$user = $userManager->get(self::USER_ID);
 		$user->delete();
 	}
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR updates `DirectDownloadServiceTest` to use the app container for `DirectController` instead of building it manually.



##  Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Due to the changes in the server PR (https://github.com/nextcloud/server/pull/62809), a new constructor was added. Because of this, the following error occurs in the Psalm tests:

```zsh
Error: tests/lib/Service/DirectDownloadServiceTest.php:64:29: TooFewArguments: Too few arguments for OCA\DAV\Controller\DirectController::__construct - expecting shareManager to be passed (see https://psalm.dev/025)
```


## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Updated `CHANGELOG.md` file
