### PR TITLE
fix: no encryption warning when the encryption is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix: Default OIDC provider name not set while updating to Nextcloud Hub setup [#1130](https://github.com/nextcloud/integration_openproject/pull/1130)
 - Fix: User shown connected in webUI after converting existing OAuth to SSO via setup endpoint [#1141](https://github.com/nextcloud/integration_openproject/pull/1141)
 - Fix: Incorrect setup status while configuring integration with existing project folder [#1145](https://github.com/nextcloud/integration_openproject/pull/1145)
+- Fix: No encryption warning for project folder when the server-side encryption is enabled [#1147](https://github.com/nextcloud/integration_openproject/pull/1147)
 
 ### Changed
 

--- a/lib/Service/OpenProjectAPIService.php
+++ b/lib/Service/OpenProjectAPIService.php
@@ -1248,12 +1248,13 @@ class OpenProjectAPIService {
 	}
 
 	public function isServerSideEncryptionEnabled(): bool {
-		$isEncryptionForHomeStorageEnabled = $this->config->getAppValue('encryption', 'encryptHomeStorage', '0') === '1';
-		return (
-			$this->appManager->isInstalled('encryption') &&
-			$this->encryptionManager->isEnabled() &&
-			$isEncryptionForHomeStorageEnabled
-		);
+		$homeStorageEncrypted = false;
+		if ($this->appManager->isInstalled('encryption')) {
+			// home storage encryption is enabled by default
+			// when the default encryption module is enabled
+			$homeStorageEncrypted = $this->config->getAppValue('encryption', 'encryptHomeStorage', '1') === '1';
+		}
+		return $this->encryptionManager->isEnabled() && $homeStorageEncrypted;
 	}
 
 	/**


### PR DESCRIPTION
Backport of https://github.com/nextcloud/integration_openproject/pull/1144

WP: https://community.openproject.org/wp/NEX-686