### PR TITLE
ci: use required nodejs version

### DIFF
--- a/.github/workflows/app-upgrade.yml
+++ b/.github/workflows/app-upgrade.yml
@@ -93,8 +93,9 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238
         with:
-          node-version-file: package.json
+          node-version-file: integration_openproject/package.json
           cache: 'npm'
+          cache-dependency-path: 'integration_openproject/package-lock.json'
 
       - name: Wait for Nextcloud server to be ready
         run: |

--- a/.github/workflows/app-upgrade.yml
+++ b/.github/workflows/app-upgrade.yml
@@ -90,6 +90,12 @@ jobs:
           tools: composer, phpunit
           extensions: intl, gd, sqlite3
 
+      - name: Setup NodeJS
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238
+        with:
+          node-version-file: package.json
+          cache: 'npm'
+
       - name: Wait for Nextcloud server to be ready
         run: |
           if ! timeout 5m bash -c '

--- a/.github/workflows/nighlty-ci-master.yml
+++ b/.github/workflows/nighlty-ci-master.yml
@@ -18,4 +18,4 @@ jobs:
       branch: master
       nextcloud_versions: '33 34 master'
       php_versions: '8.3 8.4 8.5'
-      app_upgrade_nc_versions: '34'
+      app_upgrade_nc_versions: 'master'

--- a/.github/workflows/nighlty-ci-master.yml
+++ b/.github/workflows/nighlty-ci-master.yml
@@ -18,4 +18,4 @@ jobs:
       branch: master
       nextcloud_versions: '33 34 master'
       php_versions: '8.3 8.4 8.5'
-      app_upgrade_nc_versions: 'master'
+      app_upgrade_nc_versions: '34'


### PR DESCRIPTION
Fix CI: https://github.com/nextcloud/integration_openproject/actions/runs/33456696872/job/99731904992
```
ERROR in [eslint] The requested module 'node:module' does not provide an export named 'findPackageJSON'
```