### PR TITLE
fix: no encryption warning when the encryption is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix: Default OIDC provider name not set while updating to Nextcloud Hub setup [#1126](https://github.com/nextcloud/integration_openproject/pull/1126)
 - Fix: User shown connected in webUI after converting existing OAuth to SSO via setup endpoint [#1132](https://github.com/nextcloud/integration_openproject/pull/1132)
 - Fix: Incorrect setup status while configuring integration with existing project folder [#1142](https://github.com/nextcloud/integration_openproject/pull/1142)
+- Fix: No encryption warning for project folder when the server-side encryption is enabled [#1144](https://github.com/nextcloud/integration_openproject/pull/1144)
 
 ### Changed
 

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -1248,14 +1248,13 @@ class OpenProjectAPIService {
 	}
 
 	public function isServerSideEncryptionEnabled(): bool {
-		// home storage encryption is enabled by default
-		// when the default encryption module is enabled.
-		$isEncryptionForHomeStorageEnabled = $this->config->getAppValue('encryption', 'encryptHomeStorage', '1') === '1';
-		return (
-			$this->appManager->isInstalled('encryption') &&
-			$this->encryptionManager->isEnabled() &&
-			$isEncryptionForHomeStorageEnabled
-		);
+		$homeStorageEncrypted = false;
+		if ($this->appManager->isInstalled('encryption')) {
+			// home storage encryption is enabled by default
+			// when the default encryption module is enabled
+			$homeStorageEncrypted = $this->config->getAppValue('encryption', 'encryptHomeStorage', '1') === '1';
+		}
+		return $this->encryptionManager->isEnabled() && $homeStorageEncrypted;
 	}
 
 	/**

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -1248,7 +1248,9 @@ class OpenProjectAPIService {
 	}
 
 	public function isServerSideEncryptionEnabled(): bool {
-		$isEncryptionForHomeStorageEnabled = $this->config->getAppValue('encryption', 'encryptHomeStorage', '0') === '1';
+		// home storage encryption is enabled by default
+		// when the default encryption module is enabled.
+		$isEncryptionForHomeStorageEnabled = $this->config->getAppValue('encryption', 'encryptHomeStorage', '1') === '1';
 		return (
 			$this->appManager->isInstalled('encryption') &&
 			$this->encryptionManager->isEnabled() &&


### PR DESCRIPTION
## Description
When the default encryption module is enabled, by default the home storage encryption is also enabled.

See:
https://github.com/nextcloud/server/blob/a7ca8994d8cec28765bf43f3b4654df122b015e7/apps/encryption/lib/Util.php#L50-L52

## Related Issue or Workpackage
- Fixes https://community.openproject.org/wp/NEX-679

## Screenshots (if appropriate):
<img width="947" height="291" alt="Screenshot from 2026-08-17 12-36-29" src="https://github.com/user-attachments/assets/a5aa685e-a901-46a7-9343-d1872d075c35" />

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Updated `CHANGELOG.md` file
