### PR TITLE
fix: project folder form header is disabled even when the form fields are visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix: User shown connected in webUI after converting existing OAuth to SSO via setup endpoint [#1132](https://github.com/nextcloud/integration_openproject/pull/1132)
 - Fix: Incorrect setup status while configuring integration with existing project folder [#1142](https://github.com/nextcloud/integration_openproject/pull/1142)
 - Fix: No encryption warning for project folder when the server-side encryption is enabled [#1144](https://github.com/nextcloud/integration_openproject/pull/1144)
+- Fix: Project folder form header in disabled mode even when the form fields are visible [#1149](https://github.com/nextcloud/integration_openproject/pull/1149)
 
 ### Changed
 

--- a/src/components/admin/FormProjectFolder.vue
+++ b/src/components/admin/FormProjectFolder.vue
@@ -317,6 +317,13 @@ export default {
 			return t('integration_openproject', 'This value will only be accessible once. Now, as an administrator copy this password to OpenProject {htmlLink}.', { htmlLink }, null, { escape: false, sanitize: false })
 		},
 	},
+	watch: {
+		isAuthorizationSettingFormComplete(value) {
+			if (value && this.projectFolderInfo.freshSetup) {
+				this.setProjectFolderFormToEditMode()
+			}
+		},
+	},
 	created() {
 		if (!this.projectFolderInfo.freshSetup) {
 			this.setProjectFolderFormToViewMode()

--- a/tests/js/components/admin/FormProjectFolder.spec.js
+++ b/tests/js/components/admin/FormProjectFolder.spec.js
@@ -307,10 +307,16 @@ describe('Component: FormProjectFolder', () => {
 			describe('fresh setup', () => {
 				let wrapper
 				beforeEach(async () => {
-					wrapper = getWrapper({ props: defaultProps })
+					const props = structuredClone(defaultProps)
+					props.formState.openprojectOauth.complete = false
+					wrapper = getWrapper({ props })
+					await nextTick()
 				})
 
 				it('should show enabled form fields', async () => {
+					await wrapper.setProps(defaultProps)
+					await nextTick()
+
 					expect(wrapper.vm.folderFormMode).toBe(F_MODES.EDIT)
 					expect(wrapper.vm.passwordFormMode).toBe(F_MODES.DISABLE)
 					expect(wrapper.emitted().formcomplete).toBeUndefined()
@@ -335,6 +341,9 @@ describe('Component: FormProjectFolder', () => {
 					expect(wrapper.find(selectors.appPasswordFormContainer).exists()).toBe(false)
 				})
 				it('should show disabled form fields if project folder is disabled', async () => {
+					await wrapper.setProps(defaultProps)
+					await nextTick()
+
 					const projectFolderSetupSwitch = wrapper.findComponent(selectors.projectFolderSetupSwitch)
 					projectFolderSetupSwitch.vm.$emit('update:modelValue', false)
 					await flushPromises()
@@ -348,6 +357,11 @@ describe('Component: FormProjectFolder', () => {
 				})
 
 				describe('on save: disabled project folder', () => {
+					beforeEach(async () => {
+						await wrapper.setProps(defaultProps)
+						await nextTick()
+					})
+
 					it('should set status "Inactive"', async () => {
 						const spySetAppPasswordFormToEditMode = vi.spyOn(wrapper.vm, 'setAppPasswordFormToEditMode')
 						const projectFolderSetupSwitch = wrapper.findComponent(selectors.projectFolderSetupSwitch)
@@ -447,6 +461,11 @@ describe('Component: FormProjectFolder', () => {
 				})
 
 				describe('on save: enabled project folder', () => {
+					beforeEach(async () => {
+						await wrapper.setProps(defaultProps)
+						await nextTick()
+					})
+
 					describe('upon success', () => {
 						beforeEach(() => {
 							const props = structuredClone(defaultProps)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
the heading's disabled state (`isProjectFolderFormInDisableMode`) was only set once in `created()`,  and was never updated when authorization setting form completed (`isAuthorizationSettingFormComplete`) after mount. Added a watcher on `isAuthorizationSettingFormComplete` to switch to `edit` mode as soon as authorization setting form completes.

## Related Issue or Workpackage
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://community.openproject.org/wp/NEX-681

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Updated `CHANGELOG.md` file
