### PR TITLE
fix: no OpenProject notification in Nextcloud dashboard

### DIFF
--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -64,7 +64,6 @@ export default {
 			authMethod: loadState('integration_openproject', 'authorization_method'),
 			oidc_user: loadState('integration_openproject', 'oidc_user'),
 			settingsUrl: generateUrl('/settings/user/openproject'),
-			themingColor: OCA.Theming ? OCA.Theming.color.replace('#', '') : '0082C9',
 			windowVisibility: true,
 			itemMenu: {
 				markAsRead: {


### PR DESCRIPTION
Port https://github.com/nextcloud/integration_openproject/pull/1045