### PR TITLE
feat: remove OpenProject token revocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Removed
 
+- Remove access token revocation and let OpenProject handle it [#1143](https://github.com/nextcloud/integration_openproject/pull/1143)
+
 ## 3.1.1 - 2026-07-13
 
 ### Fixed

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -303,7 +303,6 @@ class ConfigController extends Controller {
 			}
 		}
 
-		$this->config->deleteAppValue(Application::APP_ID, 'oPOAuthTokenRevokeStatus');
 		$resetOpenProjectClient = ((key_exists('openproject_client_id', $values) && $values['openproject_client_id'] !== $oldClientId) ||
 						(key_exists('openproject_client_secret', $values) && $values['openproject_client_secret'] !== $oldClientSecret));
 		if (
@@ -313,45 +312,8 @@ class ConfigController extends Controller {
 			$runningFullResetWithOAuth2Auth ||
 			$switchingOAuthToOIDC
 		) {
-			$this->userManager->callForAllUsers(function (IUser $user) use (
-				$oldOpenProjectOauthUrl, $oldClientId, $oldClientSecret
-			) {
-				$userUID = $user->getUID();
-				$accessToken = $this->config->getUserValue($userUID, Application::APP_ID, 'token', '');
-
-				// revoke is possible only when the user has the access token stored in the database
-				// plus, for a successful revoke, the old OP client information is also needed
-				// there may be cases where the software only have host url saved but not the client information
-				// in this case, the token is not revoked and just cleared if present in the database
-				if ($accessToken && $oldOpenProjectOauthUrl && $oldClientId && $oldClientSecret) {
-					try {
-						$this->openprojectAPIService->revokeUserOAuthToken(
-							$userUID,
-							$oldOpenProjectOauthUrl,
-							$accessToken,
-							$oldClientId,
-							$oldClientSecret
-						);
-						if (
-							$this->config->getAppValue(Application::APP_ID, 'oPOAuthTokenRevokeStatus', '') === ''
-						) {
-							$this->config->setAppValue(Application::APP_ID, 'oPOAuthTokenRevokeStatus', 'success');
-						}
-					} catch (ConnectException $e) {
-						$this->config->setAppValue(Application::APP_ID, 'oPOAuthTokenRevokeStatus', 'connection_error');
-						$this->logger->error(
-							'Error: ' . $e->getMessage(),
-							['app' => Application::APP_ID]
-						);
-					} catch (OpenprojectErrorException $e) {
-						$this->config->setAppValue(Application::APP_ID, 'oPOAuthTokenRevokeStatus', 'other_error');
-						$this->logger->error(
-							'Error: ' . $e->getMessage(),
-							['app' => Application::APP_ID]
-						);
-					}
-				}
-				$this->clearUserInfo($userUID);
+			$this->userManager->callForAllUsers(function (IUser $user) {
+				$this->clearUserInfo($user->getUID());
 			});
 		} elseif ($runningFullResetWithOIDCAuth || $runningOIDCReset) {
 			$this->resetOIDCConfigs();
@@ -384,14 +346,8 @@ class ConfigController extends Controller {
 			$this->resetOIDCConfigs();
 		}
 
-		// if the revoke has failed at least once, the last status is stored in the database
-		// this is not a neat way to give proper information about the revoke status
-		// TODO: find way to report every user's revoke status
-		$oPOAuthTokenRevokeStatus = $this->config->getAppValue(Application::APP_ID, 'oPOAuthTokenRevokeStatus', '');
-		$this->config->deleteAppValue(Application::APP_ID, 'oPOAuthTokenRevokeStatus');
 		return [
 			"status" => OpenProjectAPIService::isAdminConfigOk($this->config),
-			"oPOAuthTokenRevokeStatus" => $oPOAuthTokenRevokeStatus,
 			"oPUserAppPassword" => $appPassword,
 		];
 	}
@@ -654,9 +610,6 @@ class ConfigController extends Controller {
 				$response['status'] = OpenProjectAPIService::isAdminConfigOk($this->config);
 			}
 
-			if ($setup['oPOAuthTokenRevokeStatus']) {
-				$response['openproject_revocation_status'] = $setup['oPOAuthTokenRevokeStatus'];
-			}
 			if ($setup['oPUserAppPassword']) {
 				$response['openproject_user_app_password'] = $setup['oPUserAppPassword'];
 			}
@@ -716,9 +669,6 @@ class ConfigController extends Controller {
 				$response['status'] = OpenProjectAPIService::isAdminConfigOk($this->config);
 			}
 
-			if ($setup['oPOAuthTokenRevokeStatus']) {
-				$response['openproject_revocation_status'] = $setup['oPOAuthTokenRevokeStatus'];
-			}
 			if ($setup['oPUserAppPassword']) {
 				$response['openproject_user_app_password'] = $setup['oPUserAppPassword'];
 			}
@@ -752,11 +702,8 @@ class ConfigController extends Controller {
 	 */
 	public function resetIntegration(): DataResponse {
 		try {
-			$status = $this->setIntegrationConfig($this->settingsService->getDefaultSettings());
+			$this->setIntegrationConfig($this->settingsService->getDefaultSettings());
 			$result = ["status" => true];
-			if ($status['oPOAuthTokenRevokeStatus'] !== '') {
-				$result['openproject_revocation_status'] = $status['oPOAuthTokenRevokeStatus'];
-			}
 			return new DataResponse($result);
 		} catch (\Exception $e) {
 			return new DataResponse([

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -245,6 +245,10 @@ class ConfigController extends Controller {
 			$oldAuthMethod === Application::AUTH_METHOD_OAUTH && key_exists('authorization_method', $values) &&
 			$values['authorization_method'] === Application::AUTH_METHOD_OIDC
 		);
+		$switchingOIDCToOAuth = (
+			$oldAuthMethod === Application::AUTH_METHOD_OIDC && key_exists('authorization_method', $values) &&
+			$values['authorization_method'] === Application::AUTH_METHOD_OAUTH
+		);
 
 		// determines if we are switching from "oidc" to "oauth2" auth method
 		$runningOIDCReset = false;
@@ -304,18 +308,17 @@ class ConfigController extends Controller {
 		}
 
 		$resetOpenProjectClient = ((key_exists('openproject_client_id', $values) && $values['openproject_client_id'] !== $oldClientId) ||
-						(key_exists('openproject_client_secret', $values) && $values['openproject_client_secret'] !== $oldClientSecret));
-		if (
-			// when the OP client information has changed
-			(!$runningFullResetWithOIDCAuth && $resetOpenProjectClient) ||
-			// when the OP client information is reset
-			$runningFullResetWithOAuth2Auth ||
-			$switchingOAuthToOIDC
-		) {
+			(key_exists('openproject_client_secret', $values) && $values['openproject_client_secret'] !== $oldClientSecret));
+
+		if ($resetOpenProjectClient || $runningFullResetWithOAuth2Auth || $switchingOAuthToOIDC) {
 			$this->userManager->callForAllUsers(function (IUser $user) {
 				$this->clearUserInfo($user->getUID());
 			});
-		} elseif ($runningFullResetWithOIDCAuth || $runningOIDCReset) {
+
+			if ($switchingOAuthToOIDC || $runningFullResetWithOAuth2Auth) {
+				$this->resetOauth2Configs();
+			}
+		} elseif ($runningFullResetWithOIDCAuth || $runningOIDCReset || $switchingOIDCToOAuth) {
 			$this->resetOIDCConfigs();
 			$this->userManager->callForAllUsers(function (IUser $user) {
 				$this->clearUserInfo($user->getUID());
@@ -333,17 +336,6 @@ class ConfigController extends Controller {
 			// for other cases when api has key 'setup_app_password' and 'setup_project_folder' we set it to false
 			// assuming user has either fully set the integration or partially without project folder/app password
 			$this->config->setAppValue(Application::APP_ID, 'fresh_project_folder_setup', "0");
-		}
-
-		// when switching from "oauth2" to "oidc" authorization method
-		if ($switchingOAuthToOIDC) {
-			$this->resetOauth2Configs();
-		}
-
-		// when switching from "oidc" to "oauth2" authorization method
-		if (key_exists('authorization_method', $values) &&
-			$values['authorization_method'] === Application::AUTH_METHOD_OAUTH && $runningOIDCReset) {
-			$this->resetOIDCConfigs();
 		}
 
 		return [

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -8,14 +8,12 @@
 
 namespace OCA\OpenProject\Controller;
 
-use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\GuzzleException;
 use InvalidArgumentException;
 use OC\User\NoUserException;
 use OCA\OAuth2\Controller\SettingsController;
 use OCA\OAuth2\Exceptions\ClientNotFoundException;
 use OCA\OpenProject\AppInfo\Application;
-use OCA\OpenProject\Exception\OpenprojectErrorException;
 use OCA\OpenProject\Exception\OpenprojectGroupfolderSetupConflictException;
 use OCA\OpenProject\Service\OauthService;
 use OCA\OpenProject\Service\OpenProjectAPIService;

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -313,7 +313,7 @@ class ConfigController extends Controller {
 				$this->clearUserInfo($user->getUID());
 			});
 
-			if ($switchingOAuthToOIDC || $runningFullResetWithOAuth2Auth) {
+			if ($switchingOAuthToOIDC) {
 				$this->resetOauth2Configs();
 			}
 		} elseif ($runningFullResetWithOIDCAuth || $runningOIDCReset || $switchingOIDCToOAuth) {

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -1012,54 +1012,6 @@ class OpenProjectAPIService {
 	}
 
 	/**
-	 * Sends a POST request to the OpenProject API server to revoke an OAuth token for the provided client
-	 *
-	 * @param string $userUID the uid of the user to revoke the token for
-	 * @param string $openProjectUrl the url of the openproject instance
-	 * @param string $accessToken the refresh token to be revoked
-	 * @param string $clientId the client id of the OAuth app
-	 * @param string $clientSecret the client secret of the OAuth app
-	 *
-	 * @return void
-	 * @throws OpenprojectErrorException
-	 * @throws ConnectException
-	 */
-	public function revokeUserOAuthToken(
-		string $userUID,
-		string $openProjectUrl,
-		string $accessToken,
-		string $clientId,
-		string $clientSecret
-	): void {
-		$options = [
-			'headers' => [
-				'User-Agent' => 'Nextcloud OpenProject integration',
-				'Content-Type' => 'application/x-www-form-urlencoded',
-				'Authorization' => 'Basic ' . \base64_encode($clientId . ':' . $clientSecret)
-			]
-		];
-		try {
-			$response = $this->client->post(
-				rtrim($openProjectUrl, "/") . '/oauth/revoke' . '?token=' . $accessToken,
-				$options
-			);
-			$body = $response->getBody();
-			$respCode = $response->getStatusCode();
-			if ($respCode !== 200) {
-				throw new OpenprojectErrorException('Failed to revoke token in OpenProject for user "'. $userUID . '".\nResponse body: "' . $body . '"');
-			}
-		} catch (ConnectException $e) {
-			throw new ConnectException(
-				'Could not revoke token in OpenProject for user "' .
-				$userUID . '".\n Message: "' . $e->getMessage() . '"',
-				$e->getRequest()
-			);
-		} catch (ServerException | ClientException | Exception $e) {
-			throw new OpenprojectErrorException('Could not revoke token in OpenProject for user "' . $userUID . '".\n Message: "' . $e->getMessage() . '"');
-		}
-	}
-
-	/**
 	 * @throws OpenprojectGroupfolderSetupConflictException
 	 */
 	public function isSystemReadyForProjectFolderSetUp(): bool {

--- a/src/components/admin/FormOAuthSettings.vue
+++ b/src/components/admin/FormOAuthSettings.vue
@@ -190,7 +190,6 @@ export default {
 			openprojectFormOrder: ADMIN_SETTINGS_FORM.openprojectOauth.order.toString(),
 			nextcloudFormOrder: ADMIN_SETTINGS_FORM.nextcloudOauth.order.toString(),
 			loading: false,
-			openprojectTokenRevokeStatus: null,
 			// state that holds the current changed form values
 			currentOpenProjectForm: {
 				clientId: this.oauthSettings.openproject_client_id || '',
@@ -301,30 +300,6 @@ export default {
 		setNextcloudFormToEditMode() {
 			this.setNextcloudFormMode(F_MODES.EDIT)
 		},
-		notifyOpenProjectTokenRevoke() {
-			switch (this.openprojectTokenRevokeStatus) {
-			case 'connection_error':
-				showError(
-					t(
-						'integration_openproject',
-						'Failed to perform revoke request due to connection error with the OpenProject server',
-					),
-				)
-				break
-			case 'other_error':
-				showError(
-					t('integration_openproject', "Failed to revoke some users' OpenProject OAuth access tokens"),
-				)
-				break
-			case 'success':
-				showSuccess(
-					t('integration_openproject', "Successfully revoked users' OpenProject OAuth access tokens"),
-				)
-				break
-			default:
-				break
-			}
-		},
 		async createNextcloudClient() {
 			try {
 				const response = await createNextcloudOAuthClient()
@@ -342,11 +317,10 @@ export default {
 		async saveOpenProjectClient() {
 			this.loading = true
 			try {
-				const response = await saveAdminConfig({
+				await saveAdminConfig({
 					openproject_client_id: this.currentOpenProjectForm.clientId,
 					openproject_client_secret: this.currentOpenProjectForm.clientSecret,
 				})
-				this.openprojectTokenRevokeStatus = response?.data?.oPOAuthTokenRevokeStatus
 				this.savedOpenProjectForm = structuredClone(this.currentOpenProjectForm)
 				this.setOpenProjectFromToViewMode()
 				this.$emit('formcomplete', this.markOpenProjectFormComplete)
@@ -357,12 +331,10 @@ export default {
 					await this.createNextcloudClient()
 				}
 			} catch (error) {
-				this.openprojectTokenRevokeStatus = null
 				const errorMessage = error?.response?.data?.error || error?.message
 				const message = t('integration_openproject', 'Failed to save OpenProject admin options')
 				showError(message + ': ' + errorMessage)
 			}
-			this.notifyOpenProjectTokenRevoke()
 			this.loading = false
 		},
 		resetOpenProjectClient() {

--- a/tests/js/components/admin/FormOAuthSettings.spec.js
+++ b/tests/js/components/admin/FormOAuthSettings.spec.js
@@ -335,7 +335,6 @@ describe('Component: FormOAuthSettings', () => {
 						}))
 						const wrapper = getWrapper()
 						const spyCreateNextcloudClient = vi.spyOn(wrapper.vm, 'createNextcloudClient')
-						const spyNotifyOpenProjectTokenRevoke = vi.spyOn(wrapper.vm, 'notifyOpenProjectTokenRevoke')
 						wrapper.findComponent(selectors.opClientIdInput).vm.$emit('update:modelValue', opClientId)
 						wrapper.findComponent(selectors.opClientSecretInput).vm.$emit('update:modelValue', opClientSecret)
 						wrapper.findComponent(selectors.opSaveButton).vm.$emit('click')
@@ -362,7 +361,6 @@ describe('Component: FormOAuthSettings', () => {
 						expect(spyCreateNextcloudClient).toHaveBeenCalledTimes(1)
 						expect(showSuccess).toHaveBeenCalledTimes(1)
 						expect(showError).toHaveBeenCalledTimes(0)
-						expect(spyNotifyOpenProjectTokenRevoke).toHaveBeenCalledTimes(1)
 
 						expect(wrapper.vm.nextcloudFormMode).toBe(F_MODES.EDIT)
 						expect(wrapper.find(selectors.ncClientIdInput).exists()).toBe(true)
@@ -390,7 +388,6 @@ describe('Component: FormOAuthSettings', () => {
 							},
 						})
 						const spyCreateNextcloudClient = vi.spyOn(wrapper.vm, 'createNextcloudClient')
-						const spyNotifyOpenProjectTokenRevoke = vi.spyOn(wrapper.vm, 'notifyOpenProjectTokenRevoke')
 						wrapper.findComponent(selectors.opClientIdInput).vm.$emit('update:modelValue', opClientId)
 						wrapper.findComponent(selectors.opClientSecretInput).vm.$emit('update:modelValue', opClientSecret)
 						wrapper.findComponent(selectors.opSaveButton).vm.$emit('click')
@@ -400,7 +397,6 @@ describe('Component: FormOAuthSettings', () => {
 						expect(spyCreateNextcloudClient).not.toHaveBeenCalled()
 						expect(showSuccess).toHaveBeenCalledTimes(1)
 						expect(showError).toHaveBeenCalledTimes(0)
-						expect(spyNotifyOpenProjectTokenRevoke).toHaveBeenCalledTimes(1)
 					})
 				})
 
@@ -409,7 +405,6 @@ describe('Component: FormOAuthSettings', () => {
 						saveAdminConfig.mockImplementation(() => Promise.reject(new Error('Failure')))
 						const wrapper = getWrapper()
 						const spyCreateNextcloudClient = vi.spyOn(wrapper.vm, 'createNextcloudClient').mockImplementation(() => vi.fn())
-						const spyNotifyOpenProjectTokenRevoke = vi.spyOn(wrapper.vm, 'notifyOpenProjectTokenRevoke')
 
 						wrapper.findComponent(selectors.opClientIdInput).vm.$emit('update:modelValue', opClientId)
 						wrapper.findComponent(selectors.opClientSecretInput).vm.$emit('update:modelValue', opClientSecret)
@@ -423,16 +418,13 @@ describe('Component: FormOAuthSettings', () => {
 						expect(wrapper.vm.openprojectFormMode).toBe(F_MODES.EDIT)
 						expect(spyCreateNextcloudClient).toHaveBeenCalledTimes(0)
 
-						expect(wrapper.vm.openprojectTokenRevokeStatus).toBeNull()
 						expect(showSuccess).toHaveBeenCalledTimes(0)
 						expect(showError).toHaveBeenCalledTimes(1)
-						expect(spyNotifyOpenProjectTokenRevoke).toHaveBeenCalledTimes(1)
 					})
 					it('should show error if Nextcloud OAuth client creation fails', async () => {
 						createNextcloudOAuthClient.mockImplementation(() => Promise.reject(new Error('Failure')))
 						const wrapper = getWrapper()
 						const spyCreateNextcloudClient = vi.spyOn(wrapper.vm, 'createNextcloudClient')
-						const spyNotifyOpenProjectTokenRevoke = vi.spyOn(wrapper.vm, 'notifyOpenProjectTokenRevoke')
 
 						wrapper.findComponent(selectors.opClientIdInput).vm.$emit('update:modelValue', opClientId)
 						wrapper.findComponent(selectors.opClientSecretInput).vm.$emit('update:modelValue', opClientSecret)
@@ -450,7 +442,6 @@ describe('Component: FormOAuthSettings', () => {
 						expect(spyCreateNextcloudClient).toHaveBeenCalledTimes(1)
 						expect(showSuccess).toHaveBeenCalledTimes(1)
 						expect(showError).toHaveBeenCalledTimes(1)
-						expect(spyNotifyOpenProjectTokenRevoke).toHaveBeenCalledTimes(1)
 					})
 				})
 			})

--- a/tests/js/components/admin/FormOAuthSettings.spec.js
+++ b/tests/js/components/admin/FormOAuthSettings.spec.js
@@ -641,58 +641,6 @@ describe('Component: FormOAuthSettings', () => {
 			})
 		})
 	})
-
-	describe('revoke OpenProject OAuth token', () => {
-		it('should show success when revoke status is success', async () => {
-			saveAdminConfig.mockImplementationOnce(() => Promise.resolve({
-				data: {
-					oPOAuthTokenRevokeStatus: 'success',
-				},
-			}))
-			const wrapper = getWrapper()
-			const spyCreateNextcloudClient = vi.spyOn(wrapper.vm, 'createNextcloudClient').mockImplementation(() => vi.fn())
-			const spyNotifyOpenProjectTokenRevoke = vi.spyOn(wrapper.vm, 'notifyOpenProjectTokenRevoke')
-			wrapper.findComponent(selectors.opClientIdInput).vm.$emit('update:modelValue', 'id')
-			wrapper.findComponent(selectors.opClientSecretInput).vm.$emit('update:modelValue', 'secret')
-			wrapper.findComponent(selectors.opSaveButton).vm.$emit('click')
-			await flushPromises()
-
-			expect(spyCreateNextcloudClient).toHaveBeenCalledTimes(1)
-			expect(wrapper.vm.openprojectTokenRevokeStatus).toBe('success')
-			expect(spyNotifyOpenProjectTokenRevoke).toHaveBeenCalledTimes(1)
-			expect(showSuccess).toHaveBeenCalledTimes(2)
-			expect(showError).toHaveBeenCalledTimes(0)
-			expect(showSuccess).toHaveBeenCalledWith('OpenProject admin options saved')
-			expect(showSuccess).toHaveBeenCalledWith('Successfully revoked users\' OpenProject OAuth access tokens')
-
-		})
-		it.each([
-			['connection_error', 'Failed to perform revoke request due to connection error with the OpenProject server'],
-			['other_error', 'Failed to revoke some users\' OpenProject OAuth access tokens'],
-		])('should show error message on various failure', async (errorCode, errorMessage) => {
-			saveAdminConfig.mockImplementationOnce(() => Promise.resolve({
-				data: {
-					oPOAuthTokenRevokeStatus: errorCode,
-				},
-			}))
-			const wrapper = getWrapper()
-			const spyCreateNextcloudClient = vi.spyOn(wrapper.vm, 'createNextcloudClient').mockImplementation(() => vi.fn())
-			const spyNotifyOpenProjectTokenRevoke = vi.spyOn(wrapper.vm, 'notifyOpenProjectTokenRevoke')
-			wrapper.findComponent(selectors.opClientIdInput).vm.$emit('update:modelValue', 'id')
-			wrapper.findComponent(selectors.opClientSecretInput).vm.$emit('update:modelValue', 'secret')
-			wrapper.findComponent(selectors.opSaveButton).vm.$emit('click')
-			await flushPromises()
-
-			expect(spyCreateNextcloudClient).toHaveBeenCalledTimes(1)
-			expect(wrapper.vm.openprojectTokenRevokeStatus).toBe(errorCode)
-			expect(spyNotifyOpenProjectTokenRevoke).toHaveBeenCalledTimes(1)
-
-			expect(showSuccess).toHaveBeenCalledTimes(1)
-			expect(showError).toHaveBeenCalledTimes(1)
-			expect(showSuccess).toHaveBeenCalledWith('OpenProject admin options saved')
-			expect(showError).toHaveBeenCalledWith(errorMessage)
-		})
-	})
 })
 
 function getWrapper({ data = {}, props = {} } = {}) {

--- a/tests/lib/Controller/ConfigControllerTest.php
+++ b/tests/lib/Controller/ConfigControllerTest.php
@@ -789,14 +789,6 @@ class ConfigControllerTest extends TestCase {
 				$oauthSettingsControllerMock
 					->expects($this->never())
 					->method('deleteClient');
-			} elseif ($updateNCOAuthClient === 'delete') { // delete the client
-				$oauthServiceMock
-					->expects($this->never())
-					->method('setClientRedirectUri');
-				$oauthSettingsControllerMock
-					->expects($this->exactly(2))
-					->method('deleteClient')
-					->with(123);
 			} else {
 				$oauthServiceMock
 					->expects($this->never())

--- a/tests/lib/Controller/ConfigControllerTest.php
+++ b/tests/lib/Controller/ConfigControllerTest.php
@@ -805,7 +805,7 @@ class ConfigControllerTest extends TestCase {
 					->expects($this->once())
 					->method('deleteClient')
 					->with(123);
-			} 
+			}
 		} else {
 			$oauthServiceMock->expects($this->never())->method('setClientRedirectUri');
 		}

--- a/tests/lib/Controller/ConfigControllerTest.php
+++ b/tests/lib/Controller/ConfigControllerTest.php
@@ -7,10 +7,8 @@
 
 namespace OCA\OpenProject\Controller;
 
-use GuzzleHttp\Exception\ConnectException;
 use OCA\OAuth2\Controller\SettingsController;
 use OCA\OpenProject\AppInfo\Application;
-use OCA\OpenProject\Exception\OpenprojectErrorException;
 use OCA\OpenProject\Service\OauthService;
 use OCA\OpenProject\Service\OpenProjectAPIService;
 use OCA\OpenProject\Service\SettingsService;
@@ -28,7 +26,6 @@ use OCP\IUserManager;
 use OCP\Security\ISecureRandom;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Psr\Http\Message\RequestInterface;
 use Psr\Log\LoggerInterface;
 
 class ConfigControllerTest extends TestCase {

--- a/tests/lib/Controller/ConfigControllerTest.php
+++ b/tests/lib/Controller/ConfigControllerTest.php
@@ -523,7 +523,6 @@ class ConfigControllerTest extends TestCase {
 				[Application::APP_ID, 'openproject_client_id', '', $credsToUpdate['openproject_client_id']],
 				[Application::APP_ID, 'openproject_client_secret', '', $credsToUpdate['openproject_client_secret']],
 				[Application::APP_ID, 'nc_oauth_client_id', '', '123'],
-				[Application::APP_ID, 'oPOAuthTokenRevokeStatus', '', ''],
 			]);
 		$apiService = $this->getMockBuilder(OpenProjectAPIService::class)
 			->disableOriginalConstructor()
@@ -541,7 +540,6 @@ class ConfigControllerTest extends TestCase {
 		$this->assertSame(
 			[
 				'status' => $adminConfigStatus,
-				'oPOAuthTokenRevokeStatus' => '',
 				"oPUserAppPassword" => null
 			],
 			$result->getData()
@@ -619,7 +617,6 @@ class ConfigControllerTest extends TestCase {
 				[Application::APP_ID, 'oidc_provider', '', $credsToUpdate['oidc_provider']],
 				[Application::APP_ID, 'sso_provider_type', '', Application::NEXTCLOUD_HUB_OIDC_PROVIDER_TYPE],
 				[Application::APP_ID, 'targeted_audience_client_id', '', $credsToUpdate['targeted_audience_client_id']],
-				[Application::APP_ID, 'oPOAuthTokenRevokeStatus', '', ''],
 			]);
 
 		
@@ -639,7 +636,6 @@ class ConfigControllerTest extends TestCase {
 		$this->assertSame(
 			[
 				'status' => $adminConfigStatus,
-				'oPOAuthTokenRevokeStatus' => '',
 				"oPUserAppPassword" => null
 			],
 			$result->getData()
@@ -779,7 +775,6 @@ class ConfigControllerTest extends TestCase {
 				[Application::APP_ID, 'openproject_client_id', '', $oldCreds['openproject_client_id']],
 				[Application::APP_ID, 'openproject_client_secret', '', $oldCreds['openproject_client_secret']],
 				[Application::APP_ID, 'nc_oauth_client_id', '', '123'],
-				[Application::APP_ID, 'oPOAuthTokenRevokeStatus', '', ''],
 			]);
 		$configMock
 			->method('getUserValue')
@@ -907,369 +902,6 @@ class ConfigControllerTest extends TestCase {
 		);
 		return $userManager;
 	}
-
-	/**
-	 * @return array<mixed>
-	 */
-	public function oPOAuthTokenRevokeDataProvider() {
-		return [
-			[
-				'oldConfig' => [
-					'authorization_method' => Application::AUTH_METHOD_OAUTH,
-					'openproject_client_id' => 'op_client',
-					'openproject_client_secret' => 'op_client_secret',
-					'nc_oauth_client_id' => 'nc_client',
-				],
-				'newConfig' => [
-					'authorization_method' => null,
-					'openproject_client_id' => null,
-					'openproject_client_secret' => null,
-					'openproject_instance_url' => null,
-					'default_enable_navigation' => false,
-					'default_enable_unified_search' => false,
-				],
-				'configStatus' => false,
-				'mode' => 'reset',
-			],
-			[
-				'oldConfig' => [
-					'authorization_method' => Application::AUTH_METHOD_OAUTH,
-					'openproject_client_id' => 'op_client',
-					'openproject_client_secret' => 'op_client_secret',
-					'nc_oauth_client_id' => 'nc_client',
-				],
-				'newConfig' => [
-					'authorization_method' => Application::AUTH_METHOD_OAUTH,
-					'openproject_client_id' => 'client_id_changed',
-					'openproject_client_secret' => 'client_secret_changed',
-					'openproject_instance_url' => 'http://localhost:3000',
-					'default_enable_navigation' => true,
-					'default_enable_unified_search' => true,
-				],
-				'configStatus' => true,
-				'mode' => 'change',
-			]
-		];
-	}
-
-	/**
-	 * @param array<mixed> $oldConfig
-	 * @param array<mixed> $newConfig
-	 * @param bool $adminConfigStatus
-	 * @param string $mode
-	 *
-	 * @return void
-	 * @throws OpenprojectErrorException
-	 * @dataProvider oPOAuthTokenRevokeDataProvider
-	 */
-	public function testSetAdminConfigForOPOAuthTokenRevoke(array $oldConfig, array $newConfig, bool $adminConfigStatus, string $mode) {
-		$oldAdminConfig = [
-			'openproject_instance_url' => 'http://localhost:3000',
-			'default_enable_navigation' => true,
-			'default_enable_unified_search' => true,
-		];
-		$oldAdminConfig = array_merge($oldAdminConfig, $oldConfig);
-		$testUser = 'test101';
-		$userTokens = [
-			'admin' => 'admin_token',
-			$testUser => 'user_token',
-		];
-
-		$userManager = $this->checkForUsersCountBeforeTest();
-		$this->user1 = $userManager->createUser($testUser, $testUser);
-
-		$apiService = $this
-			->getMockBuilder(OpenProjectAPIService::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$configMock = $this->getMockBuilder(IConfig::class)->getMock();
-		$oauthServiceMock = $this->createMock(OauthService::class);
-		$oauthSettingsControllerMock = $this->createMock('OCA\OAuth2\Controller\SettingsController');
-
-		if ($mode === "reset") {
-			$this->expectMethodCalls($configMock, 'deleteAppValue', [
-				[[Application::APP_ID, 'nc_oauth_client_id'], null],
-				[[Application::APP_ID, 'oPOAuthTokenRevokeStatus'], null],
-				[[Application::APP_ID, 'oPOAuthTokenRevokeStatus'], null],
-			], true);
-		} else {
-			$this->expectMethodCalls($configMock, 'deleteAppValue', [
-				[[Application::APP_ID, 'oPOAuthTokenRevokeStatus'], null],
-				[[Application::APP_ID, 'oPOAuthTokenRevokeStatus'], null],
-			], true);
-		}
-
-		$configMock
-			->method('getAppValue')
-			->willReturnMap([
-				[Application::APP_ID, 'openproject_instance_url', '', $oldAdminConfig['openproject_instance_url']],
-				[Application::APP_ID, 'authorization_method', '', $oldAdminConfig['authorization_method']],
-				[Application::APP_ID, 'openproject_client_id', '', $oldAdminConfig['openproject_client_id']],
-				[Application::APP_ID, 'openproject_client_secret', '', $oldAdminConfig['openproject_client_secret']],
-				[Application::APP_ID, 'nc_oauth_client_id', '', $oldAdminConfig['nc_oauth_client_id']],
-				[Application::APP_ID, 'oPOAuthTokenRevokeStatus', '', ''],
-			]);
-
-		$configMock
-			->method('setAppValue')
-			->willReturnMap([
-				[Application::APP_ID, 'authorization_method', $newConfig['authorization_method'], null],
-				[Application::APP_ID, 'openproject_client_id', $newConfig['openproject_client_id'], null],
-				[Application::APP_ID, 'openproject_client_secret', $newConfig['openproject_client_secret'], null],
-				[Application::APP_ID, 'openproject_instance_url', $newConfig['openproject_instance_url'], null],
-				[Application::APP_ID, 'default_enable_navigation', $newConfig['default_enable_navigation'], null],
-				[Application::APP_ID, 'default_enable_unified_search', $newConfig['default_enable_unified_search'], null],
-				[Application::APP_ID, 'oPOAuthTokenRevokeStatus', 'success', null]
-			]);
-
-		$configMock
-			->method('getUserValue')
-			->willReturnMap([
-				['admin', Application::APP_ID, 'token', '', $userTokens['admin']],
-				[$testUser, Application::APP_ID, 'token', '', $userTokens[$testUser]],
-			]);
-
-		$apiService
-			->expects($this->exactly(2))
-			->method('revokeUserOAuthToken')
-			->willReturnMap([
-				[$oldAdminConfig['openproject_instance_url'], $userTokens['admin'], $oldAdminConfig['openproject_client_id'], $oldAdminConfig['openproject_client_secret'], true],
-				[$oldAdminConfig['openproject_instance_url'], $userTokens[$testUser], $oldAdminConfig['openproject_client_id'], $oldAdminConfig['openproject_client_secret'], true],
-			]);
-
-		$configMock
-			->expects($this->exactly(12))
-			->method("deleteUserValue")
-			->willReturnMap([
-				['admin', Application::APP_ID, 'token', null],
-				['admin', Application::APP_ID, 'login', null],
-				['admin', Application::APP_ID, 'user_id', null],
-				['admin', Application::APP_ID, 'user_name', null],
-				['admin', Application::APP_ID, 'refresh_token', null],
-				['admin', Application::APP_ID, 'token_expires_at', null],
-				[$testUser, Application::APP_ID, 'token', null],
-				[$testUser, Application::APP_ID, 'login', null],
-				[$testUser, Application::APP_ID, 'user_id', null],
-				[$testUser, Application::APP_ID, 'user_name', null],
-				[$testUser, Application::APP_ID, 'refresh_token', null],
-				[$testUser, Application::APP_ID, 'token_expires_at', null],
-			]);
-
-		$constructArgs = $this->getConfigControllerConstructArgs([
-			'config' => $configMock,
-			'userManager' => $userManager,
-			'openprojectAPIService' => $apiService,
-			'oauthService' => $oauthServiceMock,
-			'settingsController' => $oauthSettingsControllerMock,
-			'userId' => 'test101'
-		]);
-		$configController = new ConfigController(...$constructArgs);
-
-		$result = $configController->setAdminConfig($newConfig);
-		$this->assertEquals(Http::STATUS_OK, $result->getStatus());
-		$data = $result->getData();
-		$this->assertArrayHasKey('status', $data);
-		$this->assertArrayHasKey('oPOAuthTokenRevokeStatus', $data);
-		$this->assertArrayHasKey('oPUserAppPassword', $data);
-	}
-
-	/**
-	 * @return array<mixed>
-	 */
-	public function oPOAuthTokenRevokeErrorDataProvider() {
-		$connectException = new ConnectException('Connection error', $this->createMock(RequestInterface::class));
-		$opException = new OpenprojectErrorException('Other error');
-		return [
-			["connection_error", $connectException, ['Error: Connection error', ['app' => 'integration_openproject']]],
-			["other_error", $opException, ['Error: Other error', ['app' => 'integration_openproject']]]
-		];
-	}
-
-
-	/**
-	 * @param string $errorCode
-	 * @param ConnectException|OpenprojectErrorException $exception
-	 * @param array<mixed> $errMessage
-	 *
-	 * @return void
-	 * @dataProvider oPOAuthTokenRevokeErrorDataProvider
-	 * @throws OpenprojectErrorException
-	 */
-	public function testOPOAuthTokenRevokeErrors($errorCode, $exception, $errMessage) {
-		$oldAdminConfig = [
-			'authorization_method' => Application::AUTH_METHOD_OAUTH,
-			'openproject_client_id' => 'some_old_client_id',
-			'openproject_client_secret' => 'some_old_client_secret',
-			'openproject_instance_url' => 'http://localhost:3000',
-		];
-		$newAdminConfig = [
-			'authorization_method' => '',
-			'openproject_client_id' => '',
-			'openproject_client_secret' => '',
-			'openproject_instance_url' => '',
-		];
-		$userTokens = [
-			'admin' => 'admin_token',
-		];
-		$userManager = $this->checkForUsersCountBeforeTest();
-		$apiService = $this
-			->getMockBuilder(OpenProjectAPIService::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$configMock = $this->getMockBuilder(IConfig::class)->getMock();
-		$oauthServiceMock = $this->createMock(OauthService::class);
-		$oauthSettingsControllerMock = $this->createMock('OCA\OAuth2\Controller\SettingsController');
-		$loggerInterfaceMock = $this->createMock(LoggerInterface::class);
-
-		$this->expectMethodCalls($configMock, 'getAppValue', [
-			[[Application::APP_ID, 'openproject_instance_url', ''], $oldAdminConfig['openproject_instance_url']],
-			[[Application::APP_ID, 'authorization_method', ''], $oldAdminConfig['authorization_method']],
-			[[Application::APP_ID, 'openproject_client_id', ''], $oldAdminConfig['openproject_client_id']],
-			[[Application::APP_ID, 'openproject_client_secret', ''], $oldAdminConfig['openproject_client_secret']],
-			[[Application::APP_ID, 'nc_oauth_client_id', ''], ''],
-			[[Application::APP_ID, 'oPOAuthTokenRevokeStatus', ''], $errorCode],
-			[[Application::APP_ID, 'authorization_method', ''], Application::AUTH_METHOD_OAUTH],
-			[[Application::APP_ID, 'openproject_instance_url', ''], $newAdminConfig['openproject_instance_url']],
-			[[Application::APP_ID, 'fresh_project_folder_setup', ''], false],
-			[[Application::APP_ID, 'openproject_client_id', ''], $newAdminConfig['openproject_client_id']],
-			[[Application::APP_ID, 'openproject_client_secret', ''], $newAdminConfig['openproject_client_secret']],
-			[[Application::APP_ID, 'openproject_instance_url', ''], $newAdminConfig['openproject_instance_url']],
-		]);
-
-		$configMock
-			->expects($this->exactly(6))
-			->method('setAppValue')
-			->willReturnMap([
-				[Application::APP_ID, 'authorization_method', $newAdminConfig['authorization_method'], null],
-				[Application::APP_ID, 'openproject_client_id', $newAdminConfig['openproject_client_id'], null],
-				[Application::APP_ID, 'openproject_client_secret', $newAdminConfig['openproject_client_secret'], null],
-				[Application::APP_ID, 'openproject_instance_url', $newAdminConfig['openproject_instance_url'], null],
-				[Application::APP_ID, 'oPOAuthTokenRevokeStatus', $errorCode, null],
-				[Application::APP_ID, 'fresh_project_folder_setup', false, null],
-			]);
-
-		$configMock
-			->method('getUserValue')
-			->willReturnMap([
-				['admin', Application::APP_ID, 'token', '', $userTokens['admin']],
-			]);
-
-		$loggerInterfaceMock
-			->method("error")
-			->with(
-				$errMessage[0],
-				$errMessage[1]
-			);
-
-		$apiService
-			->expects($this->exactly(1))
-			->method('revokeUserOAuthToken')
-			->with(
-				'admin',
-				$oldAdminConfig['openproject_instance_url'],
-				$userTokens['admin'],
-				$oldAdminConfig['openproject_client_id'],
-				$oldAdminConfig['openproject_client_secret']
-			)
-			->willThrowException($exception);
-
-		$configMock
-			->expects($this->exactly(6))
-			->method("deleteUserValue")
-			->willReturnMap([
-				['admin', Application::APP_ID, 'token', null],
-				['admin', Application::APP_ID, 'login', null],
-				['admin', Application::APP_ID, 'user_id', null],
-				['admin', Application::APP_ID, 'user_name', null],
-				['admin', Application::APP_ID, 'refresh_token', null],
-				['admin', Application::APP_ID, 'token_expires_at', null],
-			]);
-
-		$this->expectMethodCalls($configMock, 'deleteAppValue', [
-			[[Application::APP_ID, 'oPOAuthTokenRevokeStatus'], null],
-			[[Application::APP_ID, 'oPOAuthTokenRevokeStatus'], null],
-		], true);
-
-		$constructArgs = $this->getConfigControllerConstructArgs([
-			'config' => $configMock,
-			'userManager' => $userManager,
-			'openprojectAPIService' => $apiService,
-			'loggerInterface' => $loggerInterfaceMock,
-			'oauthService' => $oauthServiceMock,
-			'settingsController' => $oauthSettingsControllerMock,
-			'userId' => 'admin'
-		]);
-		$configController = new ConfigController(...$constructArgs);
-
-		$result = $configController->setAdminConfig($newAdminConfig);
-		$this->assertEquals(Http::STATUS_OK, $result->getStatus());
-		$data = $result->getData();
-		$this->assertArrayHasKey('status', $data);
-		$this->assertEquals(false, $data['status']);
-		$this->assertArrayHasKey('oPOAuthTokenRevokeStatus', $data);
-		$this->assertEquals($errorCode, $data['oPOAuthTokenRevokeStatus']);
-	}
-
-	/**
-	 * @return void
-	 */
-	public function testOPOAuthTokenRevokeDoesNotOccurIfNoOPOAuthClientHasChanged() {
-		$oldAdminConfig = [
-			'authorization_method' => Application::AUTH_METHOD_OAUTH,
-			'openproject_client_id' => 'some_old_client_id',
-			'openproject_client_secret' => 'some_old_client_secret',
-			'openproject_instance_url' => 'http://localhost:3000',
-		];
-		$newAdminConfig = $oldAdminConfig;
-		$userManager = $this->checkForUsersCountBeforeTest();
-		$apiService = $this
-			->getMockBuilder(OpenProjectAPIService::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$configMock = $this->getMockBuilder(IConfig::class)->getMock();
-		$oauthServiceMock = $this->createMock(OauthService::class);
-		$oauthSettingsControllerMock = $this->createMock('OCA\OAuth2\Controller\SettingsController');
-		$loggerInterfaceMock = $this->createMock(LoggerInterface::class);
-
-		$configMock
-			->method('getAppValue')
-			->willReturnMap([
-				[Application::APP_ID, 'openproject_instance_url', '', $oldAdminConfig['openproject_instance_url']],
-				[Application::APP_ID, 'authorization_method', '', $oldAdminConfig['authorization_method']],
-				[Application::APP_ID, 'openproject_client_id', '', $oldAdminConfig['openproject_client_id']],
-				[Application::APP_ID, 'openproject_client_secret', '', $oldAdminConfig['openproject_client_secret']],
-				[Application::APP_ID, 'oPOAuthTokenRevokeStatus', '', ''],
-			]);
-
-		$configMock
-			->expects($this->exactly(2))
-			->method('deleteAppValue')
-			->with(Application::APP_ID, 'oPOAuthTokenRevokeStatus');
-
-		$apiService
-			->expects($this->exactly(0))
-			->method('revokeUserOAuthToken');
-
-		$constructArgs = $this->getConfigControllerConstructArgs([
-			'config' => $configMock,
-			'userManager' => $userManager,
-			'openprojectAPIService' => $apiService,
-			'loggerInterface' => $loggerInterfaceMock,
-			'oauthService' => $oauthServiceMock,
-			'settingsController' => $oauthSettingsControllerMock,
-			'userId' => 'admin'
-		]);
-		$configController = new ConfigController(...$constructArgs);
-
-		$result = $configController->setAdminConfig($newAdminConfig);
-		$this->assertEquals(Http::STATUS_OK, $result->getStatus());
-		$data = $result->getData();
-		$this->assertArrayHasKey('status', $data);
-		$this->assertEquals(false, $data['status']);
-		$this->assertArrayHasKey('oPOAuthTokenRevokeStatus', $data);
-		$this->assertEquals("", $data['oPOAuthTokenRevokeStatus']);
-	}
-
 
 	public function testSetupIntegrationProjectFoldersSetUp():void {
 		$service = $this->getMockBuilder(OpenProjectAPIService::class)
@@ -1487,7 +1119,6 @@ class ConfigControllerTest extends TestCase {
 				['integration_openproject', 'oidc_provider', '', $oldCreds['oidc_provider']],
 				['integration_openproject', 'targeted_audience_client_id', '', $oldCreds['targeted_audience_client_id']],
 				['integration_openproject', 'nc_oauth_client_id', '', '123'],
-				['integration_openproject', 'oPOAuthTokenRevokeStatus', '', ''],
 				['integration_openproject', 'authorization_method', '', Application::AUTH_METHOD_OIDC],
 				['integration_openproject', 'oidc_provider', '', $credsToUpdate['oidc_provider']],
 				['integration_openproject', 'targeted_audience_client_id', '', $credsToUpdate['targeted_audience_client_id']],
@@ -1572,7 +1203,6 @@ class ConfigControllerTest extends TestCase {
 			[['integration_openproject', 'openproject_client_id', ''], $oldCreds['openproject_client_id']],
 			[['integration_openproject', 'openproject_client_secret', ''], $oldCreds['openproject_client_secret']],
 			[['integration_openproject', 'nc_oauth_client_id', ''], '123'],
-			[['integration_openproject', 'oPOAuthTokenRevokeStatus', ''], '123'],
 			[['integration_openproject', 'authorization_method', ''], Application::AUTH_METHOD_OAUTH],
 			[['integration_openproject', 'openproject_client_id', ''], $credsToUpdate['openproject_client_id']],
 			[['integration_openproject', 'openproject_client_secret', ''], $credsToUpdate['openproject_client_secret']],
@@ -1683,7 +1313,6 @@ class ConfigControllerTest extends TestCase {
 			[['integration_openproject', 'authorization_method', ''], $oldConfig['authorization_method']],
 			[['integration_openproject', 'oidc_provider', ''], $oldConfig['oidc_provider']],
 			[['integration_openproject', 'targeted_audience_client_id', ''], $oldConfig['targeted_audience_client_id']],
-			[['integration_openproject', 'oPOAuthTokenRevokeStatus', ''], ''],
 			[['integration_openproject', 'authorization_method', ''], $newConfig['authorization_method']],
 			[['integration_openproject', 'oidc_provider', ''], $newConfig['oidc_provider']],
 			[['integration_openproject', 'targeted_audience_client_id', ''], $newConfig['targeted_audience_client_id']],

--- a/tests/lib/Controller/ConfigControllerTest.php
+++ b/tests/lib/Controller/ConfigControllerTest.php
@@ -789,7 +789,15 @@ class ConfigControllerTest extends TestCase {
 				$oauthSettingsControllerMock
 					->expects($this->never())
 					->method('deleteClient');
-			} else { // delete the client
+			} elseif ($updateNCOAuthClient === 'delete') { // delete the client
+				$oauthServiceMock
+					->expects($this->never())
+					->method('setClientRedirectUri');
+				$oauthSettingsControllerMock
+					->expects($this->exactly(2))
+					->method('deleteClient')
+					->with(123);
+			} else {
 				$oauthServiceMock
 					->expects($this->never())
 					->method('setClientRedirectUri');
@@ -797,7 +805,7 @@ class ConfigControllerTest extends TestCase {
 					->expects($this->once())
 					->method('deleteClient')
 					->with(123);
-			}
+			} 
 		} else {
 			$oauthServiceMock->expects($this->never())->method('setClientRedirectUri');
 		}


### PR DESCRIPTION
## Description
Do not revoke OpenProject client access tokens in the integration app. OpenProject will handle its tokens.

## Related Issue or Workpackage
- Fixes https://community.openproject.org/wp/NEX-680

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [x] Updated `CHANGELOG.md` file
