### PR TITLE
fix: incorrect setup status while configuring integration with existing project folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fix: Default OIDC provider name not set while updating to Nextcloud Hub setup [#1126](https://github.com/nextcloud/integration_openproject/pull/1126)
 - Fix: User shown connected in webUI after converting existing OAuth to SSO via setup endpoint [#1132](https://github.com/nextcloud/integration_openproject/pull/1132)
+- Fix: Incorrect setup status while configuring integration with existing project folder [#1142](https://github.com/nextcloud/integration_openproject/pull/1142)
 
 ### Changed
 

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -985,7 +985,7 @@ class OpenProjectAPIService {
 	public static function isAdminConfigOk(IConfig $config): bool {
 		$authMethod = $config->getAppValue(Application::APP_ID, 'authorization_method');
 
-		if ($authMethod === Application::AUTH_METHOD_OAUTH) {
+		if (!$authMethod || $authMethod === Application::AUTH_METHOD_OAUTH) {
 			return self::isAdminConfigOkForOauth2($config);
 		}
 

--- a/tests/acceptance/features/api/oauthSetup.feature
+++ b/tests/acceptance/features/api/oauthSetup.feature
@@ -605,3 +605,57 @@ Feature: setup the integration with OAuth method
     # user "OpenProject" cannot make api request using the old app password
     When user "OpenProject" sends a "PROPFIND" request to "/remote.php/webdav" using old app password
     Then the HTTP status code should be "401"
+
+
+  Scenario: update settings with project folder
+    Given the administrator has set up the integration with the following settings:
+      """
+      {
+        "values": {
+          "openproject_instance_url": "http://some-host.de",
+          "openproject_client_id": "client-id",
+          "openproject_client_secret": "client-secret",
+          "default_enable_navigation": false,
+          "default_enable_unified_search": false,
+          "setup_project_folder": true,
+          "setup_app_password": true
+        }
+      }
+      """
+  	And the administrator has reset the integration setup
+  	When the administrator sends a PATCH request to the "setup" endpoint with this data:
+      """
+      {
+        "values": {
+		  "openproject_instance_url": "http://some-host.de",
+          "openproject_client_id": "client-id",
+          "openproject_client_secret": "client-secret",
+          "setup_project_folder": false,
+          "setup_app_password": true
+        }
+      }
+      """
+	Then the HTTP status code should be "200"
+	And the data of the response should match
+      """
+      {
+        "type": "object",
+        "required": [
+          "status",
+          "nextcloud_oauth_client_name",
+          "openproject_redirect_uri",
+          "nextcloud_client_id",
+          "openproject_user_app_password"
+        ],
+        "properties": {
+          "status": {"const": true},
+          "nextcloud_oauth_client_name": {"const": "OpenProject client"},
+          "openproject_redirect_uri": {"pattern": "^http:\/\/.*\/oauth_clients\/[A-Za-z0-9]+\/callback$"},
+          "nextcloud_client_id": {"pattern": "[A-Za-z0-9]+"},
+          "openproject_user_app_password": {"pattern": "[A-Za-z0-9]+"}
+        },
+        "not": {
+          "required": ["openproject_revocation_status"]
+        }
+      }
+      """

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -1268,6 +1268,18 @@ class FeatureContext implements Context {
 	}
 
 	/**
+	 * @Given the administrator has reset the integration setup
+	 *
+	 * @return void
+	 */
+	public function theAdministratorHasResetTheIntegrationSetup(): void {
+		$this->sendRequestsToAppEndpoint(
+			$this->adminUsername, $this->adminPassword, 'DELETE', 'setup'
+		);
+		$this->theHTTPStatusCodeShouldBe(200);
+	}
+
+	/**
 	 * @When /^the administrator sends a (PATCH|POST|DELETE) request to the "([^"]*)" endpoint$/
 	 *
 	 * @return void

--- a/tests/lib/Service/OpenProjectAPIServiceTest.php
+++ b/tests/lib/Service/OpenProjectAPIServiceTest.php
@@ -3496,6 +3496,28 @@ class OpenProjectAPIServiceTest extends TestCase {
 			[
 				'config' => [
 					'openproject_instance_url' => 'http://op.local',
+					'authorization_method' => '',
+					'openproject_client_id' => 'clientID',
+					'openproject_client_secret' => 'clientSecret',
+					'fresh_project_folder_setup' => false,
+					'nc_oauth_client_id' => 'ncClientID',
+				],
+				'completeSetup' => true,
+			],
+			[
+				'config' => [
+					'openproject_instance_url' => 'http://op.local',
+					'authorization_method' => 'false auth method',
+					'openproject_client_id' => 'clientID',
+					'openproject_client_secret' => 'clientSecret',
+					'fresh_project_folder_setup' => false,
+					'nc_oauth_client_id' => 'ncClientID',
+				],
+				'completeSetup' => false,
+			],
+			[
+				'config' => [
+					'openproject_instance_url' => 'http://op.local',
 					'authorization_method' => Application::AUTH_METHOD_OIDC,
 					'sso_provider_type' => Application::NEXTCLOUD_HUB_OIDC_PROVIDER_TYPE,
 					'oidc_provider' => 'Nextcloud',
@@ -3508,7 +3530,8 @@ class OpenProjectAPIServiceTest extends TestCase {
 				'config' => [
 					'authorization_method' => '',
 				],
-				'completeSetup' => false,],
+				'completeSetup' => false,
+			],
 		];
 	}
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- fall back to `oauth` validation when `authorization_method` is not set  because when the `authorization_method` is not provided while updating the oauth setup via `PATCH` API
   - `isAdminConfigOk` returns `false` due to missing authorization method and hence returning `"config_status_without_project_folder":false`
   -  `PATCH` `/setup` returns `{"status":false,....}`

## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://community.openproject.org/wp/NEX-683

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [x] Code changes
- [x] Unit tests added
- [x] Acceptance tests added
- [x] Updated `CHANGELOG.md` file
