### PR TITLE
fix: project folder form header is disabled even when the form fields are visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix: User shown connected in webUI after converting existing OAuth to SSO via setup endpoint [#1141](https://github.com/nextcloud/integration_openproject/pull/1141)
 - Fix: Incorrect setup status while configuring integration with existing project folder [#1145](https://github.com/nextcloud/integration_openproject/pull/1145)
 - Fix: No encryption warning for project folder when the server-side encryption is enabled [#1147](https://github.com/nextcloud/integration_openproject/pull/1147)
+- Fix: Project folder form header in disabled mode even when the form fields are visible [#1155](https://github.com/nextcloud/integration_openproject/pull/1155)
 
 ### Changed
 

--- a/src/components/admin/FormProjectFolder.vue
+++ b/src/components/admin/FormProjectFolder.vue
@@ -313,6 +313,13 @@ export default {
 			return t('integration_openproject', 'This value will only be accessible once. Now, as an administrator copy this password to OpenProject {htmlLink}.', { htmlLink }, null, { escape: false, sanitize: false })
 		},
 	},
+	watch: {
+		isAuthorizationSettingFormComplete(value) {
+			if (value && this.projectFolderInfo.freshSetup) {
+				this.setProjectFolderFormToEditMode()
+			}
+		},
+	},
 	created() {
 		if (!this.projectFolderInfo.freshSetup) {
 			this.setProjectFolderFormToViewMode()

--- a/tests/jest/components/admin/FormProjectFolder.spec.js
+++ b/tests/jest/components/admin/FormProjectFolder.spec.js
@@ -314,10 +314,16 @@ describe('Component: FormProjectFolder', () => {
 			describe('fresh setup', () => {
 				let wrapper
 				beforeEach(async () => {
-					wrapper = getWrapper({ props: defaultProps })
+					const props = structuredClone(defaultProps)
+					props.formState.openprojectOauth.complete = false
+					wrapper = getWrapper({ props })
+					await wrapper.vm.$nextTick()
 				})
 
 				it('should show enabled form fields', async () => {
+					await wrapper.setProps(defaultProps)
+					await wrapper.vm.$nextTick()
+
 					expect(wrapper.vm.folderFormMode).toBe(F_MODES.EDIT)
 					expect(wrapper.vm.passwordFormMode).toBe(F_MODES.DISABLE)
 					expect(wrapper.emitted().formcomplete).toBe(undefined)
@@ -342,6 +348,9 @@ describe('Component: FormProjectFolder', () => {
 					expect(wrapper.find(selectors.appPasswordFormContainer).exists()).toBe(false)
 				})
 				it('should show disabled form fields if project folder is disabled', async () => {
+					await wrapper.setProps(defaultProps)
+					await wrapper.vm.$nextTick()
+
 					const projectFolderSetupSwitch = wrapper.find(selectors.projectFolderSetupSwitch)
 					projectFolderSetupSwitch.vm.$emit('update:checked', false)
 					await flushPromises()
@@ -355,6 +364,11 @@ describe('Component: FormProjectFolder', () => {
 				})
 
 				describe('on save: disabled project folder', () => {
+					beforeEach(async () => {
+						await wrapper.setProps(defaultProps)
+						await wrapper.vm.$nextTick()
+					})
+
 					it('should set status "Inactive"', async () => {
 						const spySetAppPasswordFormToEditMode = jest.spyOn(wrapper.vm, 'setAppPasswordFormToEditMode')
 						const projectFolderSetupSwitch = wrapper.find(selectors.projectFolderSetupSwitch)
@@ -454,6 +468,11 @@ describe('Component: FormProjectFolder', () => {
 				})
 
 				describe('on save: enabled project folder', () => {
+					beforeEach(async () => {
+						await wrapper.setProps(defaultProps)
+						await wrapper.vm.$nextTick()
+					})
+
 					describe('upon success', () => {
 						beforeEach(() => {
 							const props = structuredClone(defaultProps)


### PR DESCRIPTION
Backport https://github.com/nextcloud/integration_openproject/pull/1149

WP: https://community.openproject.org/wp/NEX-689